### PR TITLE
fix: suppress elevenlabs pydantic v1 warning on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests as integration tests (requires provider API credentials)",
 ]
+filterwarnings = [
+    "ignore:Core Pydantic V1 functionality isn't compatible with Python 3.14:UserWarning",
+]
 
 [tool.coverage.run]
 source = ["src"]

--- a/src/punt_vox/providers/__init__.py
+++ b/src/punt_vox/providers/__init__.py
@@ -8,8 +8,18 @@ import os
 import platform
 import shutil
 import subprocess
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING
+
+# elevenlabs SDK imports pydantic.v1 which warns on Python 3.14+.
+# Their issue, not ours — suppress until they ship a fix.
+warnings.filterwarnings(
+    "ignore",
+    message="Core Pydantic V1 functionality isn't compatible with Python 3.14",
+    category=UserWarning,
+    module=r"elevenlabs\.core\.pydantic_utilities",
+)
 
 if TYPE_CHECKING:
     from punt_vox.types import TTSProvider


### PR DESCRIPTION
## Summary

- Suppress the `UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14` emitted by the elevenlabs SDK
- `warnings.filterwarnings` in `providers/__init__.py` (runtime) and `pyproject.toml` pytest config (test runs)
- No version pinning — vox continues to support `>=3.13`

Closes vox-2pz

## Test plan

- [x] `vox doctor` — no warning on Python 3.14
- [x] `uv run python -W all -c "from punt_vox.providers.elevenlabs import ElevenLabsProvider"` — no warning
- [x] 495 tests pass, 0 warnings
- [x] ruff, mypy, pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only suppresses a specific third-party `UserWarning` at runtime and in pytest, without changing provider behavior or data flow.
> 
> **Overview**
> Suppresses the noisy ElevenLabs SDK `UserWarning` about Pydantic v1 incompatibility on Python 3.14.
> 
> Adds a targeted `warnings.filterwarnings` in `providers/__init__.py` (scoped to `elevenlabs.core.pydantic_utilities`) and a matching `pytest` `filterwarnings` entry in `pyproject.toml` to keep test output clean.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f950be92a124c2f0cd59c8f613b5553ca79e499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->