### PR TITLE
fix(docs): use detached HEAD after merge in worktree workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,8 @@ gh pr view <number> --comments         # Read Copilot feedback
 
 ```bash
 # mcp__github__merge_pull_request(owner="punt-labs", repo="tts", pullNumber=N, merge_method="squash")
-git checkout main && git pull          # Ready for next branch
+git fetch origin main && git checkout origin/main  # Detached HEAD (worktree can't checkout main branch)
+git checkout -b feat/next-thing                     # New branch from latest main
 ```
 
 **Worktree cleanup.** Never remove a worktree from inside it — the session cwd becomes invalid and unrecoverable. Let `/exit` handle cleanup. It prompts to keep or remove the worktree on session end.


### PR DESCRIPTION
## Summary
- Fix: `git checkout main` fails inside a worktree (main worktree owns that branch)
- Use `git fetch origin main && git checkout origin/main` (detached HEAD) instead
- Tested and confirmed working in this session's worktree

## Test plan
- [x] Confirmed `git checkout main` fails inside worktree
- [x] Confirmed `git fetch origin main && git checkout origin/main` works
- [x] Confirmed new branches can be created from detached HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adjusting post-merge git commands for worktree compatibility; no runtime or production code impact.
> 
> **Overview**
> Updates `CLAUDE.md` worktree workflow guidance after merging a PR: replaces `git checkout main && git pull` with `git fetch origin main && git checkout origin/main` (detached HEAD) and then creating the next branch from that state to avoid checkout failures inside a worktree.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a955426f73702541ea9f07fba2ded385d7e753d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->