### PR TITLE
fix: pass language code to espeak-ng -v instead of display name

### DIFF
--- a/src/punt_tts/providers/espeak.py
+++ b/src/punt_tts/providers/espeak.py
@@ -132,11 +132,11 @@ def _load_voices_from_system() -> None:
         # Extract ISO 639-1 from language code (e.g. "en-gb" -> "en")
         iso = lang.split("-")[0]
         if len(iso) == 2 and key not in VOICES:
-            VOICES[key] = EspeakVoiceConfig(name=voice_name, language=iso)
+            VOICES[key] = EspeakVoiceConfig(name=lang, language=iso)
         # Also register by language code for convenience
         lang_key = lang.lower()
         if lang_key not in VOICES:
-            VOICES[lang_key] = EspeakVoiceConfig(name=voice_name, language=iso)
+            VOICES[lang_key] = EspeakVoiceConfig(name=lang, language=iso)
 
     _voices_loaded = True
     logger.debug("Loaded %d voices from espeak-ng", len(VOICES))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,9 +253,9 @@ def say_provider() -> SayProvider:
 # ---------------------------------------------------------------------------
 
 # Test voice configs for espeak provider.
-ENGLISH_ESPEAK = EspeakVoiceConfig(name="english", language="en")
-GERMAN_ESPEAK = EspeakVoiceConfig(name="german", language="de")
-FRENCH_ESPEAK = EspeakVoiceConfig(name="french", language="fr")
+ENGLISH_ESPEAK = EspeakVoiceConfig(name="en", language="en")
+GERMAN_ESPEAK = EspeakVoiceConfig(name="de", language="de")
+FRENCH_ESPEAK = EspeakVoiceConfig(name="fr", language="fr")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_espeak_provider.py
+++ b/tests/test_espeak_provider.py
@@ -69,15 +69,15 @@ class TestEspeakProviderName:
 class TestEspeakProviderResolveVoice:
     def test_resolve_cached_voice(self, espeak_provider: EspeakProvider) -> None:
         result = espeak_provider.resolve_voice("english")
-        assert result == "english"
+        assert result == "en"
 
     def test_resolve_by_language_code(self, espeak_provider: EspeakProvider) -> None:
         result = espeak_provider.resolve_voice("en")
-        assert result == "english"
+        assert result == "en"
 
     def test_resolve_case_insensitive(self, espeak_provider: EspeakProvider) -> None:
         result = espeak_provider.resolve_voice("ENGLISH")
-        assert result == "english"
+        assert result == "en"
 
     def test_unknown_voice_raises(self, espeak_provider: EspeakProvider) -> None:
         import punt_tts.providers.espeak as espeak_mod
@@ -92,7 +92,7 @@ class TestEspeakProviderResolveVoice:
 
     def test_matching_language(self, espeak_provider: EspeakProvider) -> None:
         result = espeak_provider.resolve_voice("english", language="en")
-        assert result == "english"
+        assert result == "en"
 
     def test_mismatching_language(self, espeak_provider: EspeakProvider) -> None:
         with pytest.raises(ValueError, match="does not support language 'de'"):
@@ -151,7 +151,7 @@ class TestEspeakProviderSynthesize:
             )
 
         assert result.provider == AudioProviderId.espeak
-        assert result.voice == "english"
+        assert result.voice == "en"
         assert result.language == "en"
         assert result.text == "hello"
 
@@ -172,7 +172,7 @@ class TestEspeakProviderSynthesize:
         espeak_args = espeak_call[0][0]
         assert "espeak" in espeak_args[0]
         assert "-v" in espeak_args
-        assert espeak_args[espeak_args.index("-v") + 1] == "english"
+        assert espeak_args[espeak_args.index("-v") + 1] == "en"
         assert "-s" in espeak_args
         assert espeak_args[espeak_args.index("-s") + 1] == "157"
         assert "hello" in espeak_args


### PR DESCRIPTION
## Summary
- eSpeak provider stored VoiceName column (e.g. `English_(America)`) as the `-v` argument, but espeak-ng only accepts language codes (`en-us`) or simple names
- Now stores the Language column value so `espeak-ng -v` always receives a valid identifier

## Context
Bug report from Ubuntu: `espeak-ng -v English_(America)` fails with "The specified espeak-ng voice does not exist." while `espeak-ng -v en-us` works fine.

## Test plan
- [ ] `uv run pytest tests/test_espeak_provider.py -v` — updated assertions
- [ ] On Linux with espeak-ng: `/say hello` with voice `en-us` should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical/resolved voice identifier for the `espeak` provider (and what gets passed to `espeak-ng -v`), which can affect runtime voice selection and returned `SynthesisResult.voice` values but is limited to this provider.
> 
> **Overview**
> Fixes `espeak-ng` voice selection by storing and using the **Language column identifier** (e.g. `en`, `en-us`) as `EspeakVoiceConfig.name` instead of the `VoiceName` display string, ensuring `-v` receives a valid voice.
> 
> Updates the espeak test fixtures and assertions so `resolve_voice()` and `synthesize()` now return/record the language code (and subprocess args use `-v en`) rather than names like `english`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d20d37ce02508764a0c9da12933e1ca5bb762c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->