### PR TITLE
fix(cli): lazy provider init so install works without API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MCP tools now return valid JSON instead of Python repr (fixes panel display showing raw dict)
 - Stop hook reason is a clean single line instead of a wall of instructions
+- CLI no longer crashes on `tts install` when no TTS provider API keys are configured (lazy provider init)
 
 ## [0.3.0] - 2026-02-25
 

--- a/src/punt_tts/cli.py
+++ b/src/punt_tts/cli.py
@@ -65,9 +65,21 @@ def _print_results(results: list[SynthesisResult]) -> None:
 
 
 def _get_provider(ctx: click.Context) -> TTSProvider:
-    """Retrieve the TTSProvider from the Click context."""
-    obj = cast("dict[str, TTSProvider]", ctx.ensure_object(dict))  # pyright: ignore[reportUnknownMemberType]
-    return obj["provider"]
+    """Retrieve the TTSProvider from the Click context, initializing lazily.
+
+    The group callback stores provider_name and model but does NOT create
+    the provider — that way subcommands like ``install`` and ``serve``
+    never touch the provider layer.
+    """
+    obj = cast("dict[str, object]", ctx.ensure_object(dict))  # pyright: ignore[reportUnknownMemberType]
+    cached = obj.get("provider")
+    if cached is not None:
+        return cast("TTSProvider", cached)
+    provider_name = cast("str | None", obj.get("provider_name"))
+    model = cast("str | None", obj.get("model"))
+    provider = get_provider(provider_name, model=model)
+    obj["provider"] = provider
+    return provider
 
 
 def _resolve_voice_and_language(
@@ -161,7 +173,8 @@ def main(
     json_output_enabled = json_output
     _configure_logging(verbose)
     ctx.ensure_object(dict)
-    ctx.obj["provider"] = get_provider(provider_name, model=model)
+    ctx.obj["provider_name"] = provider_name
+    ctx.obj["model"] = model
 
 
 @main.command()


### PR DESCRIPTION
## Summary

- CLI group callback no longer eagerly calls `get_provider()` — stores provider config and initializes lazily on first use
- Fixes crash on `tts install` on fresh systems with no TTS API keys configured (auto-detect fell to Polly → `NoRegionError`)
- Subcommands that don't need a provider (`install`, `uninstall`, `install-desktop`, `serve`) never touch the provider layer

## Root Cause

The `main()` group callback called `get_provider(provider_name, model=model)` for ALL subcommands. On systems without ElevenLabs/OpenAI API keys, auto-detect falls to Polly, and Polly's constructor calls `boto3.client("polly")` which fails without an AWS region.

## Test plan

- [x] All 248 tests pass
- [x] All quality gates pass (ruff, mypy, pyright, pytest)
- [ ] Verify `tts install` works on a system without any TTS API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI context initialization; behavior changes only in when providers are constructed, with minimal impact to synthesis paths.
> 
> **Overview**
> Fixes a CLI crash by **making TTS provider initialization lazy**: the `main` Click group now stores `provider_name`/`model` in `ctx.obj` instead of eagerly calling `get_provider()`, and `_get_provider()` constructs and caches the provider only when a synthesis/doctor command needs it.
> 
> This ensures provider-independent subcommands (notably `tts install`/`serve`) don’t touch provider auto-detection or cloud SDK setup when API keys/region aren’t configured, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1ee86aaf084c4b2887eca534f736c8ced3866de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->