### PR TITLE
docs(claude): update mission workflow with ethos feedback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,17 @@ For multi-phase features (T1/T2), create a TaskCreate list with all missions up 
 - **As each mission completes**: review the result, close the mission, commit, mark the task completed, check what's unblocked, and launch the next mission(s).
 - **The task list is the source of truth** for what's done, what's in flight, and what's blocked. Update it as missions close.
 
+### Review-cycle fix rounds: bare Agent(), not missions
+
+When Copilot or Bugbot flags findings on a PR, use a bare `Agent()` call — not a mission. These are mechanical 1-round fixes where the write-set is obvious (the files the findings are in). Missions are for work with design ambiguity or multi-round potential. The overhead of scaffold/create/close isn't justified for "fix these 3 lint findings."
+
+### Lessons from vox-0qi (2026-04-11)
+
+- Write-set admission is the highest-value feature. It guaranteed parallel phases 2+3 had zero file conflicts.
+- Workers don't always read the contract via `ethos mission show` or submit results via `ethos mission result` — enforcement is partial. Verify the result artifact exists before closing (`ethos mission results <id>`).
+- **Context/prompt split**: the contract `context` field carries the *what* (goal, constraints, acceptance criteria). The Agent `prompt` carries the *how* (specific invocation instructions). Move durable design guidance into `context`; keep the prompt to "execute the contract at `<id>`" plus any session-specific notes. Don't duplicate between the two.
+- All 7 vox-0qi missions closed round 1. The reflect→advance→re-spec cycle is untested under pressure. When a mission does go to round 2, use `ethos mission reflect` to record why before advancing.
+
 ### Scratch files
 
 Mission contract YAMLs go in `.tmp/missions/`. Result artifact YAMLs go in `.tmp/missions/results/`.


### PR DESCRIPTION
Updates CLAUDE.md with lessons from the vox-0qi mission deployment and feedback from the ethos agent:

- Review-cycle fix rounds: bare Agent(), not missions (mechanical 1-round fixes don't warrant the overhead)
- Context/prompt split: contract context = the what, Agent prompt = the how. Don't duplicate.
- Added vox-0qi lessons section with write-set value, enforcement gaps, and untested paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only adjusts internal workflow guidance and does not affect runtime code or CI behavior.
> 
> **Overview**
> Updates `CLAUDE.md` to clarify when *not* to use ethos missions: PR review-cycle fixes (Copilot/Bugbot findings) should use a bare `Agent()` call for quick, mechanical edits.
> 
> Adds a `vox-0qi` lessons section emphasizing write-set admission benefits, the need to verify result artifacts before closing, and a clearer **context vs prompt** split (contract `context` = *what*, Agent `prompt` = *how*), plus guidance for using `reflect` before advancing to round 2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8ab063a8d4cf15ea6dffda32b1d18175e9d490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->