### PR TITLE
docs: make PR check blocking requirement explicit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,12 +199,11 @@ git checkout -b feat/thing-two main
 # Session end: /exit cleans up the worktree
 ```
 
-**After creating a PR, always wait for Copilot review before merging:**
+**After creating a PR, block until CI and Copilot finish.** Do not proceed to merge or start other work until these commands complete. `--watch` blocks the shell until all checks resolve — this is intentional.
 
 ```bash
-gh pr checks <number> --watch          # Wait for CI + Copilot to complete
-gh pr view <number> --comments         # Read Copilot feedback
-# Address any feedback, push fixes if needed
+gh pr checks <number> --watch          # BLOCKING: polls until all checks pass or fail
+gh pr view <number> --comments         # Read Copilot feedback — address before merging
 ```
 
 **Merge via MCP, not `gh`.** Use `mcp__github__merge_pull_request` (API-only, no local git side effects). `gh pr merge` tries to checkout main locally, which fails inside a worktree. After merging, pull main to stay ready for the next PR.


### PR DESCRIPTION
## Summary
- Changed "always wait for Copilot review" to "block until CI and Copilot finish"
- Added "Do not proceed to merge or start other work" — explicit gate
- Annotated `--watch` as BLOCKING to prevent agents from skipping it

## Test plan
- [x] CLAUDE.md renders correctly
- [x] Language is unambiguous about blocking behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that tightens workflow guidance; no runtime or build behavior is modified.
> 
> **Overview**
> Clarifies the PR workflow in `CLAUDE.md` by changing “wait for Copilot review” to an explicit **blocking gate**: agents must run `gh pr checks <number> --watch` and not start other work or merge until CI and Copilot checks complete.
> 
> Updates the example commands/comments to emphasize that `--watch` blocks intentionally and that Copilot feedback in `gh pr view --comments` should be addressed before merging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae5516c9c1315ad31a13f815d54dc5dcf48ac7d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->