### PR TITLE
fix(install): prevent silent exit when tts install fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,16 +101,17 @@ if ! ssh -o StrictHostKeyChecking=accept-new -T git@github.com 2>&1 | grep -q "s
   NEED_HTTPS_REWRITE=1
 fi
 
-"$BINARY" install
-INSTALL_EXIT=$?
-
-# Clean up the HTTPS rewrite regardless of install outcome.
-if [ "$NEED_HTTPS_REWRITE" = "1" ]; then
-  git config --global --unset url."https://github.com/".insteadOf 2>/dev/null || true
+if ! "$BINARY" install; then
+  # Clean up HTTPS rewrite before exiting on failure.
+  if [ "$NEED_HTTPS_REWRITE" = "1" ]; then
+    git config --global --unset url."https://github.com/".insteadOf 2>/dev/null || true
+  fi
+  fail "Plugin install failed"
 fi
 
-if [ "$INSTALL_EXIT" -ne 0 ]; then
-  fail "Plugin install failed"
+# Clean up the HTTPS rewrite after successful install.
+if [ "$NEED_HTTPS_REWRITE" = "1" ]; then
+  git config --global --unset url."https://github.com/".insteadOf 2>/dev/null || true
 fi
 
 # --- Step 6: tts doctor ---


### PR DESCRIPTION
## Summary

- Replace bare `"$BINARY" install` + `$?` capture with `if !` guard
- `set -eu` was causing silent script exit when `tts install` returned non-zero
- Users saw "Setting up Claude Code plugin..." then nothing — had to run `tts install` manually

## Root cause

`set -e` exits the script on any non-zero command before the next line can capture `$?`. The `fail "Plugin install failed"` message on line 112 never ran.

## Test plan

- [ ] CI passes
- [ ] `install.sh` shows error message when `tts install` fails
- [ ] `install.sh` completes through step 6 (doctor) on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script control-flow change that only affects the installer’s error handling and git URL rewrite cleanup; main risk is unintended interaction with a user’s global git config if cleanup logic is wrong.
> 
> **Overview**
> Prevents `install.sh` from exiting silently when `tts install` fails under `set -e` by wrapping the call in an `if ! ...; then fail` guard.
> 
> Ensures the temporary global git `url."https://github.com/".insteadOf` rewrite is **always** unset before reporting failure, and is now documented as being cleaned up only after a successful install.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f5032d5d9615eb64af3bba72cd20b3abdbc7ec7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->