### PR TITLE
fix: apply vibe tags to chorus and fix filename collisions

### DIFF
--- a/src/punt_tts/server.py
+++ b/src/punt_tts/server.py
@@ -205,9 +205,17 @@ def speak(
         JSON string with path, text, voice, and language fields.
     """
     _validate_voice_settings(stability, similarity, style)
-    text = _apply_vibe(text)
     provider = get_provider()
     voice, language = _resolve_voice_and_language(provider, voice, language)
+
+    dir_path = _resolve_output_dir(output_dir, ephemeral=ephemeral)
+    path = _resolve_output_path(
+        output_path,
+        dir_path,
+        f"{voice}_{text[:20].replace(' ', '_')}.mp3",
+    )
+
+    text = _apply_vibe(text)
     request = SynthesisRequest(
         text=text,
         voice=voice,
@@ -217,13 +225,6 @@ def speak(
         similarity=similarity,
         style=style,
         speaker_boost=speaker_boost,
-    )
-
-    dir_path = _resolve_output_dir(output_dir, ephemeral=ephemeral)
-    path = _resolve_output_path(
-        output_path,
-        dir_path,
-        f"{voice}_{text[:20].replace(' ', '_')}.mp3",
     )
 
     client = TTSClient(provider)
@@ -282,6 +283,7 @@ def chorus(
         text, voice, and language fields.
     """
     _validate_voice_settings(stability, similarity, style)
+    texts = [_apply_vibe(t) for t in texts]
     provider = get_provider()
     voice, language = _resolve_voice_and_language(provider, voice, language)
     requests = [


### PR DESCRIPTION
## Summary

- `chorus` now applies `_apply_vibe()` to each text before building synthesis requests — previously only `speak` applied session vibe
- `speak` generates filename from original text *before* prepending vibe tags, preventing `[dramatic tone]` from consuming the 20-char disambiguation window

Bugbot catches from PR #23.

## Test plan

- [ ] Existing test suite passes (253 tests)
- [ ] Manual: `/vibe dramatic` then use `chorus` — verify expressive tags in audio
- [ ] Manual: `/vibe dramatic` then `speak` two different texts — verify distinct filenames


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts text pre-processing and output filename generation in `speak`/`chorus`, affecting cache hits and file naming but not provider calls or data handling.
> 
> **Overview**
> Fixes session *vibe tag* handling so `chorus` prepends vibe tags to each input text before building synthesis requests.
> 
> Adjusts `speak` output path generation to use the **original** (pre-vibe) text snippet when constructing the default filename, reducing collisions and preventing vibe tags from consuming the disambiguation window.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fb08d7d8a7488827f0523900065a2d4bf4e4d6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->