### PR TITLE
fix: gate vibe tags on provider.supports_expressive_tags

### DIFF
--- a/src/punt_tts/providers/elevenlabs.py
+++ b/src/punt_tts/providers/elevenlabs.py
@@ -112,6 +112,10 @@ class ElevenLabsProvider:
     def default_voice(self) -> str:
         return "matilda"
 
+    @property
+    def supports_expressive_tags(self) -> bool:
+        return True
+
     def generate_audio(self, request: SynthesisRequest) -> SynthesisResult:
         output_path = resolve_output_path(request)
         return self.synthesize(request, output_path)

--- a/src/punt_tts/providers/espeak.py
+++ b/src/punt_tts/providers/espeak.py
@@ -178,6 +178,10 @@ class EspeakProvider:
     def default_voice(self) -> str:
         return "en"
 
+    @property
+    def supports_expressive_tags(self) -> bool:
+        return False
+
     def generate_audio(self, request: SynthesisRequest) -> SynthesisResult:
         output_path = resolve_output_path(request)
         return self.synthesize(request, output_path)

--- a/src/punt_tts/providers/openai.py
+++ b/src/punt_tts/providers/openai.py
@@ -65,6 +65,10 @@ class OpenAIProvider:
     def default_voice(self) -> str:
         return "nova"
 
+    @property
+    def supports_expressive_tags(self) -> bool:
+        return False
+
     def generate_audio(self, request: SynthesisRequest) -> SynthesisResult:
         output_path = resolve_output_path(request)
         return self.synthesize(request, output_path)

--- a/src/punt_tts/providers/polly.py
+++ b/src/punt_tts/providers/polly.py
@@ -205,6 +205,10 @@ class PollyProvider:
     def default_voice(self) -> str:
         return "joanna"
 
+    @property
+    def supports_expressive_tags(self) -> bool:
+        return False
+
     def generate_audio(self, request: SynthesisRequest) -> SynthesisResult:
         output_path = resolve_output_path(request)
         return self.synthesize(request, output_path)

--- a/src/punt_tts/providers/say.py
+++ b/src/punt_tts/providers/say.py
@@ -139,6 +139,10 @@ class SayProvider:
     def default_voice(self) -> str:
         return "fred"
 
+    @property
+    def supports_expressive_tags(self) -> bool:
+        return False
+
     def generate_audio(self, request: SynthesisRequest) -> SynthesisResult:
         output_path = resolve_output_path(request)
         return self.synthesize(request, output_path)

--- a/src/punt_tts/server.py
+++ b/src/punt_tts/server.py
@@ -133,12 +133,18 @@ def _read_vibe_tags() -> str | None:
 _LEADING_TAG_RE = re.compile(r"^\s*\[[^\]\n]+\]")
 
 
-def _apply_vibe(text: str) -> str:
-    """Prepend session vibe tags to text if configured.
+def _apply_vibe(text: str, *, expressive_tags: bool) -> str:
+    """Prepend session vibe tags to text if the provider supports them.
+
+    Only providers whose ``supports_expressive_tags`` is True interpret
+    bracketed tags as performance cues. Other providers would speak
+    them as literal words.
 
     Skips prepending when the text already starts with an expression
     tag (e.g. ``[calm]``) to avoid doubling.
     """
+    if not expressive_tags:
+        return text
     tags = _read_vibe_tags()
     if tags and not _LEADING_TAG_RE.match(text):
         return f"{tags} {text}"
@@ -318,7 +324,7 @@ def speak(
         f"{voice}_{text[:20].replace(' ', '_')}.mp3",
     )
 
-    text = _apply_vibe(text)
+    text = _apply_vibe(text, expressive_tags=provider.supports_expressive_tags)
     request = SynthesisRequest(
         text=text,
         voice=voice,
@@ -388,8 +394,9 @@ def chorus(
         text, voice, and language fields.
     """
     _validate_voice_settings(stability, similarity, style)
-    texts = [_apply_vibe(t) for t in texts]
     provider = get_provider()
+    expressive = provider.supports_expressive_tags
+    texts = [_apply_vibe(t, expressive_tags=expressive) for t in texts]
     voice, language = _resolve_voice_and_language(provider, voice, language)
     requests = [
         SynthesisRequest(

--- a/src/punt_tts/types.py
+++ b/src/punt_tts/types.py
@@ -196,6 +196,11 @@ class TTSProvider(AudioProvider, Protocol):
         """Default voice name for this provider."""
         ...
 
+    @property
+    def supports_expressive_tags(self) -> bool:
+        """Whether this provider interprets [bracketed] tags as performance cues."""
+        ...
+
     def synthesize(self, request: AudioRequest, output_path: Path) -> AudioResult:
         """Synthesize text to an audio file.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -65,31 +65,33 @@ class TestApplyVibe:
 
     def test_prepends_tags(self, _patch_config: Path) -> None:
         _patch_config.write_text('---\nvibe_tags: "[excited]"\n---\n')
-        result = _apply_vibe("Hello world")
+        result = _apply_vibe("Hello world", expressive_tags=True)
         assert result == "[excited] Hello world"
 
     def test_multiple_tags(self, _patch_config: Path) -> None:
         _patch_config.write_text('---\nvibe_tags: "[frustrated] [sighs]"\n---\n')
-        result = _apply_vibe("Hello world")
+        result = _apply_vibe("Hello world", expressive_tags=True)
         assert result == "[frustrated] [sighs] Hello world"
 
     def test_skips_prepend_when_text_starts_with_tag(self, _patch_config: Path) -> None:
         _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
-        result = _apply_vibe("[calm] Already tagged")
+        result = _apply_vibe("[calm] Already tagged", expressive_tags=True)
         assert result == "[calm] Already tagged"
 
     def test_skips_prepend_when_text_starts_with_different_tag(
         self, _patch_config: Path
     ) -> None:
         _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
-        result = _apply_vibe("[excited] Different tag")
+        result = _apply_vibe("[excited] Different tag", expressive_tags=True)
         assert result == "[excited] Different tag"
 
     def test_skips_prepend_when_tag_contains_punctuation(
         self, _patch_config: Path
     ) -> None:
         _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
-        result = _apply_vibe("[dramatic tone] Something important")
+        result = _apply_vibe(
+            "[dramatic tone] Something important", expressive_tags=True
+        )
         assert result == "[dramatic tone] Something important"
 
     def test_passthrough_when_no_tags(self, tmp_path: Path, monkeypatch: Any) -> None:
@@ -97,7 +99,12 @@ class TestApplyVibe:
 
         missing = tmp_path / "missing.md"
         monkeypatch.setattr(srv, "_CONFIG_PATH", missing)
-        assert _apply_vibe("Hello world") == "Hello world"
+        assert _apply_vibe("Hello world", expressive_tags=True) == "Hello world"
+
+    def test_skips_tags_when_not_supported(self, _patch_config: Path) -> None:
+        _patch_config.write_text('---\nvibe_tags: "[excited]"\n---\n')
+        result = _apply_vibe("Hello world", expressive_tags=False)
+        assert result == "Hello world"
 
 
 class TestWriteConfigField:


### PR DESCRIPTION
## Summary
- Added `supports_expressive_tags` property to `TTSProvider` protocol
- ElevenLabs returns `True` (eleven_v3 interprets `[brackets]` as performance cues)
- All other providers return `False` (would speak tags as literal words)
- `_apply_vibe()` now checks the provider's capability instead of hardcoding provider names
- Moved `_apply_vibe()` calls after `get_provider()` so the provider is available

Closes tts-ejg

## Test plan
- [x] 363 tests pass
- [x] mypy: 0 errors
- [x] pyright: 0 errors, 2 warnings (pre-existing pydub stubs)
- [x] ruff: clean
- [x] shellcheck: clean
- [x] New test: `test_skips_tags_when_not_supported` verifies tags are not prepended when `expressive_tags=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-scoped change to text preprocessing that only affects whether `vibe_tags` are prepended before synthesis, plus a protocol surface-area addition requiring providers to implement one boolean property.
> 
> **Overview**
> Adds a new `TTSProvider.supports_expressive_tags` capability and implements it across providers (**True** for ElevenLabs, **False** for others).
> 
> Updates server-side vibe injection so `_apply_vibe()` only prepends configured `vibe_tags` when the selected provider supports expressive bracket tags, and adjusts `speak`/`chorus` to apply this after `get_provider()` is resolved. Tests are updated and a new case asserts tags are skipped when unsupported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0532dea9dd2b1c041c4644ad73d66e0ab43cd6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->