### PR TITLE
docs: use MCP merge instead of gh pr merge in worktree workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,13 @@ git checkout -b feat/thing-two main
 gh pr checks <number> --watch          # Wait for CI + Copilot to complete
 gh pr view <number> --comments         # Read Copilot feedback
 # Address any feedback, push fixes if needed
-gh pr merge <number> --squash --delete-branch  # Only after review is clean
+```
+
+**Merge via MCP, not `gh`.** Use `mcp__github__merge_pull_request` (API-only, no local git side effects). `gh pr merge` tries to checkout main locally, which fails inside a worktree. After merging, pull main to stay ready for the next PR.
+
+```bash
+# mcp__github__merge_pull_request(owner="punt-labs", repo="tts", pullNumber=N, merge_method="squash")
+git checkout main && git pull          # Ready for next branch
 ```
 
 **Worktree cleanup.** Never remove a worktree from inside it — the session cwd becomes invalid and unrecoverable. Let `/exit` handle cleanup. It prompts to keep or remove the worktree on session end.


### PR DESCRIPTION
## Summary
- Replace `gh pr merge` with `mcp__github__merge_pull_request` in worktree workflow
- `gh pr merge` tries to checkout main locally, which fails inside a worktree
- MCP merge is API-only — no local git side effects

Follows up on #35.

## Test plan
- [x] CLAUDE.md renders correctly
- [x] Confirmed `gh pr merge` fails inside worktree (PR #35)
- [ ] Test MCP merge from inside worktree (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change. It only alters recommended merge commands for worktree usage and has no runtime or CI impact.
> 
> **Overview**
> Updates `CLAUDE.md` to **stop recommending `gh pr merge`** in worktree-based workflows and instead merge via `mcp__github__merge_pull_request` (API-only) to avoid the local `main` checkout behavior that can fail inside a worktree.
> 
> Adds a brief post-merge step to `git checkout main && git pull` to keep the worktree ready for the next branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 699620b8e18d5332ae5256fbb375f3eaaca9582a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->