### PR TITLE
test: add 42 partition tests for notify/speak state machine

### DIFF
--- a/tests/test_server_partition.py
+++ b/tests/test_server_partition.py
@@ -334,13 +334,13 @@ class TestMute:
 
 # ---------------------------------------------------------------------------
 # Observation partitions — config-based guards
-# These verify that hook/watcher guard conditions are expressed correctly
-# in the config state produced by operations.
+# These verify hook/watcher guard predicates against static config state
+# (written via _write_state, not produced by notify/speak operations).
 # ---------------------------------------------------------------------------
 
 
 class TestStopObservations:
-    """Partitions 26-32: StopFires/StopChime/StopVoice observations."""
+    """Partitions 26-31: StopFires/StopChime/StopVoice observations."""
 
     def test_partition_26_stop_fires_non(self, _patch_config: Path) -> None:
         """P26: nOn/sVoice → stop fires (notify ≠ nOff)."""


### PR DESCRIPTION
## Summary
- 42 test cases derived from the Z specification (`docs/vox-notify.tex`) using TTF testing tactics
- Covers all 5 command operations (VoxOn, VoxOff, VoxCont, Unmute, Mute), 6 observation guard conditions, 3 invariant preservation sequences, and 2 rejected input cases
- Full spec-implementation conformance coverage for the state machine merged in PR #81

## Test plan
- [x] All 570 tests pass locally (`make check`)
- [x] Lint, mypy, pyright clean
- [x] No production code changes — test-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds coverage without modifying production behavior; risk is limited to potential CI time/flakiness from extensive file-based state setup.
> 
> **Overview**
> Adds `tests/test_server_partition.py`, a large partition-test suite derived from the Z spec to verify the `notify()`/`speak()` state transitions by writing config pre-states, invoking the commands, and asserting config and JSON outputs.
> 
> The new tests cover VoxOn/VoxOff/VoxCont, mute/unmute (including voice replacement), observation guard predicates for stop/watcher behavior, multi-step invariant preservation sequences, and rejected invalid input modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d735af32b9f0c7247e2a6dba2325e40bfec989b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->