### PR TITLE
feat: vibe-driven music generation via ElevenLabs Music API (vox-0qi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Background music generation (`/music on|off`, `vox music on|off`)**: vibe-driven instrumental music that loops during coding sessions. When music mode is on, vox generates ~2-minute tracks via the ElevenLabs Music API using the current session vibe, style modifier, and time-of-day context, then loops them at reduced volume through voxd while speech and chimes play at full volume on top. When the vibe changes (via `/vibe` or auto-vibe), a new track generates to match. `/music on style techno` sets a persistent style preference; `/music off` stops playback. Session ownership ensures only the controlling session's vibe drives the music. State is daemon-wide and ephemeral (daemon restart = music off). Typical credit usage: 1-3 tracks per session (~2k credits each). Requires ElevenLabs paid plan. Includes CLI commands (`vox music on [--style ...]`, `vox music off`), MCP tool (`music`), slash command (`/music`), vibe-to-prompt mapping, `MusicProvider` protocol, `ElevenLabsMusicProvider`, `MusicLoop` async task in voxd, and dedicated playback subprocess separate from the speech/chime queue. Closes vox-0qi.
+
 ### Changed
 
 - **`vox doctor --json` rows now include `status_kind` field (vox-kl7)**: each check row carries `status_kind` with values `"pass"`, `"warn"`, `"fail"`, or `"skip"` so machine consumers can distinguish warnings from hard failures. The existing `passed` boolean is unchanged.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Do NOT set: `mission_id`, `status`, `created_at`, `evaluator.pinned_at`, `evalua
 
 ### Worker prompt template
 
-```
+```text
 Mission <id> is yours. Read it first: `ethos mission show <id>`.
 The contract names the write set, success criteria, and budget.
 Your first write must land inside the write set — the store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,15 @@ exists. Do not commit, push, or merge — return results to me.
 
 Worker and evaluator must be distinct handles with no shared role.
 
+### Task tracking and parallelism
+
+For multi-phase features (T1/T2), create a TaskCreate list with all missions up front and wire dependencies via `addBlockedBy`. This gives the user visibility into progress and lets you parallelize independent phases.
+
+- **Create all tasks first**, then set dependencies. Mark phase 1 complete immediately if already done.
+- **Launch independent missions in parallel** — if phases 2 and 3 don't depend on each other, create both missions and spawn both workers in the same message. Two `Agent()` calls, both `run_in_background: true`.
+- **As each mission completes**: review the result, close the mission, commit, mark the task completed, check what's unblocked, and launch the next mission(s).
+- **The task list is the source of truth** for what's done, what's in flight, and what's blocked. Update it as missions close.
+
 ### Scratch files
 
 Mission contract YAMLs go in `.tmp/missions/`. Result artifact YAMLs go in `.tmp/missions/results/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,79 @@ Tests mirror source: `test_types.py`, `test_core.py`, `test_output.py`, `test_pl
 - Use `side_effect=lambda` instead of `return_value` for fresh mocks per call.
 - Integration tests requiring AWS credentials are marked `@pytest.mark.integration`.
 
+## Delegation with Missions
+
+All code delegation uses ethos missions (`/mission` skill). Missions are typed contracts between a leader (claude) and a worker (bwk, rmh, mdm, adb, djb) that enforce write-set admission, frozen evaluators, bounded rounds, and append-only event logs.
+
+### When to use missions
+
+- Any bounded task with clear success criteria and a known set of files to touch.
+- Sized for 1-3 rounds of one worker plus one evaluator.
+- The Phase 3 runtime enforces the contract — write-set admission, frozen evaluator, result artifacts — instead of trusting prompt discipline.
+
+Do NOT use missions for: exploratory research, work you do yourself, or epics that need decomposition first (decompose into multiple missions).
+
+### Workflow
+
+1. **Scaffold**: `/mission` skill scaffolds the contract YAML from conversation context.
+2. **Confirm**: present the contract to the user (or decide as leader). Edit any field before creation.
+3. **Create**: `ethos mission create --file .tmp/missions/<name>.yaml` — returns a mission ID.
+4. **Spawn**: `Agent(subagent_type=<worker>, run_in_background=true)` with a prompt that points at the mission ID. The worker reads the contract via `ethos mission show <id>` as its first action.
+5. **Track**: `ethos mission show <id>`, `ethos mission log <id>`, `ethos mission results <id>`.
+6. **Review**: read the result artifact. Pass → `ethos mission close <id>`. Continue → `ethos mission reflect <id> --file <path>` then `ethos mission advance <id>`. Fail → `ethos mission close <id> --status failed`.
+
+### Contract schema (required fields)
+
+```yaml
+leader: claude
+worker: rmh                    # bwk|rmh|mdm|adb|djb|kpz
+evaluator:
+  handle: djb                  # must differ from worker, no shared role
+inputs:
+  bead: vox-0qi                # optional bead link
+write_set:                     # repo-relative paths, at least one
+  - src/punt_vox/music.py
+  - tests/test_music.py
+success_criteria:              # at least one verifiable criterion
+  - vibe_to_prompt returns correct prompt for all test cases
+  - make check passes
+budget:
+  rounds: 2                    # 1-10
+  reflection_after_each: true  # leader reflects after each round
+```
+
+Optional: `context` (design notes), `tools` (worker allowlist), `session`, `repo`.
+Do NOT set: `mission_id`, `status`, `created_at`, `evaluator.pinned_at`, `evaluator.hash`, `current_round` — the store manages these.
+
+### Worker prompt template
+
+```
+Mission <id> is yours. Read it first: `ethos mission show <id>`.
+The contract names the write set, success criteria, and budget.
+Your first write must land inside the write set — the store
+refuses anything else. After your work for this round, submit a
+result artifact: `ethos mission result <id> --file <path>`. See
+`ethos mission result --help` for the YAML shape. The mission
+will refuse to close until a valid result for the current round
+exists. Do not commit, push, or merge — return results to me.
+```
+
+### Evaluator defaults
+
+| Task type | Evaluator |
+|-----------|-----------|
+| Security-sensitive code | `djb` |
+| Go internals / library design | `mdm` or `bwk` |
+| Python library design | `rmh` |
+| CLI / developer experience | `mdm` |
+| Infrastructure / CI | `adb` |
+
+Worker and evaluator must be distinct handles with no shared role.
+
+### Scratch files
+
+Mission contract YAMLs go in `.tmp/missions/`. Result artifact YAMLs go in `.tmp/missions/results/`.
+
 ## Issue Tracking with Beads
 
 This project uses **beads** (`bd`) for issue tracking.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Doctor also inspects `~/.config/systemd/user/vox.service` on Linux if it exists.
 - **Graceful absence** --- if punt-vox isn't installed, Claude Code works exactly as before
 - **MCP-native** --- runs as a Claude Code plugin with slash commands and hooks
 - **Audio daemon** --- `voxd` is a system-level audio server that handles synthesis and playback. Deduplicates audio across sessions, serializes playback, caches synthesis results
+- **Background music** --- `/music on` generates vibe-driven instrumental tracks via the ElevenLabs Music API and loops them at low volume while you work. When the vibe changes, a new track generates to match. Style modifiers (`/music on style techno`) persist across invocations. Requires an ElevenLabs paid plan; each track costs ~2,000 credits
 
 ## What It Looks Like
 
@@ -214,6 +215,9 @@ Chimes are mood-aware: when a vibe is active, chimes pitch-shift to match (brigh
 | `/vibe <mood>` | Set session mood --- voice adapts to match |
 | `/vibe auto` | Auto-detect mood from session signals (default) |
 | `/vibe off` | Disable vibe --- neutral voice |
+| `/music on` | Start vibe-driven background music |
+| `/music on style techno` | Start music with a style modifier |
+| `/music off` | Stop background music |
 
 ## Providers
 
@@ -360,6 +364,9 @@ vox notify y                                   # Enable notifications
 vox notify c                                   # Continuous spoken mode
 vox speak n                                    # Chimes only
 vox voice matilda                              # Set session voice
+vox music on                                   # Start background music
+vox music on --style techno                    # Start music with style modifier
+vox music off                                  # Stop background music
 vox status                                     # Current state
 vox version                                    # Print version
 vox doctor                                     # Check setup

--- a/commands/music.md
+++ b/commands/music.md
@@ -1,0 +1,50 @@
+---
+description: "Control background music generation"
+argument-hint: "on [style ...] | off"
+allowed-tools: ["mcp__plugin_vox_mic__music", "mcp__plugin_vox_mic__status"]
+---
+
+# /music command
+
+Control vibe-driven background music generation. When on, vox generates
+instrumental tracks derived from the current session vibe and loops them
+through voxd at reduced volume. When the vibe changes, a new track
+generates to match.
+
+## Usage
+
+- `/music on` -- start music with current vibe
+- `/music on style techno` -- start music with a style modifier
+- `/music off` -- stop music
+- `/music` -- show current music state
+
+## Style modifier
+
+The style parameter persists in voxd. `/music on style techno` sets the
+style; subsequent `/music on` (without style) reuses it. `/music on
+style jazz` changes it.
+
+## Implementation
+
+Parse `$ARGUMENTS`:
+
+### `on` (with optional `style ...`)
+
+Call the `music` MCP tool with `mode="on"`. If the user provided style
+words after `on style`, join them and pass as `style`. No text output
+after changes -- the panel confirms.
+
+### `off`
+
+Call the `music` MCP tool with `mode="off"`. No text output -- the
+panel confirms.
+
+### No argument
+
+Call the `status` MCP tool and report current music state.
+
+### Requirements
+
+Music generation requires an ElevenLabs paid plan. Each track costs
+approximately 2,000 credits (~3 minutes of audio). A typical session
+generates 1-3 tracks (one per vibe change).

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -1426,6 +1426,64 @@ def mcp() -> None:
 
 
 # ---------------------------------------------------------------------------
+# music subcommand group
+# ---------------------------------------------------------------------------
+
+music_app = typer.Typer(
+    help="Control background music generation.",
+    no_args_is_help=True,
+)
+app.add_typer(music_app, name="music")
+
+
+@music_app.command("on")
+def music_on_cmd(  # pyright: ignore[reportUnusedFunction]
+    style: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--style",
+            help="Style modifier for music generation (e.g. techno, jazz).",
+        ),
+    ] = None,
+) -> None:
+    """Start background music generation via voxd."""
+    style_str = " ".join(style) if style else None
+    client = VoxClientSync()
+    try:
+        result = client.music("on", style=style_str)
+        status = result.get("status", "unknown")
+        payload: dict[str, object] = {"music": "on", "status": status}
+        if style_str:
+            payload["style"] = style_str
+        text = f"Music on ({status})"
+        if style_str:
+            text += f" — style: {style_str}"
+        _emit(payload, text)
+    except VoxdConnectionError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except VoxdProtocolError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@music_app.command("off")
+def music_off_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
+    """Stop background music generation."""
+    client = VoxClientSync()
+    try:
+        result = client.music("off")
+        status = result.get("status", "stopped")
+        _emit({"music": "off", "status": status}, f"Music off ({status})")
+    except VoxdConnectionError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except VoxdProtocolError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+# ---------------------------------------------------------------------------
 # daemon subcommand group
 # ---------------------------------------------------------------------------
 

--- a/src/punt_vox/client.py
+++ b/src/punt_vox/client.py
@@ -426,6 +426,56 @@ class VoxClient:
         resp = await self._send_and_recv({"type": "health"}, timeout=_TIMEOUT_SHORT)
         return resp
 
+    async def music(
+        self,
+        mode: str,
+        *,
+        style: str | None = None,
+        vibe: str | None = None,
+        vibe_tags: str | None = None,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Start or stop music playback.
+
+        *mode* is ``"on"`` or ``"off"``. When ``"on"``, optional *style*,
+        *vibe*, *vibe_tags*, and *owner_id* are forwarded to voxd.  When
+        ``"off"``, only *owner_id* is sent.
+        """
+        request_id = uuid.uuid4().hex[:12]
+        if mode == "on":
+            msg: dict[str, object] = {"type": "music_on", "id": request_id}
+            if style is not None:
+                msg["style"] = style
+            if vibe is not None:
+                msg["vibe"] = vibe
+            if vibe_tags is not None:
+                msg["vibe_tags"] = vibe_tags
+            if owner_id is not None:
+                msg["owner_id"] = owner_id
+        else:
+            msg = {"type": "music_off", "id": request_id}
+            if owner_id is not None:
+                msg["owner_id"] = owner_id
+        return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
+
+    async def music_vibe(
+        self,
+        *,
+        vibe: str | None = None,
+        vibe_tags: str | None = None,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Send a vibe update for the currently playing music."""
+        request_id = uuid.uuid4().hex[:12]
+        msg: dict[str, object] = {"type": "music_vibe", "id": request_id}
+        if vibe is not None:
+            msg["vibe"] = vibe
+        if vibe_tags is not None:
+            msg["vibe_tags"] = vibe_tags
+        if owner_id is not None:
+            msg["owner_id"] = owner_id
+        return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
+
 
 # ---------------------------------------------------------------------------
 # Sync wrapper
@@ -505,3 +555,41 @@ class VoxClientSync:
     def health(self) -> dict[str, object]:
         """Check daemon health."""
         return self._run(self._call("health"))  # type: ignore[no-any-return]
+
+    def music(
+        self,
+        mode: str,
+        *,
+        style: str | None = None,
+        vibe: str | None = None,
+        vibe_tags: str | None = None,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Start or stop music playback."""
+        return self._run(  # type: ignore[no-any-return]
+            self._call(
+                "music",
+                mode,
+                style=style,
+                vibe=vibe,
+                vibe_tags=vibe_tags,
+                owner_id=owner_id,
+            )
+        )
+
+    def music_vibe(
+        self,
+        *,
+        vibe: str | None = None,
+        vibe_tags: str | None = None,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Send a vibe update for the currently playing music."""
+        return self._run(  # type: ignore[no-any-return]
+            self._call(
+                "music_vibe",
+                vibe=vibe,
+                vibe_tags=vibe_tags,
+                owner_id=owner_id,
+            )
+        )

--- a/src/punt_vox/client.py
+++ b/src/punt_vox/client.py
@@ -121,6 +121,7 @@ class VoxClient:
         self._port = port
         self._token = token
         self._ws: websockets.asyncio.client.ClientConnection | None = None
+        self._default_owner_id: str = uuid.uuid4().hex
 
     # -- connection lifecycle ------------------------------------------------
 
@@ -444,21 +445,26 @@ class VoxClient:
         if mode not in ("on", "off"):
             err = f"invalid music mode: {mode!r} (expected 'on' or 'off')"
             raise ValueError(err)
+        effective_owner = owner_id if owner_id is not None else self._default_owner_id
         request_id = uuid.uuid4().hex[:12]
         if mode == "on":
-            msg: dict[str, object] = {"type": "music_on", "id": request_id}
+            msg: dict[str, object] = {
+                "type": "music_on",
+                "id": request_id,
+                "owner_id": effective_owner,
+            }
             if style is not None:
                 msg["style"] = style
             if vibe is not None:
                 msg["vibe"] = vibe
             if vibe_tags is not None:
                 msg["vibe_tags"] = vibe_tags
-            if owner_id is not None:
-                msg["owner_id"] = owner_id
         else:
-            msg = {"type": "music_off", "id": request_id}
-            if owner_id is not None:
-                msg["owner_id"] = owner_id
+            msg = {
+                "type": "music_off",
+                "id": request_id,
+                "owner_id": effective_owner,
+            }
         return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
 
     async def music_vibe(
@@ -469,14 +475,17 @@ class VoxClient:
         owner_id: str | None = None,
     ) -> dict[str, Any]:
         """Send a vibe update for the currently playing music."""
+        effective_owner = owner_id if owner_id is not None else self._default_owner_id
         request_id = uuid.uuid4().hex[:12]
-        msg: dict[str, object] = {"type": "music_vibe", "id": request_id}
+        msg: dict[str, object] = {
+            "type": "music_vibe",
+            "id": request_id,
+            "owner_id": effective_owner,
+        }
         if vibe is not None:
             msg["vibe"] = vibe
         if vibe_tags is not None:
             msg["vibe_tags"] = vibe_tags
-        if owner_id is not None:
-            msg["owner_id"] = owner_id
         return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
 
 

--- a/src/punt_vox/client.py
+++ b/src/punt_vox/client.py
@@ -441,6 +441,9 @@ class VoxClient:
         *vibe*, *vibe_tags*, and *owner_id* are forwarded to voxd.  When
         ``"off"``, only *owner_id* is sent.
         """
+        if mode not in ("on", "off"):
+            err = f"invalid music mode: {mode!r} (expected 'on' or 'off')"
+            raise ValueError(err)
         request_id = uuid.uuid4().hex[:12]
         if mode == "on":
             msg: dict[str, object] = {"type": "music_on", "id": request_id}

--- a/src/punt_vox/music.py
+++ b/src/punt_vox/music.py
@@ -77,8 +77,10 @@ def _layer_style_mood_feel(
         parts.append(f"{vibe} mood")
 
     if vibe_tags:
-        # Strip brackets: "[cheerful]" -> "cheerful"
-        clean = vibe_tags.strip().strip("[]")
+        # Strip brackets: "[warm] [satisfied]" -> "warm, satisfied"
+        clean = vibe_tags.replace("[", "").replace("]", "").strip()
+        # Collapse whitespace runs from removed brackets into ", "
+        clean = ", ".join(word for word in clean.split() if word)
         if clean:
             parts.append(f"{clean} feel")
 

--- a/src/punt_vox/music.py
+++ b/src/punt_vox/music.py
@@ -1,0 +1,103 @@
+"""Vibe-to-prompt mapping for music generation."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+# -- Layer 2: time-of-day brackets (hour -> phrase) -------------------------
+
+_TIME_OF_DAY: tuple[tuple[range, str], ...] = (
+    (range(6, 12), "late-morning energy, fresh and building momentum"),
+    (range(12, 17), "afternoon focus, steady and locked in"),
+    (range(17, 22), "evening wind-down, reflective but still moving"),
+    # 22-05 handled as the fallback
+)
+
+_LATE_NIGHT = "late-night deep focus, minimal and hypnotic"
+
+# -- Layer 3: work-intensity thresholds -------------------------------------
+
+_COMMIT_THRESHOLD = 3
+_FAIL_THRESHOLD = 2
+
+_FLOW_STATE = "productive flow state, things are shipping"
+_GRINDING = "grinding through a tough problem, tension building"
+_STEADY = "steady working pace"
+
+# -- Layer 4: constant suffix -----------------------------------------------
+
+_LOOP_SUFFIX = (
+    "Loopable, no distinct intro or outro, smooth ambient texture "
+    "that cycles naturally. Driving beat but not overwhelming \u2014 "
+    "background music for deep work."
+)
+
+_DEFAULT_STYLE = "ambient"
+
+
+def vibe_to_prompt(
+    vibe: str | None,
+    vibe_tags: str | None,
+    style: str | None,
+    hour: int,
+    signals: list[str],
+) -> str:
+    """Assemble a music-generation prompt from session context.
+
+    Each of the four layers contributes a distinct dimension. Layers
+    with no content are omitted; the remaining layers are joined with
+    ``". "`` separators.
+    """
+    layers: list[str] = [
+        _layer_style_mood_feel(vibe, vibe_tags, style),
+        _layer_time_of_day(hour),
+        _layer_work_intensity(signals),
+        _LOOP_SUFFIX,
+    ]
+    return ". ".join(layer for layer in layers if layer)
+
+
+# -- Layer builders ---------------------------------------------------------
+
+
+def _layer_style_mood_feel(
+    vibe: str | None,
+    vibe_tags: str | None,
+    style: str | None,
+) -> str:
+    """Build layer 1: style + mood + feel."""
+    parts: list[str] = []
+
+    if style:
+        parts.append(f"{style} music")
+    else:
+        parts.append(f"{_DEFAULT_STYLE} music")
+
+    if vibe:
+        parts.append(f"{vibe} mood")
+
+    if vibe_tags:
+        # Strip brackets: "[cheerful]" -> "cheerful"
+        clean = vibe_tags.strip().strip("[]")
+        if clean:
+            parts.append(f"{clean} feel")
+
+    return ", ".join(parts)
+
+
+def _layer_time_of_day(hour: int) -> str:
+    """Map hour (0-23) to a time-of-day phrase."""
+    for hours, phrase in _TIME_OF_DAY:
+        if hour in hours:
+            return phrase
+    return _LATE_NIGHT
+
+
+def _layer_work_intensity(signals: list[str]) -> str:
+    """Derive work-intensity phrase from recent signal strings."""
+    counts = Counter(signals)
+    if counts.get("git-commit", 0) >= _COMMIT_THRESHOLD:
+        return _FLOW_STATE
+    if counts.get("tests-fail", 0) >= _FAIL_THRESHOLD:
+        return _GRINDING
+    return _STEADY

--- a/src/punt_vox/providers/elevenlabs_music.py
+++ b/src/punt_vox/providers/elevenlabs_music.py
@@ -1,0 +1,116 @@
+"""ElevenLabs Music generation provider."""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from elevenlabs.core import ApiError  # pyright: ignore[reportMissingTypeStubs]
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ElevenLabsMusicProvider"]
+
+_DEFAULT_OUTPUT_FORMAT = "mp3_44100_128"
+
+
+class ElevenLabsMusicProvider:
+    """ElevenLabs Music provider.
+
+    Implements the MusicProvider protocol using the ElevenLabs SDK's
+    music.stream endpoint. Streams bytes to a temp file in the same
+    directory as the target, then renames atomically on completion.
+
+    Always passes force_instrumental=True — background music should
+    never have vocals.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        client: Any | None = None,  # pyright: ignore[reportExplicitAny]
+        output_format: str = _DEFAULT_OUTPUT_FORMAT,
+    ) -> None:
+        self._output_format = output_format
+        if client is not None:
+            self._client: Any = client  # pyright: ignore[reportExplicitAny]
+        else:
+            from elevenlabs import ElevenLabs  # pyright: ignore[reportMissingTypeStubs]
+
+            key = api_key or os.environ.get("ELEVENLABS_API_KEY")
+            self._client = ElevenLabs(api_key=key)  # pyright: ignore[reportUnknownMemberType]
+
+    async def generate_track(
+        self, prompt: str, duration_ms: int, output_path: Path
+    ) -> Path:
+        """Generate a music track and write it to output_path.
+
+        Streams the response to a temporary file in the same directory as
+        output_path, then renames to the final path on completion. This
+        ensures partially-written files never appear at the target path.
+
+        Args:
+            prompt: Descriptive prompt for the track.
+            duration_ms: Desired track length in milliseconds.
+            output_path: Where to write the audio file.
+
+        Returns:
+            The path to the generated file.
+
+        Raises:
+            ApiError: On ElevenLabs API failure.
+            RuntimeError: When the API returns no audio data.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        logger.info(
+            "Generating music track: duration_ms=%d, format=%s",
+            duration_ms,
+            self._output_format,
+        )
+
+        try:
+            response: Any = self._client.music.stream(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+                prompt=prompt,
+                music_length_ms=duration_ms,
+                force_instrumental=True,
+                output_format=self._output_format,
+            )
+        except ApiError:
+            logger.exception("ElevenLabs music API call failed")
+            raise
+
+        # Stream to a temp file alongside the target, rename on success.
+        fd, tmp_name = tempfile.mkstemp(
+            dir=output_path.parent,
+            suffix=".tmp",
+        )
+        tmp_path = Path(tmp_name)
+        bytes_written = 0
+
+        try:
+            with open(fd, "wb") as f:
+                for chunk in response:  # pyright: ignore[reportUnknownVariableType]
+                    f.write(chunk)  # pyright: ignore[reportUnknownArgumentType]
+                    bytes_written += len(chunk)  # pyright: ignore[reportUnknownArgumentType]
+
+            if bytes_written == 0:
+                msg = "ElevenLabs music API returned no audio data"
+                raise RuntimeError(msg)
+
+            tmp_path.rename(output_path)
+        except BaseException:
+            # Clean up the temp file on any failure (including KeyboardInterrupt).
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+        logger.info(
+            "Wrote music track: %s (%d bytes)",
+            output_path,
+            bytes_written,
+        )
+        return output_path

--- a/src/punt_vox/providers/elevenlabs_music.py
+++ b/src/punt_vox/providers/elevenlabs_music.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import tempfile
@@ -44,26 +45,11 @@ class ElevenLabsMusicProvider:
             key = api_key or os.environ.get("ELEVENLABS_API_KEY")
             self._client = ElevenLabs(api_key=key)  # pyright: ignore[reportUnknownMemberType]
 
-    async def generate_track(
-        self, prompt: str, duration_ms: int, output_path: Path
-    ) -> Path:
-        """Generate a music track and write it to output_path.
+    def _generate_sync(self, prompt: str, duration_ms: int, output_path: Path) -> Path:
+        """Run the synchronous SDK call and file write.
 
-        Streams the response to a temporary file in the same directory as
-        output_path, then renames to the final path on completion. This
-        ensures partially-written files never appear at the target path.
-
-        Args:
-            prompt: Descriptive prompt for the track.
-            duration_ms: Desired track length in milliseconds.
-            output_path: Where to write the audio file.
-
-        Returns:
-            The path to the generated file.
-
-        Raises:
-            ApiError: On ElevenLabs API failure.
-            RuntimeError: When the API returns no audio data.
+        Extracted so ``generate_track`` can delegate to a thread via
+        ``asyncio.to_thread``, keeping the event loop unblocked.
         """
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -114,3 +100,27 @@ class ElevenLabsMusicProvider:
             bytes_written,
         )
         return output_path
+
+    async def generate_track(
+        self, prompt: str, duration_ms: int, output_path: Path
+    ) -> Path:
+        """Generate a music track and write it to output_path.
+
+        Delegates to a worker thread so the synchronous ElevenLabs SDK
+        call and file I/O do not block the event loop.
+
+        Args:
+            prompt: Descriptive prompt for the track.
+            duration_ms: Desired track length in milliseconds.
+            output_path: Where to write the audio file.
+
+        Returns:
+            The path to the generated file.
+
+        Raises:
+            ApiError: On ElevenLabs API failure.
+            RuntimeError: When the API returns no audio data.
+        """
+        return await asyncio.to_thread(
+            self._generate_sync, prompt, duration_ms, output_path
+        )

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -479,8 +479,11 @@ def vibe(
                 vibe_tags=_state.vibe_tags or "",
                 owner_id=_state.session_id,
             )
-        except VoxdConnectionError:
-            logger.warning("voxd unreachable during vibe propagation; music off")
+        except Exception:
+            logger.warning(
+                "voxd error during vibe propagation; music off",
+                exc_info=True,
+            )
             _state.music_mode = "off"
 
     return json.dumps({"vibe": updates})
@@ -518,7 +521,8 @@ def music(
             vibe_tags=_state.vibe_tags or "",
             owner_id=_state.session_id,
         )
-    except VoxdConnectionError as exc:
+    except Exception as exc:
+        logger.warning("voxd error in music tool; music off", exc_info=True)
         _state.music_mode = "off"
         return _error(str(exc))
 

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import random
-from dataclasses import dataclass
+import uuid
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -48,6 +49,7 @@ mcp._mcp_server.version = __version__  # pyright: ignore[reportPrivateUsage]
 class SessionState:
     """In-memory session state. Seeded from .vox/config.md on startup."""
 
+    session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     notify: str = "n"
     speak: str = "n"
     voice: str | None = None
@@ -57,6 +59,7 @@ class SessionState:
     vibe: str | None = None
     vibe_tags: str | None = None
     vibe_signals: str = ""
+    music_mode: str = "off"
 
 
 # Module-level singleton; initialized in run_server().
@@ -467,7 +470,60 @@ def vibe(
 
     write_fields(updates, _find_config())
 
+    # Propagate vibe change to music loop if this session owns music.
+    if _state.music_mode == "on":
+        client = _voxd_client()
+        try:
+            client.music_vibe(
+                vibe=_state.vibe or "",
+                vibe_tags=_state.vibe_tags or "",
+                owner_id=_state.session_id,
+            )
+        except VoxdConnectionError:
+            logger.warning("voxd unreachable during vibe propagation; music off")
+            _state.music_mode = "off"
+
     return json.dumps({"vibe": updates})
+
+
+@mcp.tool()
+def music(
+    mode: str,
+    style: str | None = None,
+) -> str:
+    """Control background music generation.
+
+    When on, voxd generates instrumental tracks derived from the current
+    session vibe and loops them. Vibe changes automatically trigger new
+    track generation for the owning session.
+
+    Args:
+        mode: "on" to start music, "off" to stop.
+        style: Optional style modifier (e.g. "techno", "jazz").
+            Persists across calls -- subsequent ``on`` reuses the
+            last-set style.
+
+    Returns:
+        JSON string with the voxd response.
+    """
+    if mode not in ("on", "off"):
+        return _error(f"Invalid mode '{mode}'. Use on/off.")
+
+    client = _voxd_client()
+    try:
+        resp = client.music(
+            mode=mode,
+            style=style or "",
+            vibe=_state.vibe or "",
+            vibe_tags=_state.vibe_tags or "",
+            owner_id=_state.session_id,
+        )
+    except VoxdConnectionError as exc:
+        _state.music_mode = "off"
+        return _error(str(exc))
+
+    _state.music_mode = mode
+    return json.dumps(resp)
 
 
 @mcp.tool()
@@ -626,6 +682,7 @@ def status() -> str:
             "vibe": _state.vibe,
             "vibe_tags": _state.vibe_tags,
             "vibe_signals": _state.vibe_signals,
+            "music_mode": _state.music_mode,
         }
     )
 

--- a/src/punt_vox/types.py
+++ b/src/punt_vox/types.py
@@ -21,6 +21,9 @@ __all__ = [
     "DirectPlayProvider",
     "HealthCheck",
     "MergeStrategy",
+    "MusicProvider",
+    "MusicRequest",
+    "MusicResult",
     "SynthesisRequest",
     "SynthesisResult",
     "TTSProvider",
@@ -296,6 +299,46 @@ class DirectPlayProvider(Protocol):
 
     def play_directly(self, request: AudioRequest) -> int:
         """Synthesize and play, returning the subprocess exit code."""
+        ...
+
+
+@dataclass(frozen=True)
+class MusicRequest:
+    """Request to generate a music track."""
+
+    prompt: str
+    duration_ms: int
+    style: str | None = None
+    vibe: str | None = None
+    vibe_tags: str | None = None
+
+
+@dataclass(frozen=True)
+class MusicResult:
+    """Result of a music generation request."""
+
+    path: Path
+    duration_ms: int
+    prompt: str
+
+
+@runtime_checkable
+class MusicProvider(Protocol):
+    """Provider-agnostic interface for music generation engines."""
+
+    async def generate_track(
+        self, prompt: str, duration_ms: int, output_path: Path
+    ) -> Path:
+        """Generate a music track and write it to output_path.
+
+        Args:
+            prompt: Descriptive prompt for the track.
+            duration_ms: Desired track length in milliseconds.
+            output_path: Where to write the audio file.
+
+        Returns:
+            The path to the generated file.
+        """
         ...
 
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -440,6 +440,27 @@ def _player_command(path: Path) -> list[str]:
     return ["ffplay", "-nodisp", "-autoexit", str(path)]
 
 
+_MUSIC_VOLUME = 30
+
+
+def _music_player_command(path: Path) -> list[str]:
+    """Return the argv for playing a music track at reduced volume.
+
+    Music plays at ``-volume 30`` so speech and chimes overlay on top
+    at full volume without runtime volume manipulation.
+    """
+    if _is_darwin():
+        return ["afplay", "--volume", "0.3", str(path)]
+    return ["ffplay", "-nodisp", "-autoexit", "-volume", str(_MUSIC_VOLUME), str(path)]
+
+
+def _music_output_dir() -> Path:
+    """Return the directory for generated music tracks."""
+    from punt_vox.output import default_output_dir
+
+    return default_output_dir() / "music"
+
+
 def _record_playback_result(
     ctx: DaemonContext,
     *,
@@ -838,6 +859,15 @@ class DaemonContext:
         # on every request. See ``punt_vox.paths.installed_version`` for
         # fallback semantics when running from an uninstalled source tree.
         self.daemon_version: str = installed_version()
+        # Music state — daemon-wide, one set of speakers, one loop.
+        self.music_mode: str = "off"
+        self.music_style: str = ""
+        self.music_owner: str = ""
+        self.music_vibe: tuple[str, str] = ("", "")  # (vibe, vibe_tags)
+        self.music_track: Path | None = None
+        self.music_proc: asyncio.subprocess.Process | None = None
+        self.music_state: str = "idle"  # "idle" | "generating" | "playing"
+        self.music_changed: asyncio.Event = asyncio.Event()
 
 
 # ---------------------------------------------------------------------------
@@ -1650,6 +1680,249 @@ async def _handle_health(
 
 
 # ---------------------------------------------------------------------------
+# Music loop and handlers
+# ---------------------------------------------------------------------------
+
+_MUSIC_DURATION_MS = 120_000
+_MUSIC_MAX_RETRIES = 3
+
+
+async def _music_backoff_sleep(seconds: float) -> None:
+    """Sleep for backoff in the music loop. Patchable by tests."""
+    await asyncio.sleep(seconds)
+
+
+def _slugify(text: str, max_len: int = 40) -> str:
+    """Slugify a string for use in filenames."""
+    import re
+
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", text).strip("_").lower()
+    return slug[:max_len]
+
+
+async def _kill_music_proc(ctx: DaemonContext) -> None:
+    """Kill the current music subprocess if running."""
+    proc = ctx.music_proc
+    if proc is not None and proc.returncode is None:
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+    ctx.music_proc = None
+
+
+async def _music_loop(ctx: DaemonContext) -> None:
+    """Background task: generate and loop music tracks.
+
+    Runs for the lifetime of the daemon. When ``music_mode`` is "on",
+    derives a prompt from the current vibe, generates a track via
+    :class:`~punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider`,
+    and loops it via ffplay at reduced volume. When ``music_changed``
+    is set, kills the current subprocess and regenerates.
+
+    Crash recovery: on failure, logs the error, resets state, and
+    retries with backoff (3 attempts). After 3 failures, sets
+    ``music_mode`` to "off".
+    """
+    retry_count = 0
+    while True:
+        # Wait until music is turned on.
+        while ctx.music_mode != "on":
+            ctx.music_changed.clear()
+            await ctx.music_changed.wait()
+
+        try:
+            # Generate a track.
+            ctx.music_state = "generating"
+            ctx.music_changed.clear()
+
+            vibe, vibe_tags = ctx.music_vibe
+            style = ctx.music_style
+
+            from punt_vox.music import vibe_to_prompt
+
+            hour = time.localtime().tm_hour
+            prompt = vibe_to_prompt(
+                vibe or None, vibe_tags or None, style or None, hour, []
+            )
+
+            output_dir = _music_output_dir()
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            vibe_slug = _slugify(vibe) if vibe else "none"
+            style_slug = _slugify(style) if style else "none"
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            filename = f"{timestamp}_{vibe_slug}_{style_slug}.mp3"
+            output_path = output_dir / filename
+
+            from punt_vox.providers.elevenlabs_music import ElevenLabsMusicProvider
+
+            provider = ElevenLabsMusicProvider()
+            track = await provider.generate_track(
+                prompt, _MUSIC_DURATION_MS, output_path
+            )
+
+            ctx.music_track = track
+            retry_count = 0  # Reset on successful generation.
+
+            # If vibe changed during generation, consume the event and
+            # regenerate on next iteration instead of playing a stale track.
+            if ctx.music_changed.is_set():
+                logger.info("Vibe changed during generation, regenerating")
+                continue
+
+            # Loop the track until music_changed is signaled or mode turns off.
+            while ctx.music_mode == "on" and not ctx.music_changed.is_set():
+                ctx.music_state = "playing"
+                cmd = _music_player_command(track)
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.PIPE,
+                    start_new_session=True,
+                )
+                ctx.music_proc = proc
+
+                # Wait for subprocess to finish or music_changed to fire.
+                wait_task = asyncio.create_task(proc.wait())
+                changed_task = asyncio.create_task(ctx.music_changed.wait())
+                _done, pending = await asyncio.wait(
+                    {wait_task, changed_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for task in pending:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+
+                if ctx.music_changed.is_set() or ctx.music_mode != "on":
+                    await _kill_music_proc(ctx)
+                    break
+
+                # Playback ended naturally — loop the same track.
+                rc = proc.returncode
+                if rc != 0:
+                    logger.warning(
+                        "Music playback ended with rc=%s for %s",
+                        rc,
+                        track.name,
+                    )
+
+        except asyncio.CancelledError:
+            await _kill_music_proc(ctx)
+            ctx.music_state = "idle"
+            raise
+        except Exception:
+            logger.exception(
+                "Music loop error (attempt %d/%d)",
+                retry_count + 1,
+                _MUSIC_MAX_RETRIES,
+            )
+            await _kill_music_proc(ctx)
+            ctx.music_state = "idle"
+            retry_count += 1
+            if retry_count >= _MUSIC_MAX_RETRIES:
+                logger.error(
+                    "Music loop failed %d times, disabling music", _MUSIC_MAX_RETRIES
+                )
+                ctx.music_mode = "off"
+                retry_count = 0
+            else:
+                # Exponential backoff: 1s, 2s, 4s...
+                await _music_backoff_sleep(2 ** (retry_count - 1))
+
+
+async def _handle_music_on(
+    msg: dict[str, object],
+    websocket: WebSocket,
+    ctx: DaemonContext,
+) -> None:
+    """Handle a 'music_on' message: start or transfer music ownership.
+
+    Ownership transfer is atomic: kill existing subprocess, update all
+    state fields, then signal MusicLoop. No interleaving.
+    """
+    request_id = str(msg.get("id", ""))
+    owner_id = str(msg.get("owner_id", ""))
+    style = str(msg.get("style", ""))
+    vibe = str(msg.get("vibe", ""))
+    vibe_tags = str(msg.get("vibe_tags", ""))
+
+    # Atomic ownership transfer: kill existing, update all fields, signal.
+    await _kill_music_proc(ctx)
+
+    ctx.music_mode = "on"
+    if style:
+        ctx.music_style = style
+    ctx.music_owner = owner_id
+    ctx.music_vibe = (vibe, vibe_tags)
+    ctx.music_state = "generating"
+    ctx.music_changed.set()
+
+    logger.info(
+        "Music on: owner=%s style=%s vibe=%s",
+        owner_id,
+        ctx.music_style,
+        vibe,
+    )
+    await websocket.send_json(
+        {"type": "music_on", "id": request_id, "status": "generating"}
+    )
+
+
+async def _handle_music_off(
+    msg: dict[str, object],
+    websocket: WebSocket,
+    ctx: DaemonContext,
+) -> None:
+    """Handle a 'music_off' message: stop music playback."""
+    request_id = str(msg.get("id", ""))
+
+    await _kill_music_proc(ctx)
+    ctx.music_mode = "off"
+    ctx.music_state = "idle"
+    ctx.music_changed.set()
+
+    logger.info("Music off")
+    await websocket.send_json(
+        {"type": "music_off", "id": request_id, "status": "stopped"}
+    )
+
+
+async def _handle_music_vibe(
+    msg: dict[str, object],
+    websocket: WebSocket,
+    ctx: DaemonContext,
+) -> None:
+    """Handle a 'music_vibe' message: update vibe if sender is owner."""
+    request_id = str(msg.get("id", ""))
+    owner_id = str(msg.get("owner_id", ""))
+    vibe = str(msg.get("vibe", ""))
+    vibe_tags = str(msg.get("vibe_tags", ""))
+
+    if owner_id != ctx.music_owner:
+        await websocket.send_json(
+            {"type": "music_vibe", "id": request_id, "status": "ignored"}
+        )
+        return
+
+    new_vibe = (vibe, vibe_tags)
+    if new_vibe == ctx.music_vibe:
+        await websocket.send_json(
+            {"type": "music_vibe", "id": request_id, "status": "ignored"}
+        )
+        return
+
+    ctx.music_vibe = new_vibe
+    ctx.music_changed.set()
+
+    logger.info("Music vibe changed: vibe=%s tags=%s", vibe, vibe_tags)
+    await websocket.send_json(
+        {"type": "music_vibe", "id": request_id, "status": "generating"}
+    )
+
+
+# ---------------------------------------------------------------------------
 # WebSocket route
 # ---------------------------------------------------------------------------
 
@@ -1666,6 +1939,9 @@ _HANDLERS: dict[
     "record": _handle_record,
     "voices": _handle_voices,
     "health": _handle_health,
+    "music_on": _handle_music_on,
+    "music_off": _handle_music_off,
+    "music_vibe": _handle_music_vibe,
 }
 
 
@@ -1829,9 +2105,17 @@ def main(
         # Start playback consumer
         consumer_task = asyncio.create_task(_playback_consumer(ctx))
         logger.info("Playback consumer started")
+        # Start music loop
+        music_task = asyncio.create_task(_music_loop(ctx))
+        logger.info("Music loop started")
         try:
             yield
         finally:
+            music_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await music_task
+            # Kill any lingering music subprocess.
+            await _kill_music_proc(ctx)
             consumer_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await consumer_task

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1741,8 +1741,9 @@ async def _music_loop(ctx: DaemonContext) -> None:
             from punt_vox.music import vibe_to_prompt
 
             hour = time.localtime().tm_hour
+            # TODO(vox-0qi): pass session signals for work-intensity layer
             prompt = vibe_to_prompt(
-                vibe or None, vibe_tags or None, style or None, hour, []
+                vibe or None, vibe_tags or None, style or None, hour, signals=[]
             )
 
             output_dir = _music_output_dir()
@@ -1778,7 +1779,7 @@ async def _music_loop(ctx: DaemonContext) -> None:
                     *cmd,
                     stdin=asyncio.subprocess.DEVNULL,
                     stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.DEVNULL,
                     start_new_session=True,
                 )
                 ctx.music_proc = proc

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1728,6 +1728,10 @@ async def _music_loop(ctx: DaemonContext) -> None:
         # Wait until music is turned on.
         while ctx.music_mode != "on":
             ctx.music_changed.clear()
+            # Re-check after clear to avoid lost wakeup: a handler may
+            # have set music_mode between our check and the clear().
+            if ctx.music_mode == "on":
+                break
             await ctx.music_changed.wait()
 
         try:
@@ -1849,6 +1853,12 @@ async def _handle_music_on(
     vibe = str(msg.get("vibe", ""))
     vibe_tags = str(msg.get("vibe_tags", ""))
 
+    if not owner_id:
+        await websocket.send_json(
+            {"type": "error", "id": request_id, "message": "owner_id is required"}
+        )
+        return
+
     # Atomic ownership transfer: kill existing, update all fields, signal.
     await _kill_music_proc(ctx)
 
@@ -1900,6 +1910,12 @@ async def _handle_music_vibe(
     owner_id = str(msg.get("owner_id", ""))
     vibe = str(msg.get("vibe", ""))
     vibe_tags = str(msg.get("vibe_tags", ""))
+
+    if not owner_id:
+        await websocket.send_json(
+            {"type": "error", "id": request_id, "message": "owner_id is required"}
+        )
+        return
 
     if owner_id != ctx.music_owner:
         await websocket.send_json(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2414,3 +2414,112 @@ class TestDaemonRestartCommand:
         assert result.exit_code == 1
         assert "voxd.log" in result.output
         assert "refused" in result.output
+
+
+# ---------------------------------------------------------------------------
+# music tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusicCommand:
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_basic(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {"status": "generating"}
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "on"])
+
+        assert result.exit_code == 0
+        mock_instance.music.assert_called_once_with("on", style=None)
+        assert "Music on" in result.output
+        assert "generating" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_with_style(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {"status": "generating"}
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "on", "--style", "techno"])
+
+        assert result.exit_code == 0
+        mock_instance.music.assert_called_once_with("on", style="techno")
+        assert "Music on" in result.output
+        assert "techno" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_with_multi_word_style(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {"status": "generating"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["music", "on", "--style", "lo-fi", "--style", "chill"]
+        )
+
+        assert result.exit_code == 0
+        mock_instance.music.assert_called_once_with("on", style="lo-fi chill")
+        assert "lo-fi chill" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_off(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {"status": "stopped"}
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "off"])
+
+        assert result.exit_code == 0
+        mock_instance.music.assert_called_once_with("off")
+        assert "Music off" in result.output
+        assert "stopped" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_connection_error(self, mock_client_cls: MagicMock) -> None:
+        from punt_vox.client import VoxdConnectionError
+
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.side_effect = VoxdConnectionError("not running")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "on"])
+
+        assert result.exit_code == 1
+        assert "not running" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_off_connection_error(self, mock_client_cls: MagicMock) -> None:
+        from punt_vox.client import VoxdConnectionError
+
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.side_effect = VoxdConnectionError("not running")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "off"])
+
+        assert result.exit_code == 1
+        assert "not running" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_json_output(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {"status": "generating"}
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--json", "music", "on", "--style", "jazz"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["music"] == "on"
+        assert data["style"] == "jazz"
+        assert data["status"] == "generating"
+
+    def test_music_no_subcommand_shows_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["music"])
+        # no_args_is_help=True causes typer to exit with code 0 and
+        # display help text listing the available subcommands.
+        assert result.exit_code == 0 or result.exit_code == 2
+        assert "on" in result.output
+        assert "off" in result.output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -575,7 +575,8 @@ class TestVoxClientMusic:
         assert "style" not in sent
         assert "vibe" not in sent
         assert "vibe_tags" not in sent
-        assert "owner_id" not in sent
+        # owner_id always present — uses default when caller omits it
+        assert sent["owner_id"] == client._default_owner_id  # pyright: ignore[reportPrivateUsage]
 
     @pytest.mark.asyncio
     async def test_music_error_raises(self) -> None:
@@ -657,7 +658,8 @@ class TestVoxClientMusicVibe:
         assert sent["type"] == "music_vibe"
         assert "vibe" not in sent
         assert "vibe_tags" not in sent
-        assert "owner_id" not in sent
+        # owner_id always present — uses default when caller omits it
+        assert sent["owner_id"] == client._default_owner_id  # pyright: ignore[reportPrivateUsage]
 
     @pytest.mark.asyncio
     async def test_music_vibe_error_raises(self) -> None:
@@ -672,6 +674,69 @@ class TestVoxClientMusicVibe:
 
         with pytest.raises(VoxdProtocolError, match="daemon shutting down"):
             await client.music_vibe(vibe="happy", owner_id="sess-abc")
+
+
+class TestVoxClientDefaultOwnerId:
+    """VoxClient generates a default owner_id for callers that omit it."""
+
+    def test_default_owner_id_is_nonempty_hex(self) -> None:
+        client = VoxClient(port=8421, token="tok")
+        owner = client._default_owner_id  # pyright: ignore[reportPrivateUsage]
+        assert len(owner) == 32
+        assert all(c in "0123456789abcdef" for c in owner)
+
+    def test_two_clients_get_distinct_ids(self) -> None:
+        a = VoxClient(port=8421, token="tok")
+        b = VoxClient(port=8421, token="tok")
+        assert a._default_owner_id != b._default_owner_id  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_music_uses_default_when_owner_id_none(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "d1", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        await client.music("on")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["owner_id"] == client._default_owner_id  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_music_vibe_uses_default_when_owner_id_none(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_vibe", "id": "d2", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        await client.music_vibe(vibe="happy")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["owner_id"] == client._default_owner_id  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio
+    async def test_explicit_owner_id_overrides_default(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "d3", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        await client.music("on", owner_id="explicit-id")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["owner_id"] == "explicit-id"
 
 
 class TestVoxClientSync:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -591,6 +591,12 @@ class TestVoxClientMusic:
         with pytest.raises(VoxdProtocolError, match="music generation failed"):
             await client.music("on", owner_id="sess-abc")
 
+    @pytest.mark.asyncio
+    async def test_music_invalid_mode_raises(self) -> None:
+        client = VoxClient(port=8421, token="tok")
+        with pytest.raises(ValueError, match="invalid music mode"):
+            await client.music("pause")
+
 
 class TestVoxClientMusicVibe:
     """Test music_vibe method."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -505,6 +505,169 @@ class TestVoxClientReconnect:
 # ---------------------------------------------------------------------------
 
 
+class TestVoxClientMusic:
+    """Test music method."""
+
+    @pytest.mark.asyncio
+    async def test_music_on_sends_correct_message(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "m1", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        result = await client.music(
+            "on",
+            style="techno",
+            vibe="focused",
+            vibe_tags="[calm]",
+            owner_id="sess-abc",
+        )
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_on"
+        assert sent["style"] == "techno"
+        assert sent["vibe"] == "focused"
+        assert sent["vibe_tags"] == "[calm]"
+        assert sent["owner_id"] == "sess-abc"
+        assert "id" in sent
+        assert result["status"] == "generating"
+
+    @pytest.mark.asyncio
+    async def test_music_off_sends_correct_message(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_off", "id": "m2", "status": "stopped"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        result = await client.music("off", owner_id="sess-abc")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_off"
+        assert sent["owner_id"] == "sess-abc"
+        assert "style" not in sent
+        assert "vibe" not in sent
+        assert "vibe_tags" not in sent
+        assert result["status"] == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_music_on_omits_none_params(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "m3", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        await client.music("on")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_on"
+        assert "style" not in sent
+        assert "vibe" not in sent
+        assert "vibe_tags" not in sent
+        assert "owner_id" not in sent
+
+    @pytest.mark.asyncio
+    async def test_music_error_raises(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "error", "id": "m4", "message": "music generation failed"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(VoxdProtocolError, match="music generation failed"):
+            await client.music("on", owner_id="sess-abc")
+
+
+class TestVoxClientMusicVibe:
+    """Test music_vibe method."""
+
+    @pytest.mark.asyncio
+    async def test_music_vibe_sends_correct_message(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_vibe", "id": "v1", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        result = await client.music_vibe(
+            vibe="happy", vibe_tags="[warm]", owner_id="sess-abc"
+        )
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_vibe"
+        assert sent["vibe"] == "happy"
+        assert sent["vibe_tags"] == "[warm]"
+        assert sent["owner_id"] == "sess-abc"
+        assert "id" in sent
+        assert result["status"] == "generating"
+
+    @pytest.mark.asyncio
+    async def test_music_vibe_ignored_when_not_owner(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_vibe", "id": "v2", "status": "ignored"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        result = await client.music_vibe(
+            vibe="sad", vibe_tags="[melancholy]", owner_id="other-sess"
+        )
+        assert result["status"] == "ignored"
+
+    @pytest.mark.asyncio
+    async def test_music_vibe_omits_none_params(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_vibe", "id": "v3", "status": "generating"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        await client.music_vibe()
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_vibe"
+        assert "vibe" not in sent
+        assert "vibe_tags" not in sent
+        assert "owner_id" not in sent
+
+    @pytest.mark.asyncio
+    async def test_music_vibe_error_raises(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "error", "id": "v4", "message": "daemon shutting down"}
+            )
+        )
+        client = VoxClient(port=8421, token="tok")
+        client._ws = mock_ws  # pyright: ignore[reportPrivateUsage]
+
+        with pytest.raises(VoxdProtocolError, match="daemon shutting down"):
+            await client.music_vibe(vibe="happy", owner_id="sess-abc")
+
+
 class TestVoxClientSync:
     """Test synchronous wrapper."""
 
@@ -625,3 +788,70 @@ class TestVoxClientSync:
             sync_client = VoxClientSync(port=8421, token="tok")
             result = sync_client.voices()
             assert result == ["fred"]
+
+    def test_music_on(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "m1", "status": "generating"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            sync_client = VoxClientSync(port=8421, token="tok")
+            result = sync_client.music("on", style="techno", owner_id="sess-1")
+            assert result["status"] == "generating"
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_on"
+        assert sent["style"] == "techno"
+        assert sent["owner_id"] == "sess-1"
+
+    def test_music_off(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_off", "id": "m2", "status": "stopped"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            sync_client = VoxClientSync(port=8421, token="tok")
+            result = sync_client.music("off", owner_id="sess-1")
+            assert result["status"] == "stopped"
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_off"
+
+    def test_music_vibe(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_vibe", "id": "v1", "status": "generating"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            sync_client = VoxClientSync(port=8421, token="tok")
+            result = sync_client.music_vibe(
+                vibe="happy", vibe_tags="[warm]", owner_id="sess-1"
+            )
+            assert result["status"] == "generating"
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_vibe"
+        assert sent["vibe"] == "happy"
+        assert sent["vibe_tags"] == "[warm]"
+        assert sent["owner_id"] == "sess-1"

--- a/tests/test_elevenlabs_music_provider.py
+++ b/tests/test_elevenlabs_music_provider.py
@@ -1,0 +1,368 @@
+"""Tests for punt_vox.providers.elevenlabs_music."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from elevenlabs.core import ApiError  # pyright: ignore[reportMissingTypeStubs]
+
+from punt_vox.providers.elevenlabs_music import ElevenLabsMusicProvider
+from punt_vox.types import MusicProvider
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_music_stream_response(
+    chunks: list[bytes] | None = None,
+) -> list[bytes]:
+    """Return a list of byte chunks simulating client.music.stream()."""
+    if chunks is not None:
+        return chunks
+    return [b"\xff\xfb\x90\x00" * 256, b"\xff\xfb\x90\x00" * 128]
+
+
+@pytest.fixture
+def mock_music_client() -> MagicMock:
+    """Create a mock ElevenLabs client with music.stream configured."""
+    client = MagicMock()
+    client.music.stream.side_effect = (
+        lambda **kwargs: _make_music_stream_response()  # pyright: ignore[reportUnknownLambdaType]
+    )
+    return client
+
+
+@pytest.fixture
+def music_provider(mock_music_client: MagicMock) -> ElevenLabsMusicProvider:
+    """Create an ElevenLabsMusicProvider with a mocked client."""
+    return ElevenLabsMusicProvider(client=mock_music_client)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_implements_music_provider(
+        self, music_provider: ElevenLabsMusicProvider
+    ) -> None:
+        assert isinstance(music_provider, MusicProvider)
+
+
+# ---------------------------------------------------------------------------
+# generate_track — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateTrack:
+    @pytest.mark.asyncio
+    async def test_writes_file_to_output_path(
+        self,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "track.mp3"
+        result = await music_provider.generate_track("chill beats", 120_000, out)
+
+        assert result == out
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    @pytest.mark.asyncio
+    async def test_creates_parent_directories(
+        self,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "nested" / "deep" / "track.mp3"
+        result = await music_provider.generate_track("lo-fi", 60_000, out)
+
+        assert result == out
+        assert out.exists()
+
+    @pytest.mark.asyncio
+    async def test_file_contains_all_streamed_bytes(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        chunk_a = b"\x01\x02\x03"
+        chunk_b = b"\x04\x05"
+        mock_music_client.music.stream.side_effect = (
+            lambda **kwargs: [chunk_a, chunk_b]  # pyright: ignore[reportUnknownLambdaType]
+        )
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        out = tmp_path / "exact.mp3"
+
+        await provider.generate_track("test", 10_000, out)
+
+        assert out.read_bytes() == chunk_a + chunk_b
+
+    @pytest.mark.asyncio
+    async def test_returns_output_path(
+        self,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "result.mp3"
+        result = await music_provider.generate_track("ambient", 120_000, out)
+        assert result == out
+
+
+# ---------------------------------------------------------------------------
+# SDK call arguments
+# ---------------------------------------------------------------------------
+
+
+class TestSdkCallArguments:
+    @pytest.mark.asyncio
+    async def test_force_instrumental_always_true(
+        self,
+        mock_music_client: MagicMock,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "instrumental.mp3"
+        await music_provider.generate_track("rock", 120_000, out)
+
+        call_kwargs = mock_music_client.music.stream.call_args.kwargs
+        assert call_kwargs["force_instrumental"] is True
+
+    @pytest.mark.asyncio
+    async def test_passes_prompt(
+        self,
+        mock_music_client: MagicMock,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "prompt.mp3"
+        await music_provider.generate_track("jazzy chill vibes", 120_000, out)
+
+        call_kwargs = mock_music_client.music.stream.call_args.kwargs
+        assert call_kwargs["prompt"] == "jazzy chill vibes"
+
+    @pytest.mark.asyncio
+    async def test_passes_duration_ms(
+        self,
+        mock_music_client: MagicMock,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "duration.mp3"
+        await music_provider.generate_track("beats", 90_000, out)
+
+        call_kwargs = mock_music_client.music.stream.call_args.kwargs
+        assert call_kwargs["music_length_ms"] == 90_000
+
+    @pytest.mark.asyncio
+    async def test_default_output_format(
+        self,
+        mock_music_client: MagicMock,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "format.mp3"
+        await music_provider.generate_track("ambient", 120_000, out)
+
+        call_kwargs = mock_music_client.music.stream.call_args.kwargs
+        assert call_kwargs["output_format"] == "mp3_44100_128"
+
+    @pytest.mark.asyncio
+    async def test_custom_output_format(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        provider = ElevenLabsMusicProvider(
+            client=mock_music_client,
+            output_format="mp3_22050_32",
+        )
+        out = tmp_path / "custom_fmt.mp3"
+        await provider.generate_track("ambient", 120_000, out)
+
+        call_kwargs = mock_music_client.music.stream.call_args.kwargs
+        assert call_kwargs["output_format"] == "mp3_22050_32"
+
+
+# ---------------------------------------------------------------------------
+# Temp file cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestTempFileCleanup:
+    @pytest.mark.asyncio
+    async def test_no_temp_files_after_success(
+        self,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "clean.mp3"
+        await music_provider.generate_track("test", 60_000, out)
+
+        remaining = list(tmp_path.iterdir())
+        assert remaining == [out]
+
+    @pytest.mark.asyncio
+    async def test_temp_file_cleaned_on_api_error(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_music_client.music.stream.side_effect = ApiError(status_code=500)
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        out = tmp_path / "fail.mp3"
+
+        with pytest.raises(ApiError):
+            await provider.generate_track("test", 60_000, out)
+
+        # No temp files left behind.
+        assert not out.exists()
+        tmp_files = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert tmp_files == []
+
+    @pytest.mark.asyncio
+    async def test_temp_file_cleaned_on_empty_response(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_music_client.music.stream.side_effect = lambda **kwargs: []  # pyright: ignore[reportUnknownLambdaType]
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        out = tmp_path / "empty.mp3"
+
+        with pytest.raises(RuntimeError, match="no audio data"):
+            await provider.generate_track("test", 60_000, out)
+
+        assert not out.exists()
+        tmp_files = [p for p in tmp_path.iterdir() if p.suffix == ".tmp"]
+        assert tmp_files == []
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_api_error_propagates(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_music_client.music.stream.side_effect = ApiError(status_code=429)
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        out = tmp_path / "rate_limit.mp3"
+
+        with pytest.raises(ApiError):
+            await provider.generate_track("test", 60_000, out)
+
+    @pytest.mark.asyncio
+    async def test_empty_response_raises_runtime_error(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        mock_music_client.music.stream.side_effect = lambda **kwargs: []  # pyright: ignore[reportUnknownLambdaType]
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        out = tmp_path / "empty.mp3"
+
+        with pytest.raises(RuntimeError, match="no audio data"):
+            await provider.generate_track("test", 60_000, out)
+
+    @pytest.mark.asyncio
+    async def test_api_error_logged(
+        self,
+        mock_music_client: MagicMock,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_music_client.music.stream.side_effect = ApiError(status_code=503)
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        out = tmp_path / "logged.mp3"
+
+        with caplog.at_level(logging.ERROR), pytest.raises(ApiError):
+            await provider.generate_track("test", 60_000, out)
+
+        assert "music API call failed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Constructor — api_key handling
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_accepts_injected_client(self, mock_music_client: MagicMock) -> None:
+        provider = ElevenLabsMusicProvider(client=mock_music_client)
+        assert provider._client is mock_music_client  # pyright: ignore[reportPrivateUsage]
+
+    def test_api_key_fallback_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key-123")
+        captured: dict[str, Any] = {}
+
+        def fake_elevenlabs(**kwargs: Any) -> MagicMock:  # pyright: ignore[reportExplicitAny]
+            captured.update(kwargs)
+            return MagicMock()
+
+        # ElevenLabs is imported lazily inside __init__; patch the SDK class.
+        monkeypatch.setattr("elevenlabs.ElevenLabs", fake_elevenlabs)
+
+        ElevenLabsMusicProvider()
+        assert captured.get("api_key") == "test-key-123"
+
+    def test_explicit_api_key_overrides_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "env-key")
+        captured: dict[str, Any] = {}
+
+        def fake_elevenlabs(**kwargs: Any) -> MagicMock:  # pyright: ignore[reportExplicitAny]
+            captured.update(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr("elevenlabs.ElevenLabs", fake_elevenlabs)
+
+        ElevenLabsMusicProvider(api_key="explicit-key")
+        assert captured.get("api_key") == "explicit-key"
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+class TestLogging:
+    @pytest.mark.asyncio
+    async def test_logs_generation_start(
+        self,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        out = tmp_path / "log_start.mp3"
+        with caplog.at_level(logging.INFO):
+            await music_provider.generate_track("test", 120_000, out)
+
+        assert "Generating music track" in caplog.text
+        assert "120000" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_completion(
+        self,
+        music_provider: ElevenLabsMusicProvider,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        out = tmp_path / "log_done.mp3"
+        with caplog.at_level(logging.INFO):
+            await music_provider.generate_track("test", 60_000, out)
+
+        assert "Wrote music track" in caplog.text
+        assert "log_done.mp3" in caplog.text

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,0 +1,195 @@
+"""Tests for vibe-to-prompt mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from punt_vox.music import vibe_to_prompt
+
+# -- Layer 2: time-of-day parametrization -----------------------------------
+
+_TIME_CASES: list[tuple[int, str]] = [
+    (6, "late-morning energy, fresh and building momentum"),
+    (7, "late-morning energy, fresh and building momentum"),
+    (11, "late-morning energy, fresh and building momentum"),
+    (12, "afternoon focus, steady and locked in"),
+    (14, "afternoon focus, steady and locked in"),
+    (16, "afternoon focus, steady and locked in"),
+    (17, "evening wind-down, reflective but still moving"),
+    (19, "evening wind-down, reflective but still moving"),
+    (21, "evening wind-down, reflective but still moving"),
+    (22, "late-night deep focus, minimal and hypnotic"),
+    (0, "late-night deep focus, minimal and hypnotic"),
+    (3, "late-night deep focus, minimal and hypnotic"),
+    (5, "late-night deep focus, minimal and hypnotic"),
+]
+
+# -- Layer 3: signal intensity parametrization ------------------------------
+
+_SIGNAL_CASES: list[tuple[list[str], str]] = [
+    (
+        ["git-commit", "git-commit", "git-commit"],
+        "productive flow state, things are shipping",
+    ),
+    (
+        ["git-commit"] * 5,
+        "productive flow state, things are shipping",
+    ),
+    (
+        ["tests-fail", "tests-fail"],
+        "grinding through a tough problem, tension building",
+    ),
+    (
+        ["tests-fail"] * 4,
+        "grinding through a tough problem, tension building",
+    ),
+    (
+        [],
+        "steady working pace",
+    ),
+    (
+        ["git-commit"],
+        "steady working pace",
+    ),
+    (
+        ["tests-fail"],
+        "steady working pace",
+    ),
+    (
+        ["other-signal", "other-signal", "other-signal"],
+        "steady working pace",
+    ),
+]
+
+_LOOP_SUFFIX = (
+    "Loopable, no distinct intro or outro, smooth ambient texture "
+    "that cycles naturally. Driving beat but not overwhelming \u2014 "
+    "background music for deep work."
+)
+
+
+class TestTimeOfDay:
+    """Layer 2 — hour brackets map to correct phrases."""
+
+    @pytest.mark.parametrize(("hour", "expected"), _TIME_CASES)
+    def test_time_bracket(self, hour: int, expected: str) -> None:
+        result = vibe_to_prompt(None, None, None, hour, [])
+        assert expected in result
+
+
+class TestWorkIntensity:
+    """Layer 3 — signal counts map to correct intensity phrases."""
+
+    @pytest.mark.parametrize(("signals", "expected"), _SIGNAL_CASES)
+    def test_signal_intensity(self, signals: list[str], expected: str) -> None:
+        result = vibe_to_prompt(None, None, None, 14, signals)
+        assert expected in result
+
+
+class TestCommitTakesPrecedence:
+    """When both commit and fail thresholds are met, commits win."""
+
+    def test_commits_over_fails(self) -> None:
+        signals = ["git-commit"] * 3 + ["tests-fail"] * 2
+        result = vibe_to_prompt(None, None, None, 14, signals)
+        assert "productive flow state" in result
+        assert "grinding" not in result
+
+
+class TestStyleMoodFeel:
+    """Layer 1 — style, vibe, and vibe_tags assembly."""
+
+    def test_full_layer(self) -> None:
+        result = vibe_to_prompt("happy", "[cheerful]", "techno", 14, [])
+        assert "techno music" in result
+        assert "happy mood" in result
+        assert "cheerful feel" in result
+
+    def test_no_style_falls_back_to_ambient(self) -> None:
+        result = vibe_to_prompt("happy", None, None, 14, [])
+        assert "ambient music" in result
+        assert "happy mood" in result
+
+    def test_no_vibe_omits_mood_and_feel(self) -> None:
+        result = vibe_to_prompt(None, None, "techno", 14, [])
+        assert "techno music" in result
+        assert "mood" not in result
+        assert "feel" not in result
+
+    def test_no_vibe_no_style(self) -> None:
+        result = vibe_to_prompt(None, None, None, 14, [])
+        assert "ambient music" in result
+        assert "mood" not in result
+
+    def test_vibe_tags_brackets_stripped(self) -> None:
+        result = vibe_to_prompt(None, "[calm]", None, 14, [])
+        assert "calm feel" in result
+        assert "[" not in result.split(". ")[0]
+
+    def test_empty_vibe_tags_omitted(self) -> None:
+        result = vibe_to_prompt(None, "[]", None, 14, [])
+        assert "feel" not in result
+
+
+class TestFallbacks:
+    """Graceful omission when layers have no content."""
+
+    def test_no_style_no_vibe_no_signals(self) -> None:
+        result = vibe_to_prompt(None, None, None, 14, [])
+        assert result.startswith("ambient music")
+        assert "steady working pace" in result
+        assert _LOOP_SUFFIX in result
+
+    def test_no_signals(self) -> None:
+        result = vibe_to_prompt("focused", "[calm]", "jazz", 10, [])
+        assert "steady working pace" in result
+
+    def test_no_vibe(self) -> None:
+        result = vibe_to_prompt(None, None, "lo-fi", 22, [])
+        assert "lo-fi music" in result
+        assert "mood" not in result
+
+
+class TestCombinedPrompt:
+    """Full assembly matches the prototype format from the spec."""
+
+    def test_prototype_example(self) -> None:
+        """Reproduce the exact example from the spec."""
+        result = vibe_to_prompt(
+            "happy",
+            "[cheerful]",
+            "techno",
+            14,
+            ["git-commit"] * 3,
+        )
+        expected = (
+            "techno music, happy mood, cheerful feel. "
+            "afternoon focus, steady and locked in. "
+            "productive flow state, things are shipping. " + _LOOP_SUFFIX
+        )
+        assert result == expected
+
+    def test_layer_separator(self) -> None:
+        """Layers are joined by '. ' — check boundaries between them."""
+        result = vibe_to_prompt("calm", None, None, 8, [])
+        # Layer 1 -> ". " -> Layer 2
+        assert "calm mood. late-morning" in result
+        # Layer 2 -> ". " -> Layer 3
+        assert "momentum. steady working" in result
+        # Layer 3 -> ". " -> Layer 4
+        assert "pace. Loopable" in result
+
+    def test_all_layers_present(self) -> None:
+        result = vibe_to_prompt(
+            "energetic",
+            "[bright]",
+            "drum-and-bass",
+            19,
+            ["tests-fail", "tests-fail"],
+        )
+        assert "drum-and-bass music" in result
+        assert "energetic mood" in result
+        assert "bright feel" in result
+        assert "evening wind-down" in result
+        assert "grinding through a tough problem" in result
+        assert _LOOP_SUFFIX in result

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -126,6 +126,12 @@ class TestStyleMoodFeel:
         assert "calm feel" in result
         assert "[" not in result.split(". ")[0]
 
+    def test_multi_tag_vibe_tags_cleaned(self) -> None:
+        result = vibe_to_prompt(None, "[warm] [satisfied]", None, 14, [])
+        assert "warm, satisfied feel" in result
+        assert "[" not in result
+        assert "]" not in result
+
     def test_empty_vibe_tags_omitted(self) -> None:
         result = vibe_to_prompt(None, "[]", None, 14, [])
         assert "feel" not in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1050,6 +1050,23 @@ class TestMusicTool:
         assert "error" in result
         assert srv._state.music_mode == "off"
 
+    def test_music_protocol_error_resets_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import punt_vox.server as srv
+        from punt_vox.client import VoxdProtocolError
+
+        srv._state.music_mode = "on"
+
+        mock_client = MagicMock()
+        mock_client.music.side_effect = VoxdProtocolError("bad response")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on"))
+
+        assert "error" in result
+        assert srv._state.music_mode == "off"
+
 
 # ---------------------------------------------------------------------------
 # vibe tool — music propagation tests
@@ -1108,6 +1125,25 @@ class TestVibeToolMusicPropagation:
 
         mock_client = MagicMock()
         mock_client.music_vibe.side_effect = VoxdConnectionError("gone")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(vibe(mood="sad"))
+
+        # Vibe update itself should succeed.
+        assert result["vibe"]["vibe"] == "sad"
+        # But music_mode should be reset.
+        assert srv._state.music_mode == "off"
+
+    def test_vibe_protocol_error_resets_music(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import punt_vox.server as srv
+        from punt_vox.client import VoxdProtocolError
+
+        srv._state.music_mode = "on"
+
+        mock_client = MagicMock()
+        mock_client.music_vibe.side_effect = VoxdProtocolError("bad response")
         monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
 
         result = json.loads(vibe(mood="sad"))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,6 +20,7 @@ from punt_vox.resolve import (
 )
 from punt_vox.server import (
     SessionState,
+    music,
     notify,
     record,
     speak,
@@ -909,3 +910,209 @@ class TestStatusTool:
         assert result["provider"] is None
         assert result["notify"] == "n"
         assert result["speak"] == "n"
+        assert result["music_mode"] == "off"
+
+    def test_music_mode_reflected(self) -> None:
+        import punt_vox.server as srv
+
+        srv._state.music_mode = "on"
+        result = json.loads(status())
+        assert result["music_mode"] == "on"
+
+
+# ---------------------------------------------------------------------------
+# SessionState identity tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionState:
+    """Tests for SessionState defaults and session_id generation."""
+
+    def test_session_id_is_uuid_hex(self) -> None:
+        state = SessionState()
+        assert len(state.session_id) == 32
+        int(state.session_id, 16)  # valid hex
+
+    def test_each_instance_gets_unique_id(self) -> None:
+        a = SessionState()
+        b = SessionState()
+        assert a.session_id != b.session_id
+
+    def test_music_mode_defaults_off(self) -> None:
+        state = SessionState()
+        assert state.music_mode == "off"
+
+
+# ---------------------------------------------------------------------------
+# music tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusicTool:
+    """Tests for the music MCP tool."""
+
+    def test_music_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import punt_vox.server as srv
+
+        srv._state.vibe = "focused"
+        srv._state.vibe_tags = "[calm]"
+
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "abc",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on", style="techno"))
+
+        assert result["status"] == "generating"
+        assert srv._state.music_mode == "on"
+        mock_client.music.assert_called_once_with(
+            mode="on",
+            style="techno",
+            vibe="focused",
+            vibe_tags="[calm]",
+            owner_id=srv._state.session_id,
+        )
+
+    def test_music_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import punt_vox.server as srv
+
+        srv._state.music_mode = "on"
+
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_off",
+            "id": "abc",
+            "status": "stopped",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="off"))
+
+        assert result["status"] == "stopped"
+        assert srv._state.music_mode == "off"
+
+    def test_music_invalid_mode(self) -> None:
+        result = json.loads(music(mode="pause"))
+        assert "error" in result
+
+    def test_music_on_no_vibe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When vibe is None, empty strings are sent to voxd."""
+        import punt_vox.server as srv
+
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        music(mode="on")
+
+        call_kwargs = mock_client.music.call_args[1]
+        assert call_kwargs["vibe"] == ""
+        assert call_kwargs["vibe_tags"] == ""
+        assert srv._state.music_mode == "on"
+
+    def test_music_on_no_style(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When style is None, empty string is sent."""
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        music(mode="on")
+
+        call_kwargs = mock_client.music.call_args[1]
+        assert call_kwargs["style"] == ""
+
+    def test_music_connection_error_resets_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import punt_vox.server as srv
+        from punt_vox.client import VoxdConnectionError
+
+        srv._state.music_mode = "on"
+
+        mock_client = MagicMock()
+        mock_client.music.side_effect = VoxdConnectionError("not running")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on"))
+
+        assert "error" in result
+        assert srv._state.music_mode == "off"
+
+
+# ---------------------------------------------------------------------------
+# vibe tool — music propagation tests
+# ---------------------------------------------------------------------------
+
+
+class TestVibeToolMusicPropagation:
+    """Tests for vibe changes propagating to music loop."""
+
+    def test_vibe_propagates_when_music_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import punt_vox.server as srv
+
+        srv._state.music_mode = "on"
+        srv._state.vibe = "old"
+        srv._state.vibe_tags = "[old]"
+
+        mock_client = MagicMock()
+        mock_client.music_vibe.return_value = {
+            "type": "music_vibe",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        vibe(mood="happy", tags="[warm]")
+
+        mock_client.music_vibe.assert_called_once_with(
+            vibe="happy",
+            vibe_tags="[warm]",
+            owner_id=srv._state.session_id,
+        )
+
+    def test_vibe_no_propagation_when_music_off(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import punt_vox.server as srv
+
+        srv._state.music_mode = "off"
+
+        mock_client = MagicMock()
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        vibe(mood="happy")
+
+        mock_client.music_vibe.assert_not_called()
+
+    def test_vibe_connection_error_resets_music(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import punt_vox.server as srv
+        from punt_vox.client import VoxdConnectionError
+
+        srv._state.music_mode = "on"
+
+        mock_client = MagicMock()
+        mock_client.music_vibe.side_effect = VoxdConnectionError("gone")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(vibe(mood="sad"))
+
+        # Vibe update itself should succeed.
+        assert result["vibe"]["vibe"] == "sad"
+        # But music_mode should be reset.
+        assert srv._state.music_mode == "off"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -11,6 +11,9 @@ from punt_vox.types import (
     AudioProviderId,
     HealthCheck,
     MergeStrategy,
+    MusicProvider,
+    MusicRequest,
+    MusicResult,
     SynthesisRequest,
     SynthesisResult,
     generate_filename,
@@ -169,3 +172,74 @@ class TestGenerateFilename:
     def test_no_prefix(self) -> None:
         name = generate_filename("test")
         assert not name.startswith("pair_")
+
+
+class TestMusicRequest:
+    def test_required_fields(self) -> None:
+        req = MusicRequest(prompt="ambient techno", duration_ms=120000)
+        assert req.prompt == "ambient techno"
+        assert req.duration_ms == 120000
+
+    def test_optional_fields_default_none(self) -> None:
+        req = MusicRequest(prompt="jazz", duration_ms=60000)
+        assert req.style is None
+        assert req.vibe is None
+        assert req.vibe_tags is None
+
+    def test_all_fields(self) -> None:
+        req = MusicRequest(
+            prompt="techno music, happy mood",
+            duration_ms=120000,
+            style="techno",
+            vibe="happy",
+            vibe_tags="[cheerful]",
+        )
+        assert req.style == "techno"
+        assert req.vibe == "happy"
+        assert req.vibe_tags == "[cheerful]"
+
+    def test_frozen(self) -> None:
+        req = MusicRequest(prompt="test", duration_ms=60000)
+        with pytest.raises(AttributeError):
+            req.prompt = "changed"  # type: ignore[misc]
+
+
+class TestMusicResult:
+    def test_required_fields(self) -> None:
+        result = MusicResult(
+            path=Path("/home/user/vox-output/music/track.mp3"),
+            duration_ms=120000,
+            prompt="ambient techno",
+        )
+        assert result.path == Path("/home/user/vox-output/music/track.mp3")
+        assert result.duration_ms == 120000
+        assert result.prompt == "ambient techno"
+
+    def test_frozen(self) -> None:
+        result = MusicResult(
+            path=Path("/tmp/track.mp3"),
+            duration_ms=60000,
+            prompt="test",
+        )
+        with pytest.raises(AttributeError):
+            result.path = Path("/other.mp3")  # type: ignore[misc]
+
+
+class TestMusicProvider:
+    def test_protocol_is_runtime_checkable(self) -> None:
+        assert isinstance(MusicProvider, type)
+
+    def test_conforming_class_is_recognized(self) -> None:
+        class FakeMusic:
+            async def generate_track(
+                self, prompt: str, duration_ms: int, output_path: Path
+            ) -> Path:
+                return output_path
+
+        assert isinstance(FakeMusic(), MusicProvider)
+
+    def test_non_conforming_class_is_rejected(self) -> None:
+        class NotMusic:
+            def unrelated(self) -> None: ...
+
+        assert not isinstance(NotMusic(), MusicProvider)

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 from pathlib import Path
@@ -22,13 +23,19 @@ from punt_vox.voxd import (
     PlaybackItem,
     _apply_vibe_for_synthesis,
     _config_dir,
+    _handle_music_off,
+    _handle_music_on,
+    _handle_music_vibe,
     _handle_synthesize,
     _health_payload_full,
     _health_payload_minimal,
     _health_route,
+    _kill_music_proc,
     _load_keys,
     _log_dir,
     _model_supports_expressive_tags,
+    _music_loop,
+    _music_player_command,
     _play_audio,
     _run_dir,
     _try_direct_play,
@@ -2285,3 +2292,533 @@ class TestWsRoutePeerClose:
         assert len(ws_error_records) == 1
         # The ``finally`` branch must still decrement client_count.
         assert ctx.client_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Music integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonContextMusicFields:
+    """DaemonContext must have all 8 music fields with correct defaults."""
+
+    def test_music_mode_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_mode == "off"
+
+    def test_music_style_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_style == ""
+
+    def test_music_owner_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_owner == ""
+
+    def test_music_vibe_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_vibe == ("", "")
+
+    def test_music_track_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_track is None
+
+    def test_music_proc_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_proc is None
+
+    def test_music_state_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_state == "idle"
+
+    def test_music_changed_default(self) -> None:
+        ctx = _make_ctx()
+        assert isinstance(ctx.music_changed, asyncio.Event)
+        assert not ctx.music_changed.is_set()
+
+
+class TestMusicHandlerRegistration:
+    """Music handlers must be registered in _HANDLERS."""
+
+    def test_music_on_registered(self) -> None:
+        from punt_vox.voxd import _HANDLERS
+
+        assert "music_on" in _HANDLERS
+        assert _HANDLERS["music_on"] is _handle_music_on
+
+    def test_music_off_registered(self) -> None:
+        from punt_vox.voxd import _HANDLERS
+
+        assert "music_off" in _HANDLERS
+        assert _HANDLERS["music_off"] is _handle_music_off
+
+    def test_music_vibe_registered(self) -> None:
+        from punt_vox.voxd import _HANDLERS
+
+        assert "music_vibe" in _HANDLERS
+        assert _HANDLERS["music_vibe"] is _handle_music_vibe
+
+
+class TestHandleMusicOn:
+    """_handle_music_on: ownership transfer and state mutation."""
+
+    def test_sets_music_mode_and_owner(self) -> None:
+        ctx = _make_ctx()
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "req-1",
+            "owner_id": "session-abc",
+            "style": "techno",
+            "vibe": "focused",
+            "vibe_tags": "[calm]",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        assert ctx.music_mode == "on"
+        assert ctx.music_owner == "session-abc"
+        assert ctx.music_style == "techno"
+        assert ctx.music_vibe == ("focused", "[calm]")
+        assert ctx.music_state == "generating"
+        assert ctx.music_changed.is_set()
+
+    def test_responds_with_generating_status(self) -> None:
+        ctx = _make_ctx()
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "req-2",
+            "owner_id": "session-xyz",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "music_on", "id": "req-2", "status": "generating"}
+        )
+
+    def test_ownership_transfer_kills_existing_proc(self) -> None:
+        """Transferring ownership kills the previous subprocess."""
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "old-session"
+
+        # Simulate a running music subprocess.
+        fake_proc = MagicMock()
+        fake_proc.returncode = None
+        fake_proc.kill = MagicMock()
+        fake_proc.wait = AsyncMock(return_value=0)
+        ctx.music_proc = fake_proc
+
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "req-3",
+            "owner_id": "new-session",
+            "vibe": "happy",
+            "vibe_tags": "[warm]",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        fake_proc.kill.assert_called_once()
+        assert ctx.music_owner == "new-session"
+        assert ctx.music_proc is None
+
+    def test_preserves_existing_style_when_not_provided(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_style = "jazz"
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "req-4",
+            "owner_id": "session-1",
+            "style": "",
+            "vibe": "focused",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        assert ctx.music_style == "jazz"
+
+
+class TestHandleMusicOff:
+    """_handle_music_off: stops music and resets state."""
+
+    def test_sets_mode_off_and_state_idle(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_state = "playing"
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {"id": "req-off"}
+
+        asyncio.run(_handle_music_off(msg, ws, ctx))
+
+        assert ctx.music_mode == "off"
+        assert ctx.music_state == "idle"
+        assert ctx.music_changed.is_set()
+
+    def test_responds_with_stopped_status(self) -> None:
+        ctx = _make_ctx()
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {"id": "req-off-2"}
+
+        asyncio.run(_handle_music_off(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "music_off", "id": "req-off-2", "status": "stopped"}
+        )
+
+    def test_kills_running_subprocess(self) -> None:
+        ctx = _make_ctx()
+        fake_proc = MagicMock()
+        fake_proc.returncode = None
+        fake_proc.kill = MagicMock()
+        fake_proc.wait = AsyncMock(return_value=0)
+        ctx.music_proc = fake_proc
+
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {"id": "req-off-3"}
+
+        asyncio.run(_handle_music_off(msg, ws, ctx))
+
+        fake_proc.kill.assert_called_once()
+        assert ctx.music_proc is None
+
+
+class TestHandleMusicVibe:
+    """_handle_music_vibe: ownership check and vibe update."""
+
+    def test_matching_owner_updates_vibe(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "session-abc"
+        ctx.music_vibe = ("old", "[old-tags]")
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "vibe-1",
+            "owner_id": "session-abc",
+            "vibe": "happy",
+            "vibe_tags": "[warm]",
+        }
+
+        asyncio.run(_handle_music_vibe(msg, ws, ctx))
+
+        assert ctx.music_vibe == ("happy", "[warm]")
+        assert ctx.music_changed.is_set()
+        ws.send_json.assert_called_once_with(
+            {"type": "music_vibe", "id": "vibe-1", "status": "generating"}
+        )
+
+    def test_non_owner_rejected(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "session-abc"
+        ctx.music_vibe = ("old", "[old-tags]")
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "vibe-2",
+            "owner_id": "session-other",
+            "vibe": "happy",
+            "vibe_tags": "[warm]",
+        }
+
+        asyncio.run(_handle_music_vibe(msg, ws, ctx))
+
+        # Vibe unchanged.
+        assert ctx.music_vibe == ("old", "[old-tags]")
+        ws.send_json.assert_called_once_with(
+            {"type": "music_vibe", "id": "vibe-2", "status": "ignored"}
+        )
+
+    def test_same_vibe_ignored(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_owner = "session-abc"
+        ctx.music_vibe = ("happy", "[warm]")
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "vibe-3",
+            "owner_id": "session-abc",
+            "vibe": "happy",
+            "vibe_tags": "[warm]",
+        }
+
+        asyncio.run(_handle_music_vibe(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "music_vibe", "id": "vibe-3", "status": "ignored"}
+        )
+        assert not ctx.music_changed.is_set()
+
+
+class TestMusicPlayerCommand:
+    """_music_player_command produces the right argv at reduced volume."""
+
+    def test_linux_ffplay_with_volume(self) -> None:
+        with patch("punt_vox.voxd._is_darwin", return_value=False):
+            cmd = _music_player_command(Path("/tmp/track.mp3"))
+        assert cmd == [
+            "ffplay",
+            "-nodisp",
+            "-autoexit",
+            "-volume",
+            "30",
+            "/tmp/track.mp3",
+        ]
+
+    def test_darwin_afplay_with_volume(self) -> None:
+        with patch("punt_vox.voxd._is_darwin", return_value=True):
+            cmd = _music_player_command(Path("/tmp/track.mp3"))
+        assert cmd == ["afplay", "--volume", "0.3", "/tmp/track.mp3"]
+
+
+class TestMusicLoopStateTransitions:
+    """_music_loop: generation, playback, vibe changes, crash recovery."""
+
+    def test_generates_and_plays_then_stops_on_off(self) -> None:
+        """Full cycle: mode on -> generate -> play -> mode off."""
+        ctx = _make_ctx()
+
+        call_log: list[str] = []
+
+        async def fake_generate_track(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            call_log.append("generate")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake-music-data")
+            return output_path
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            call_log.append("play")
+            proc = MagicMock()
+            proc.returncode = 0
+
+            async def _wait() -> int:
+                await asyncio.sleep(0.01)
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock()
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider"
+                    ".generate_track",
+                    fake_generate_track,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-music"),
+                ),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                await asyncio.sleep(0)
+
+                # Turn music on.
+                ctx.music_mode = "on"
+                ctx.music_owner = "test-session"
+                ctx.music_vibe = ("focused", "[calm]")
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+
+                # Turn music off.
+                ctx.music_mode = "off"
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert "generate" in call_log
+        assert "play" in call_log
+
+    def test_crash_recovery_retries_with_backoff(self) -> None:
+        """Three failures in a row disable music mode."""
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "")
+        ctx.music_changed.set()
+
+        attempt_count = 0
+
+        async def failing_generate(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal attempt_count
+            attempt_count += 1
+            msg = f"generation failed (attempt {attempt_count})"
+            raise RuntimeError(msg)
+
+        async def _drive() -> None:
+            nonlocal attempt_count
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider"
+                    ".generate_track",
+                    failing_generate,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-music"),
+                ),
+                patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                # Yield control so the loop can run its 3 retries.
+                for _ in range(20):
+                    await asyncio.sleep(0)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert attempt_count == 3
+        assert ctx.music_mode == "off"
+        assert ctx.music_state == "idle"
+
+    def test_vibe_change_during_generation_triggers_regeneration(self) -> None:
+        """Setting music_changed during generation causes a new track."""
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "")
+        ctx.music_changed.set()
+
+        generation_count = 0
+
+        async def counting_generate(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal generation_count
+            generation_count += 1
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake-music-data")
+
+            # On first generation, simulate a vibe change mid-flight.
+            if generation_count == 1:
+                ctx.music_vibe = ("happy", "[warm]")
+                ctx.music_changed.set()
+
+            return output_path
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = 0
+
+            async def _wait() -> int:
+                await asyncio.sleep(0.01)
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock()
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider"
+                    ".generate_track",
+                    counting_generate,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-music"),
+                ),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                await asyncio.sleep(0.15)
+
+                ctx.music_mode = "off"
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert generation_count >= 2
+
+
+class TestKillMusicProc:
+    """_kill_music_proc safely terminates the music subprocess."""
+
+    def test_kills_running_proc(self) -> None:
+        ctx = _make_ctx()
+        proc = MagicMock()
+        proc.returncode = None
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        ctx.music_proc = proc
+
+        asyncio.run(_kill_music_proc(ctx))
+
+        proc.kill.assert_called_once()
+        assert ctx.music_proc is None
+
+    def test_noop_when_no_proc(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_proc = None
+
+        asyncio.run(_kill_music_proc(ctx))
+
+        assert ctx.music_proc is None
+
+    def test_noop_when_proc_already_exited(self) -> None:
+        ctx = _make_ctx()
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.kill = MagicMock()
+        ctx.music_proc = proc
+
+        asyncio.run(_kill_music_proc(ctx))
+
+        proc.kill.assert_not_called()
+        assert ctx.music_proc is None
+
+
+class TestMusicSeparateFromPlaybackQueue:
+    """Music subprocess must NOT use the existing _playback_consumer queue.
+
+    The spec explicitly requires music to run its own subprocess at
+    reduced volume, independent of the chime/TTS playback queue. This
+    test verifies the separation by checking that _handle_music_on does
+    not enqueue anything on ctx.playback_queue.
+    """
+
+    def test_music_on_does_not_enqueue(self) -> None:
+        ctx = _make_ctx()
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "sep-1",
+            "owner_id": "session-1",
+            "vibe": "focused",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        assert ctx.playback_queue.empty()

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -2822,3 +2822,127 @@ class TestMusicSeparateFromPlaybackQueue:
         asyncio.run(_handle_music_on(msg, ws, ctx))
 
         assert ctx.playback_queue.empty()
+
+
+class TestEmptyOwnerIdRejection:
+    """Handlers must reject empty owner_id to prevent ownership spoofing."""
+
+    def test_music_on_rejects_empty_owner_id(self) -> None:
+        ctx = _make_ctx()
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {"id": "empty-1", "owner_id": "", "vibe": "focused"}
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "error", "id": "empty-1", "message": "owner_id is required"}
+        )
+        # State must not mutate.
+        assert ctx.music_mode == "off"
+
+    def test_music_on_rejects_missing_owner_id(self) -> None:
+        ctx = _make_ctx()
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {"id": "empty-2", "vibe": "focused"}
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "error", "id": "empty-2", "message": "owner_id is required"}
+        )
+        assert ctx.music_mode == "off"
+
+    def test_music_vibe_rejects_empty_owner_id(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "real-session"
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {
+            "id": "empty-3",
+            "owner_id": "",
+            "vibe": "happy",
+        }
+
+        asyncio.run(_handle_music_vibe(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "error", "id": "empty-3", "message": "owner_id is required"}
+        )
+        # Vibe must not change.
+        assert ctx.music_vibe == ("", "")
+
+    def test_music_vibe_rejects_missing_owner_id(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "real-session"
+        ws = MagicMock()
+        ws.send_json = AsyncMock()
+        msg: dict[str, object] = {"id": "empty-4", "vibe": "happy"}
+
+        asyncio.run(_handle_music_vibe(msg, ws, ctx))
+
+        ws.send_json.assert_called_once_with(
+            {"type": "error", "id": "empty-4", "message": "owner_id is required"}
+        )
+        assert ctx.music_vibe == ("", "")
+
+
+class TestMusicLoopLostWakeup:
+    """_music_loop must not block when music_mode is set before clear()."""
+
+    def test_mode_on_before_wait_skips_blocking(self) -> None:
+        """If music_mode becomes 'on' between clear() and wait(), proceed."""
+        ctx = _make_ctx()
+        # Pre-set music_mode to "on" so the re-check after clear() catches it.
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "[calm]")
+        # Do NOT set music_changed — the loop must detect mode via re-check.
+
+        generation_happened = False
+
+        async def fake_generate(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal generation_happened
+            generation_happened = True
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake")
+            # Turn off to let the loop exit cleanly.
+            ctx.music_mode = "off"
+            ctx.music_changed.set()
+            return output_path
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider"
+                    ".generate_track",
+                    fake_generate,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-lost-wakeup"),
+                ),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                # Give the loop enough time to either proceed or block.
+                await asyncio.sleep(0.1)
+                if not generation_happened:
+                    # Loop is stuck — cancel and fail.
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+                else:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+
+        asyncio.run(_drive())
+
+        assert generation_happened, (
+            "music_loop blocked on wait despite music_mode=='on'"
+        )


### PR DESCRIPTION
## Summary

Adds `/music on|off` — continuous vibe-driven music generation. When on, vox generates ~2-minute instrumental tracks derived from the current session vibe and loops them at background volume through voxd. When the vibe changes, a new track generates to match. Tracks are saved to `~/vox-output/music/`.

Closes vox-0qi.

## Architecture

7 implementation phases, each delivered via an ethos mission (typed contract with write-set admission, frozen evaluator, bounded rounds):

| Phase | Mission | What | Files |
|-------|---------|------|-------|
| 1 | m-2026-04-11-001 | `MusicProvider` protocol + types | types.py |
| 2 | m-2026-04-11-002 | `ElevenLabsMusicProvider` (ElevenLabs SDK) | providers/elevenlabs_music.py |
| 3 | m-2026-04-11-003 | `vibe_to_prompt()` — 4-layer prompt assembly | music.py |
| 4 | m-2026-04-11-004 | `MusicLoop` task + voxd handlers + daemon state | voxd.py |
| 5 | m-2026-04-11-005 | `VoxClient.music()` + `music_vibe()` | client.py |
| 6 | m-2026-04-11-006 | MCP `music()` tool + session_id + vibe propagation | server.py |
| 7 | m-2026-04-11-007 | CLI command + slash command + CHANGELOG + README | __main__.py, commands/music.md |

Plus a CLAUDE.md update documenting the ethos mission workflow and task parallelism pattern.

## Key design decisions

- **Daemon-wide state**: music is a voxd-level feature, not per-repo. State lives in `DaemonContext`, not `.vox/config.md`.
- **Session ownership**: the session that runs `/music on` owns the music. Only that session's vibe changes affect the loop. Ownership transfers on explicit `/music on` from another session.
- **Looping, not regenerating**: one track per vibe, looped until vibe changes. ~2k credits per track, 1-3 tracks per session.
- **Reduced volume**: music plays at `ffplay -volume 30`, separate from the speech/chime queue. No SIGSTOP/SIGCONT — speech overlays at full volume.
- **4-layer prompt**: style+mood, time-of-day, work intensity (from vibe signals), loopability suffix. Validated in prototype before implementation.
- **Crash recovery**: 3-attempt exponential backoff, then music_mode → off.
- **Atomic ownership transfer**: kill existing subprocess, update all state fields, then signal MusicLoop.

## Test plan

- [x] `make check` green — 1231 tests (+126 new across all phases)
- [x] All 7 missions closed with pass verdicts
- [x] Prototype validated: 30s techno track generated via ElevenLabs Music API, played at reduced volume, sounded good
- [ ] CI green
- [ ] Copilot review clean
- [ ] Bugbot review clean
- [ ] End-to-end: `/music on style techno` generates and loops a track

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new long-running `voxd` music generation/playback loop plus new WebSocket message types and session ownership, which can impact daemon stability and introduces external API/file/subprocess behavior. Most changes are additive and covered by extensive new tests, but the concurrency and subprocess lifecycle paths carry moderate risk.
> 
> **Overview**
> Adds **vibe-driven background music** that can be started/stopped via `/music on|off` (new `commands/music.md`) and `vox music on|off`, generating ~2-minute instrumental tracks via the ElevenLabs Music API and looping them at reduced volume.
> 
> Implements a new daemon-wide `voxd` music subsystem: new WebSocket message types (`music_on`, `music_off`, `music_vibe`), session ownership enforcement, a background `_music_loop` task that regenerates on vibe changes with retry/backoff, and a separate playback subprocess path (not the speech/chime queue). The MCP server gains a `music` tool plus vibe-to-music propagation, and the client library adds `music()`/`music_vibe()` APIs with default per-client owner IDs.
> 
> Introduces `MusicProvider`/`MusicRequest`/`MusicResult`, `vibe_to_prompt()` prompt assembly, an `ElevenLabsMusicProvider`, and comprehensive unit/integration tests; docs/README/CHANGELOG are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f22b5aa6109fe52faad98c45dde25b5aca86fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->