### PR TITLE
fix(commands): unmute skill missing stop directive after speak in 2+ voice path (vox-0c0)

### DIFF
--- a/commands/unmute.md
+++ b/commands/unmute.md
@@ -18,7 +18,7 @@ Enable voice mode (spoken notifications). Optionally set a session voice or brow
 
 - **(no argument)**:
   1. Call the `who` MCP tool to get `current` and `featured` voices.
-  2. If `featured` has 2+ voices, build a candidate list: start with `current` (if set), then append `featured` voices, de-duplicating by name. Take the first 4 and call `AskUserQuestion` (label=name, description=blurb; append "(current)" to the current voice's description). Then call `speak` with `mode="y"` and `voice` set to the chosen name.
+  2. If `featured` has 2+ voices, build a candidate list: start with `current` (if set), then append `featured` voices, de-duplicating by name. Take the first 4 and call `AskUserQuestion` (label=name, description=blurb; append "(current)" to the current voice's description). Then call `speak` with `mode="y"` and `voice` set to the chosen name. No text output. Stop.
   3. If `featured` has fewer than 2 voices, call `speak` with `mode="y"` (provider default). Done — no text output.
 - **`@<name>`**: Call the `speak` MCP tool with `mode="y"` and `voice="<name>"`. No text output — the panel confirms.
 - **`@`** (bare @): Call the `who` MCP tool to list voices. Display featured voices with blurbs in a casual "who's around" format. Tell the user to pick with `/unmute @<name>`.


### PR DESCRIPTION
## Root Cause

The no-argument `/unmute` path with 2+ featured voices calls `AskUserQuestion` then `speak`, but has no termination directive after `speak` returns. The turn remained open, and the model produced off-script text output after the skill completed (Mode C).

Root cause traced from session log `~/.claude/projects/-home-jfreeman-Coding-punt-labs-claude-agent-sdk-smalltalk/f79fa26f-c7eb-49dc-bbcc-d44500c65a3d.jsonl` L96: Claude produced `"Human: What is a brown fox famously known for?"` as its own text output after `speak` returned. The `"Human: "` prefix caused the terminal renderer to display it as a turn marker.

Every other unmute path already had a stop directive:
- `@<name>` path: "No text output — the panel confirms."
- `<2 voices` path: "Done — no text output."

## Fix

Added "No text output. Stop." at the end of the 2+ voices `speak` call in step 2.

## Pre-PR Checklist
- [x] One-line change to `commands/unmute.md`
- [x] No code changes — plugin prompts reload automatically
- [x] CHANGELOG not updated (plugin/command behavior, not library API)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/prompt tweak that only changes control-flow instructions for the `/unmute` command to prevent unintended post-command text output.
> 
> **Overview**
> Ensures the no-argument `/unmute` path with 2+ featured voices explicitly terminates after calling `speak` by adding a *"No text output. Stop."* directive, preventing off-script text from being emitted after the voice selection flow completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28842881bec7f7961e2b6b5f914bbec7f8cde091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->