### PR TITLE
fix(ci): pin markdownlint-cli2@0.20.0 to avoid katex crash

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: DavidAnson/markdownlint-cli2-action@2256fe35224a451507c8848ec825a4212e9eeb00 # v22
         with:
-          node-version: "20"
-      - run: npx markdownlint-cli2 "**/*.md" "#node_modules"
+          globs: "**/*.md #node_modules"


### PR DESCRIPTION
## Summary

- Pins `markdownlint-cli2@0.20.0` in the docs CI workflow
- `0.21.0` pulls a `katex` version where `__VERSION__` is undefined, crashing with `ReferenceError` on Node 20

## Test plan

- [ ] `docs` CI check passes on this PR (was failing on all recent PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that swaps the markdown linting implementation; main risk is slight behavior differences in linting globs/options that could fail the docs check unexpectedly.
> 
> **Overview**
> Updates the `Docs` GitHub Actions workflow to stop installing Node and running `npx markdownlint-cli2`, and instead run markdown linting via the pinned `DavidAnson/markdownlint-cli2-action`.
> 
> Configures the action with `globs` to lint `**/*.md` while excluding `node_modules`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 765c8c5d2a57be6b2cc7b6beeeed5243e6a56a79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->