### PR TITLE
docs: address Copilot review wording from #63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Merged `/vox-on` and `/vox-off` into single `/vox on|off` command with argument parsing
+- Merged `/vox-on` and `/vox-off` into a single `/vox` slash command that accepts an `on` or `off` argument
 
 ## [0.11.0] - 2026-03-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Plugin structure (Claude Code hooks and commands):
 | `hooks/notify-permission.sh` | Notification hook: async audio alerts for permission/idle prompts |
 | `hooks/suppress-output.sh` | PostToolUse hook: formats MCP tool output for UI panel |
 | `hooks/session-start.sh` | SessionStart hook: deploys commands, cleans retired commands, auto-allows MCP tools |
-| `commands/vox.md` | `/vox on\|off` — enable/disable notifications (on: show voice roster) |
+| `commands/vox.md` | `/vox` — notifications on/off (args: `on` or `off`; `on` shows voice roster) |
 | `commands/unmute.md` | `/unmute [@voice]` — enable voice mode, set session voice, browse roster |
 | `commands/mute.md` | `/mute` — chimes only |
 | `commands/recap.md` | `/recap` — on-demand spoken summary (uses `unmute` MCP tool) |

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -22,7 +22,7 @@ fi
 
 ACTIONS=()
 
-# ── Clean up retired commands from pre-mic-API ────────────────────────
+# ── Clean up retired commands ─────────────────────────────────────────
 if [[ "$DEV_MODE" == "false" ]]; then
   RETIRED=(say.md speak.md notify.md voice.md vox-on.md vox-off.md)
   CLEANED=()


### PR DESCRIPTION
## Summary

- CHANGELOG: reword to clarify `/vox` accepts `on` or `off` argument (not literal `on|off`)
- CLAUDE.md: reword table entry for same clarity
- session-start.sh: generalize "pre-mic-API" comment to "retired commands" since the list now includes post-mic-API entries

Addresses 3 Copilot review comments from #63.

## Test plan

- [ ] `shellcheck -x hooks/session-start.sh` passes
- [ ] Docs read clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/comment-only change; no runtime behavior or interfaces are modified.
> 
> **Overview**
> Clarifies wording in `CHANGELOG.md` and `CLAUDE.md` to make it explicit that the unified `/vox` slash command accepts an `on` or `off` argument (not a literal `on|off`).
> 
> Updates a comment in `hooks/session-start.sh` to describe the command cleanup step more generally as removing *retired commands*.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 748759477f57b06f00a99b8f313b0932c7d137b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->