### PR TITLE
fix(hooks): update stale commands on plugin upgrade

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -671,3 +671,66 @@ This uses `claude plugin marketplace update` rather than operating on the clone 
 5. Added `source.ref: "v0.4.0"` to marketplace, nuked cache, reinstalled → `name: "tts"`, correct commit
 6. Discovered stale clone problem: existing users whose clone predates the ref pin still get HEAD
 7. Added `_refresh_marketplace()` to installer — pulls latest marketplace.json before install
+
+---
+
+## DES-016: Command Deployment Must Update, Not Skip-If-Exists
+
+**Date:** 2026-03-05
+**Status:** SETTLED
+**Topic:** How SessionStart hook deploys top-level commands to `~/.claude/commands/`
+
+### Problem
+
+The SessionStart hook deployed commands with a skip-if-exists guard:
+
+```bash
+# WRONG: stale commands persist forever
+if [[ ! -f "$dest" ]]; then
+  cp "$cmd_file" "$dest"
+fi
+```
+
+This meant that once a command file was deployed, it **never updated** — even across plugin upgrades and releases. Users accumulated stale command files with:
+
+- Old `allowed-tools` (e.g., `Read`, `Write`, `Edit` instead of `Bash`)
+- Old MCP tool names (e.g., `mcp__plugin_tts_vox__speak` from before the rename)
+- Old implementation logic (prompt-driven config file editing instead of CLI calls)
+
+The `/vox`, `/unmute`, `/mute`, `/vibe`, and `/recap` commands were all stale. Some still referenced tool names from 3+ releases ago.
+
+### Why This Wasn't Caught
+
+1. The developer uses `--plugin-dir .` (dev mode), which skips command deployment entirely
+2. Editable install means the developer's `vox` binary runs working-tree code
+3. The stale commands still "worked" — Claude could figure out the intent even with wrong tools — just not correctly
+4. No integration test for "install plugin, upgrade, verify commands updated"
+
+### Root Cause
+
+The original skip-if-exists logic was written to be idempotent for first-run setup. The assumption was that commands don't change across releases. That assumption was wrong from day one — commands have changed in almost every release since the plugin launched.
+
+### Fix
+
+Compare content with `diff -q` and overwrite when different:
+
+```bash
+# CORRECT: update changed commands
+mkdir -p "$COMMANDS_DIR"
+if [[ ! -f "$dest" ]] || ! diff -q "$cmd_file" "$dest" >/dev/null 2>&1; then
+  cp "$cmd_file" "$dest"
+fi
+```
+
+### Scope
+
+Fixed in all Punt Labs plugins:
+- `vox/hooks/session-start.sh`
+- `biff/hooks/session-start.sh`
+- `dungeon/hooks/session-start.sh`
+
+Updated in `punt-kit/standards/plugins.md` — the standard now mandates diff-and-update with correct/incorrect code examples.
+
+### Rule
+
+**SessionStart command deployment must always update stale files.** Never skip-if-exists for command deployment. The cost of an unnecessary copy is zero. The cost of a stale command is a broken user experience that persists across every session until the user manually deletes the file.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -47,8 +47,8 @@ if [[ "$DEV_MODE" == "false" ]]; then
     name="$(basename "$cmd_file")"
     [[ "$name" == *-dev.md ]] && continue
     dest="$COMMANDS_DIR/$name"
-    if [[ ! -f "$dest" ]]; then
-      mkdir -p "$COMMANDS_DIR"
+    mkdir -p "$COMMANDS_DIR"
+    if [[ ! -f "$dest" ]] || ! diff -q "$cmd_file" "$dest" >/dev/null 2>&1; then
       cp "$cmd_file" "$dest"
       DEPLOYED+=("/${name%.md}")
     fi


### PR DESCRIPTION
## Summary

- SessionStart hook used `[[ ! -f "$dest" ]]` (skip-if-exists) for command deployment, leaving stale files in `~/.claude/commands/` forever across plugin upgrades
- Replace with `diff -q` comparison: overwrite when content differs, skip when identical
- Log root cause and fix as DES-016 in DESIGN.md
- Updated `punt-kit/standards/plugins.md` with dedicated Command Deployment section (pushed directly to punt-kit main)

## Root cause

Commands deployed on first install never updated. Users accumulated stale files with old `allowed-tools` (Read/Write/Edit instead of Bash), old MCP tool names (`mcp__plugin_tts_vox__` from before the rename), and old implementation logic (prompt-driven config editing instead of CLI calls). Invisible to developers because dev mode skips deployment.

## Test plan

- [x] `shellcheck -x hooks/*.sh scripts/*.sh install.sh` passes
- [x] All 495 tests pass
- [ ] After merge + release: restart Claude Code, verify `/vox c` calls `vox notify c` via Bash (not Read/Write on config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the SessionStart hook to overwrite existing `~/.claude/commands/*.md` when plugin command content differs, which can affect user-modified command files. Behavior is simple but touches user home-directory state on every session start.
> 
> **Overview**
> Fixes command deployment so plugin upgrades actually refresh top-level slash command files in `~/.claude/commands/`.
> 
> `hooks/session-start.sh` now deploys commands with a content check (`diff -q`) and copies when missing *or* different, instead of skipping any existing file. `DESIGN.md` adds DES-016 documenting the stale-command root cause and the new diff-and-update rule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 578e9cf1697de610530c049265104e2bd3e13cf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->