### PR TITLE
chore: post-release v4.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.4.0",
+  "version": "4.3.2",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"


### PR DESCRIPTION
Restore dev plugin state after v4.4.0 release. Automated by restore-dev-plugin.sh.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Updates only the Claude plugin metadata name from `vox` to `vox-dev`, with no functional code or runtime behavior changes.
> 
> **Overview**
> Restores the Claude plugin to its development identity by changing `.claude-plugin/plugin.json` `name` from `vox` to `vox-dev` (post-release v4.4.0 cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02bd7bc8a843efae0b5835143dcad5af1c522b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->