### PR TITLE
fix: qualify comments and add status_kind to doctor --json (vox-t2f, vox-kl7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`vox doctor --json` rows now include `status_kind` field (vox-kl7)**: each check row carries `status_kind` with values `"pass"`, `"warn"`, `"fail"`, or `"skip"` so machine consumers can distinguish warnings from hard failures. The existing `passed` boolean is unchanged.
+
+### Fixed
+
+- **Qualified "world-readable" and "/proc" references in comments (vox-t2f)**: replaced bare "world-readable" with "others-readable (mode & 0o004)" in `service.py` keys.env race comments, and added "(Linux-specific; macOS has no /proc)" to the `/proc` reference in `voxd.py`, for cross-location consistency with PR #175's broader phrasing.
+
 ## [4.3.2] - 2026-04-11
 
 ### Fixed

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -796,6 +796,16 @@ _FAIL = "\u2717"
 _OPTIONAL = "\u25cb"
 _WARN = "\u26a0"  # ⚠ — non-fatal diagnostic, exit code unchanged
 
+# Machine-readable tri-state (+skip) for --json consumers that need to
+# distinguish warnings from hard failures.  The existing ``passed`` bool
+# is kept for back-compat; ``status_kind`` is the richer replacement.
+_STATUS_KIND: dict[str, str] = {
+    _PASS: "pass",
+    _FAIL: "fail",
+    _OPTIONAL: "skip",
+    _WARN: "warn",
+}
+
 
 def _claude_desktop_config_path() -> Path:
     return (
@@ -939,6 +949,7 @@ def doctor() -> None:
         checks.append(
             {
                 "status": symbol,
+                "status_kind": _STATUS_KIND.get(symbol, "fail"),
                 "message": message,
                 "required": required,
                 "passed": symbol == _PASS,

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -124,8 +124,8 @@ def _write_keys_env(env: dict[str, str], keys_path: Path) -> Path:
     so there is no instant at which the file exists with umask-widened
     permissions. ``Path.write_text`` would have called ``open(..., "w")``
     which creates the file with ``0o666 & ~umask`` first and only
-    chmods afterward — a world-readable exposure window on any system
-    with the typical ``umask 0022``. Copilot 3048402515 on PR #162.
+    chmods afterward — an others-readable (mode & 0o004) exposure window
+    on any system with the typical ``umask 0022``. Copilot 3048402515 on PR #162.
 
     The parent directory is also created-or-tightened to mode 0700 as a
     belt-and-suspenders step so ``_write_keys_env`` remains self-
@@ -225,7 +225,7 @@ def _write_keys_env(env: dict[str, str], keys_path: Path) -> Path:
 
     # Atomic create-and-truncate with explicit mode 0600. This replaces
     # the older ``Path.write_text`` + ``Path.chmod`` sequence, which
-    # left the file world-readable for the few instructions between
+    # left the file others-readable (mode & 0o004) for the few instructions between
     # the ``open(..., "w")`` inside ``write_text`` (which creates with
     # ``0o666 & ~umask``) and the subsequent ``chmod(0o600)``.
     fd = os.open(
@@ -241,7 +241,7 @@ def _write_keys_env(env: dict[str, str], keys_path: Path) -> Path:
     # combined with the process umask at creation time, so on an
     # unusual umask (for example 0077 or an inherited 0000) the
     # effective creation mode might not be exactly 0o600. Call chmod
-    # afterward to pin it. The file was never world-readable — at
+    # afterward to pin it. The file was never others-readable (mode & 0o004) — at
     # worst it was user-only (0o600 & ~0o077 == 0o600 on a typical
     # umask, 0o600 & ~0o000 == 0o600 on umask 0000). This chmod only
     # narrows an already-safe mode to the exact target.

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -147,7 +147,7 @@ def _log_voxd_environment() -> None:
     """Log voxd's process identity and audio env vars at startup.
 
     Single greppable INFO line so operators can verify systemd env
-    injection without poking at ``/proc``.
+    injection without poking at ``/proc`` (Linux-specific; macOS has no ``/proc``).
     """
     env = {k: os.environ.get(k, "<unset>") for k in _STARTUP_ENV_KEYS}
     # os.getuid/getgid are POSIX-only; fall back gracefully on Windows.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1617,6 +1617,111 @@ class TestDoctorCommand:
         # And the command itself must still be present, unquoted.
         assert "systemctl --user disable --now vox.service" in result.output
 
+    # ------------------------------------------------------------------
+    # status_kind field (vox-kl7)
+    # ------------------------------------------------------------------
+
+    def test_json_status_kind_pass_warn_fail(self, tmp_path: Path) -> None:
+        """--json rows carry status_kind: pass, warn, or fail.
+
+        A version-mismatched daemon triggers a warning row. All other
+        passing checks produce pass rows. The test verifies the tri-state
+        mapping and confirms the existing ``passed`` boolean is unchanged.
+        """
+        runner = CliRunner()
+
+        def which_side_effect(name: str) -> str | None:
+            if name == "ffmpeg":
+                return "/opt/homebrew/bin/ffmpeg"
+            if name == "uvx":
+                return "/usr/local/bin/uvx"
+            return None
+
+        mock_client = MagicMock()
+        mock_client.health.return_value = {
+            "provider": "elevenlabs",
+            "active_sessions": 2,
+            "port": 8421,
+            "daemon_version": "4.1.1",
+        }
+
+        with (
+            patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
+            patch(f"{_CLI}.VoxClientSync", return_value=mock_client),
+            patch(f"{_CLI}.installed_version", return_value="4.2.0"),
+            patch(
+                f"{_CLI}._claude_desktop_config_path",
+                return_value=tmp_path / "nope.json",
+            ),
+            patch(
+                f"{_CLI}.default_output_dir",
+                return_value=tmp_path / "audio",
+            ),
+            patch(f"{_CLI}.platform.system", return_value="Darwin"),
+        ):
+            result = runner.invoke(app, ["--json", "doctor"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        checks = data["checks"]
+
+        # Every row must carry status_kind.
+        for row in checks:
+            assert "status_kind" in row, f"missing status_kind: {row}"
+            assert row["status_kind"] in ("pass", "warn", "fail", "skip")
+
+        # The daemon mismatch row is a warning.
+        warn_rows = [r for r in checks if r["status_kind"] == "warn"]
+        assert len(warn_rows) >= 1
+        for wr in warn_rows:
+            assert wr["passed"] is False
+
+        # Passing rows have passed=True.
+        pass_rows = [r for r in checks if r["status_kind"] == "pass"]
+        assert len(pass_rows) >= 1
+        for pr in pass_rows:
+            assert pr["passed"] is True
+
+    def test_json_status_kind_fail_row(self, tmp_path: Path) -> None:
+        """A hard-failure row (daemon not running) has status_kind == fail."""
+        runner = CliRunner()
+
+        def which_side_effect(name: str) -> str | None:
+            if name == "ffmpeg":
+                return "/opt/homebrew/bin/ffmpeg"
+            if name == "uvx":
+                return "/usr/local/bin/uvx"
+            return None
+
+        from punt_vox.client import VoxdConnectionError
+
+        mock_client = MagicMock()
+        mock_client.health.side_effect = VoxdConnectionError("not running")
+
+        with (
+            patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
+            patch(f"{_CLI}.VoxClientSync", return_value=mock_client),
+            patch(f"{_CLI}.installed_version", return_value="4.2.0"),
+            patch(
+                f"{_CLI}._claude_desktop_config_path",
+                return_value=tmp_path / "nope.json",
+            ),
+            patch(
+                f"{_CLI}.default_output_dir",
+                return_value=tmp_path / "audio",
+            ),
+            patch(f"{_CLI}.platform.system", return_value="Darwin"),
+        ):
+            result = runner.invoke(app, ["--json", "doctor"])
+
+        # exit_code 1 because daemon is a required check
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        fail_rows = [r for r in data["checks"] if r["status_kind"] == "fail"]
+        assert len(fail_rows) >= 1
+        for fr in fail_rows:
+            assert fr["passed"] is False
+
 
 class TestValidVoxSubcommands:
     """Direct contract tests for ``_valid_vox_subcommands()``.


### PR DESCRIPTION
## Summary

Two small beads bundled: vox-t2f (comment sweep) and vox-kl7 (doctor JSON shape).

### vox-t2f — comment qualification

- `service.py`: 3 occurrences of "world-readable" → "others-readable (mode & 0o004)" to distinguish the keys.env umask-race comments from the `--api-key-file` 0o077 permission check added in PR #175.
- `voxd.py`: `/proc` comment now notes "(Linux-specific; macOS has no `/proc`)".
- No behavior change. No tests.

### vox-kl7 — `vox doctor --json` status_kind

- New `status_kind` field on each JSON check row: `"pass"`, `"warn"`, `"fail"`, `"skip"`.
- Existing `passed` boolean unchanged (back-compat).
- Machine consumers can now distinguish daemon-version-mismatch warnings from hard failures without parsing unicode symbols.

## Test plan

- [x] `make check` green (1105 passing, +2 new)
- [x] `test_json_status_kind_pass_warn_fail` — mocks a daemon version mismatch, asserts warn row has `status_kind == "warn"` and `passed == False`, pass rows have `status_kind == "pass"` and `passed == True`
- [x] `test_json_status_kind_fail_row` — asserts fail row has `status_kind == "fail"` and `passed == False`
- [x] `grep -rn 'world-readable' src/` — all hits qualified
- [x] `grep -rn '/proc' src/` — all hits Linux-acknowledged

Closes vox-t2f, vox-kl7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive JSON output field plus tests and comment-only wording tweaks, with no changes to runtime behavior beyond machine-readable doctor output.
> 
> **Overview**
> `vox doctor --json` now includes a new per-check `status_kind` field (`pass`, `warn`, `fail`, `skip`) while keeping the existing `passed` boolean for backward compatibility.
> 
> Adds CLI tests covering the `status_kind` mapping for passing checks, daemon-version warnings, and hard failures, and updates a few comments to clarify permission wording (“others-readable (mode & 0o004)”) and note that `/proc` is Linux-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abbe7e44c24e6e4d73ca3768a3946d828fe9a903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->