### PR TITLE
docs: add worktree default and Copilot review gate to workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,11 +169,25 @@ Update `CHANGELOG.md` with every user-visible change. Follow [Keep a Changelog](
 
 All code changes go on feature branches. Never commit directly to main.
 
+**Use worktrees by default.** Before creating a branch, check `/who` for other active sessions. If other sessions are active, use a worktree to avoid interfering with their working tree. If no other sessions are active, a regular branch is fine.
+
 ```bash
+# Default: worktree (safe when other sessions are active)
+# Use the EnterWorktree tool, then work normally inside the worktree
+
+# Alternative: regular branch (only when /who shows no other sessions)
 git checkout -b feat/short-description main
 # ... work, commit, push ...
 gh pr create --title "feat: description" --body "..."
-# merge via PR, then delete branch
+```
+
+**After creating a PR, always wait for Copilot review before merging:**
+
+```bash
+gh pr checks <number> --watch          # Wait for CI + Copilot to complete
+gh pr view <number> --comments         # Read Copilot feedback
+# Address any feedback, push fixes if needed
+gh pr merge <number> --squash --delete-branch  # Only after review is clean
 ```
 
 | Prefix | Use |


### PR DESCRIPTION
## Summary
- **Worktree by default**: check `/who` for other sessions before branching; use worktree when not solo
- **Copilot review gate**: `gh pr checks --watch` + `gh pr view --comments` before merging any PR

Prompted by PR #31 being merged before Copilot could review it.

## Test plan
- [x] CLAUDE.md renders correctly
- [ ] Next PR follows the new workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust contributor workflow guidance; no runtime or build impact.
> 
> **Overview**
> Updates `CLAUDE.md` development workflow to **default to using git worktrees** when other sessions are active (checked via `/who`), while still allowing a regular branch when solo.
> 
> Adds a **merge gate requiring Copilot review** by instructing authors to wait for `gh pr checks --watch` and review `gh pr view --comments` before running `gh pr merge`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ace7723a90e43681748ae4e77f51edd907e4563a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->