### PR TITLE
docs: worktree model — one per agent, many PRs, /exit cleans up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,24 @@ git checkout -b feat/short-description main
 gh pr create --title "feat: description" --body "..."
 ```
 
+**One worktree per agent, many PRs within it.** A worktree is an isolated working directory for the session. Branch freely inside it — each PR gets its own branch, not its own worktree.
+
+```bash
+# Session start: enter worktree once
+# EnterWorktree tool creates it
+
+# PR 1
+git checkout -b fix/thing-one main
+# ... work, commit, push, PR, merge ...
+
+# PR 2
+git checkout main && git pull
+git checkout -b feat/thing-two main
+# ... work, commit, push, PR, merge ...
+
+# Session end: /exit cleans up the worktree
+```
+
 **After creating a PR, always wait for Copilot review before merging:**
 
 ```bash
@@ -190,18 +208,7 @@ gh pr view <number> --comments         # Read Copilot feedback
 gh pr merge <number> --squash --delete-branch  # Only after review is clean
 ```
 
-**Worktree cleanup (after merge).** Always clean up worktrees after the PR is merged. Order matters — `cd` out before removing, or the shell's cwd becomes invalid and unrecoverable.
-
-```bash
-# 1. Merge the PR (from inside the worktree is fine)
-gh pr merge <number> --squash --delete-branch
-# 2. cd to the main repo BEFORE removing the worktree
-cd /path/to/main/repo
-# 3. Remove the worktree
-git worktree remove .claude/worktrees/<name>
-# 4. Prune any stale worktree references
-git worktree prune
-```
+**Worktree cleanup.** Never remove a worktree from inside it — the session cwd becomes invalid and unrecoverable. Let `/exit` handle cleanup. It prompts to keep or remove the worktree on session end.
 
 | Prefix | Use |
 |--------|-----|


### PR DESCRIPTION
## Summary
- **One worktree per agent**: enter once at session start, branch freely inside it
- **Many PRs per session**: each PR gets its own branch, not its own worktree
- **`/exit` handles cleanup**: never remove a worktree from inside it (cwd becomes unrecoverable)
- Replaces broken manual cleanup steps that can't work from inside a worktree

## Test plan
- [x] CLAUDE.md renders correctly
- [x] Tested worktree removal from inside — confirmed it breaks the session
- [x] Confirmed `EnterWorktree` is one-per-session (tool refuses if already in one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the recommended git worktree workflow and removes manual cleanup steps.
> 
> **Overview**
> Updates `CLAUDE.md` to recommend **one worktree per agent with multiple PR branches per session**, including an example workflow for creating successive PRs inside the same worktree.
> 
> Replaces the manual worktree removal instructions with guidance to **avoid deleting a worktree from inside itself** and to let `/exit` handle cleanup at session end.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c95c7acd0f7f4fee1f792a26716f60011b5f33c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->