### PR TITLE
chore: add biff config, gitignore LaTeX artifacts

### DIFF
--- a/.biff
+++ b/.biff
@@ -1,0 +1,2 @@
+[relay]
+url = "tls://connect.ngs.global"

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,13 @@ lancedb/
 .tts/
 research/
 .biff.local
+.entire/
+
+# LaTeX auxiliary files (prfaq.pdf is tracked, build artifacts are not)
+*.aux
+*.bbl
+*.bcf
+*.blg
+*.log
+*.out
+*.run.xml


### PR DESCRIPTION
## Summary

- Add `.biff` relay config (team communication)
- Gitignore LaTeX build artifacts (`*.aux`, `*.bbl`, `*.bcf`, `*.blg`, `*.log`, `*.out`, `*.run.xml`) — prfaq.pdf is tracked, build intermediates are not
- Gitignore `.entire/` directory

## Test plan

- [ ] `git status` shows no untracked LaTeX artifacts
- [ ] `.biff` config is tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a small relay config file and expands `.gitignore`, with no runtime or security-sensitive code changes.
> 
> **Overview**
> Adds a tracked `.biff` file configuring a `[relay]` URL.
> 
> Updates `.gitignore` to exclude the `.entire/` directory and common LaTeX auxiliary build artifacts (e.g., `*.aux`, `*.bbl`, `*.log`), keeping generated intermediates out of git.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e618cbf874f58d8a175264c7a4acba75e4ac013a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->