### PR TITLE
docs: add unreleased changelog entries for PRs #31, #33, #39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Batch `set_config` mode: pass `updates` dict to write multiple config fields in a single atomic read-write ([#33](https://github.com/punt-labs/tts/pull/33))
+
+### Fixed
+
+- Vibe tags (`[excited]`, `[weary]`, etc.) are now only prepended when the provider supports expressive tags (ElevenLabs). Other providers (Polly, OpenAI, say, espeak) no longer speak bracketed tag text literally ([#39](https://github.com/punt-labs/tts/pull/39))
+- Speak hook output now uses gendered pronouns: "matilda said her piece" instead of "matilda said the piece" ([#31](https://github.com/punt-labs/tts/pull/31))
+
 ## [0.7.0] - 2026-02-27
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds `[Unreleased]` changelog entries for three PRs merged after 0.7.0:
  - **#31** (Fixed): gendered pronouns in speak hook output
  - **#33** (Added): batch `set_config` mode
  - **#39** (Fixed): vibe tags gated on `provider.supports_expressive_tags`

## Test plan

- [ ] Changelog renders correctly on GitHub
- [ ] No user-visible PRs missing from unreleased section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update; no runtime code paths are modified.
> 
> **Overview**
> Adds new **Unreleased** `CHANGELOG.md` entries documenting: batch `set_config` updates via an `updates` dict (atomic multi-field writes), gating vibe/expression tags to providers that support them (avoids literal bracket text on other providers), and improved speak-hook phrasing with gendered pronouns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a15652004c5f74d4e880f0cbf7d94e8ea558eed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->