### PR TITLE
fix: release plugin name (v0.10.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /voice, /say, /notify, /speak, /recap",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-03-03
+
+### Fixed
+
+- Plugin name on release tags is now `vox` (was `vox-dev` — release script was not run before v0.10.0 tag)
+
 ## [0.10.0] - 2026-03-03
 
 First release as **punt-vox**. The PyPI package name changed from `punt-tts` to `punt-vox`, the CLI binary changed from `tts` to `vox`, and all internal paths and namespaces follow suit. No functional changes — this is a pure rename release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "0.10.0"
+version = "0.10.1"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"


### PR DESCRIPTION
## Summary

- Bump version 0.10.0 → 0.10.1
- v0.10.0 was tagged without running `release-plugin.sh`, so the plugin.json at the tag has `"name": "vox-dev"` instead of `"name": "vox"`
- This patch release exists so the release script can be run properly before tagging v0.10.1

## Test plan

- [ ] Quality gates pass
- [ ] After merge: run `release-plugin.sh`, tag v0.10.1, `restore-dev-plugin.sh`, push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only version metadata and changelog updates; no runtime logic changes.
> 
> **Overview**
> Bumps the project/plugin version from `0.10.0` to `0.10.1` across `pyproject.toml`, `src/punt_vox/__init__.py`, and `.claude-plugin/plugin.json`.
> 
> Updates `CHANGELOG.md` to document a patch fix for release tagging so the plugin name on release tags is `vox` rather than `vox-dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 508c95b3b9e4f289d07bb1182a96f3b684773f63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->