### PR TITLE
fix: update install.sh plugin name from tts to vox

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ fail() { printf '  %b✗%b %s\n' "$YELLOW" "$NC" "$1"; exit 1; }
 
 MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
-PLUGIN_NAME="tts"
+PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
 BINARY="vox"
 
@@ -171,5 +171,5 @@ printf '\n'
 
 printf '%b%b%s is ready!%b\n\n' "$GREEN" "$BOLD" "$PLUGIN_NAME" "$NC"
 printf 'Restart Claude Code, then:\n'
-printf '  /notify y     # hear when tasks complete or need input\n'
+printf '  /vox on       # hear when tasks complete or need input\n'
 printf '  /recap        # spoken summary of what just happened\n\n'


### PR DESCRIPTION
## Summary

- `PLUGIN_NAME="tts"` → `"vox"` — marketplace renamed in v0.11.0
- Post-install instructions: `/notify y` → `/vox on`

Without this fix, `install.sh` tries to install `tts@punt-labs` which no longer exists in the marketplace.

## Test plan

- [ ] `curl -fsSL .../install.sh | sh` installs `vox@punt-labs` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small installer-script update that only changes the marketplace plugin identifier and the printed post-install command.
> 
> **Overview**
> Updates `install.sh` to install the renamed Claude marketplace plugin by changing `PLUGIN_NAME` from `tts` to `vox`.
> 
> Adjusts the post-install instructions to use `/vox on` instead of `/notify y` so the displayed command matches the new plugin name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 017035ac9464a3f2d0a6047a73d35f154f05588a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->