### PR TITLE
chore: release v4.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.3.0",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-04-09
+
 ### Added
 
 - **`vox daemon restart` subcommand**: cycle the running `voxd` daemon via the service manager without hand-running `systemctl` or `launchctl`. Refuses to run as root (sudo is invoked internally for the two service-manager calls only), detects macOS vs Linux, drives `_launchd_stop`/`_systemd_stop` + `_ensure_port_free` for a clean shutdown, starts the daemon via `sudo systemctl start voxd` or `sudo launchctl load -w ... && sudo launchctl kickstart -k system/com.punt-labs.voxd`, and polls the authenticated health endpoint (5s window, 200ms interval) until the new process is confirmed up. On success, prints the new pid and port. On failure, exits 1 and points at `~/.punt-labs/vox/logs/voxd.log`. This is the intended command after `uv tool upgrade punt-vox` — a plain upgrade replaces the wheel but leaves the long-running daemon untouched, so changes to daemon behavior do not take effect until the service is cycled.

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.2.0"
+VERSION="4.3.0"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.2.0"
+version = "4.3.0"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.2.0"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: updates version strings and plugin metadata without changing runtime code paths.
> 
> **Overview**
> Updates the packaged/plugin release metadata for `v4.3.0`: bumps version numbers across `pyproject.toml`, `__init__.__version__`, `uv.lock`, and `install.sh`, and renames the Claude plugin from `vox-dev` to `vox`.
> 
> Adds a new `CHANGELOG.md` entry for `4.3.0` describing the release contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08a394c6068a2201e63867a50b86961e2a07538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->