### PR TITLE
docs: add worktree cleanup order-of-operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,19 @@ gh pr view <number> --comments         # Read Copilot feedback
 gh pr merge <number> --squash --delete-branch  # Only after review is clean
 ```
 
+**Worktree cleanup (after merge).** Always clean up worktrees after the PR is merged. Order matters — `cd` out before removing, or the shell's cwd becomes invalid and unrecoverable.
+
+```bash
+# 1. Merge the PR (from inside the worktree is fine)
+gh pr merge <number> --squash --delete-branch
+# 2. cd to the main repo BEFORE removing the worktree
+cd /path/to/main/repo
+# 3. Remove the worktree
+git worktree remove .claude/worktrees/<name>
+# 4. Prune any stale worktree references
+git worktree prune
+```
+
 | Prefix | Use |
 |--------|-----|
 | `feat/` | New features |


### PR DESCRIPTION
## Summary
- Documents worktree cleanup order: cd out first, then remove
- Explains that removing a worktree while your shell cwd is inside it makes the shell unrecoverable

Learned from a real incident in this session where we deleted the worktree floor we were standing on.

## Test plan
- [x] CLAUDE.md renders correctly
- [x] Steps are in the correct order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance for cleaning up git worktrees; no runtime or build behavior is affected.
> 
> **Overview**
> Adds a **post-merge worktree cleanup** section to `CLAUDE.md`, documenting the required order of operations: merge, `cd` back to the main repo, remove the worktree, then `git worktree prune`.
> 
> Calls out the failure mode of deleting a worktree while your shell is still inside it (invalid/unrecoverable cwd), to prevent repeat incidents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7646ab28e13478b70a4872bb10fdad0b5679823. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->