### PR TITLE
fix(voxd): keep old track playing during music regeneration on vibe change

### DIFF
--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1710,20 +1710,61 @@ async def _kill_music_proc(ctx: DaemonContext) -> None:
     ctx.music_proc = None
 
 
+async def _generate_music_track(ctx: DaemonContext) -> Path:
+    """Generate a music track from the current vibe and style.
+
+    Extracted so the generation phase can run as an ``asyncio.Task``
+    concurrently with the playback loop.
+    """
+    vibe, vibe_tags = ctx.music_vibe
+    style = ctx.music_style
+
+    from punt_vox.music import vibe_to_prompt
+
+    hour = time.localtime().tm_hour
+    # TODO(vox-0qi): pass session signals for work-intensity layer
+    prompt = vibe_to_prompt(
+        vibe or None, vibe_tags or None, style or None, hour, signals=[]
+    )
+
+    output_dir = _music_output_dir()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    vibe_slug = _slugify(vibe) if vibe else "none"
+    style_slug = _slugify(style) if style else "none"
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    filename = f"{timestamp}_{vibe_slug}_{style_slug}.mp3"
+    output_path = output_dir / filename
+
+    from punt_vox.providers.elevenlabs_music import ElevenLabsMusicProvider
+
+    provider = ElevenLabsMusicProvider()
+    return await provider.generate_track(prompt, _MUSIC_DURATION_MS, output_path)
+
+
 async def _music_loop(ctx: DaemonContext) -> None:
     """Background task: generate and loop music tracks.
 
-    Runs for the lifetime of the daemon. When ``music_mode`` is "on",
+    Runs for the lifetime of the daemon.  When ``music_mode`` is "on",
     derives a prompt from the current vibe, generates a track via
     :class:`~punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider`,
-    and loops it via ffplay at reduced volume. When ``music_changed``
-    is set, kills the current subprocess and regenerates.
+    and loops it via ffplay at reduced volume.
+
+    The key invariant is **gapless handoff**: the old track keeps
+    looping in its own playback subprocess while generation runs as a
+    concurrent ``asyncio.Task``.  The old subprocess is killed only
+    once the new track is ready.  If the vibe changes again during
+    generation, the in-flight generation task is cancelled and a fresh
+    one starts — the old track keeps looping throughout.
 
     Crash recovery: on failure, logs the error, resets state, and
-    retries with backoff (3 attempts). After 3 failures, sets
+    retries with backoff (3 attempts).  After 3 failures, sets
     ``music_mode`` to "off".
     """
     retry_count = 0
+    current_track: Path | None = None
+    gen_task: asyncio.Task[Path] | None = None
+
     while True:
         # Wait until music is turned on.
         while ctx.music_mode != "on":
@@ -1735,55 +1776,26 @@ async def _music_loop(ctx: DaemonContext) -> None:
             await ctx.music_changed.wait()
 
         try:
-            # Generate a track.
-            ctx.music_state = "generating"
-            ctx.music_changed.clear()
+            # --- Initial generation (no old track to loop) ----------------
+            if current_track is None:
+                ctx.music_state = "generating"
+                ctx.music_changed.clear()
+                current_track = await _generate_music_track(ctx)
+                ctx.music_track = current_track
+                retry_count = 0
 
-            vibe, vibe_tags = ctx.music_vibe
-            style = ctx.music_style
+                # Vibe changed during initial generation — regenerate
+                # immediately (no old track to keep looping).
+                if ctx.music_changed.is_set():
+                    logger.info("Vibe changed during initial generation, regenerating")
+                    current_track = None
+                    continue
 
-            from punt_vox.music import vibe_to_prompt
-
-            hour = time.localtime().tm_hour
-            # TODO(vox-0qi): pass session signals for work-intensity layer
-            prompt = vibe_to_prompt(
-                vibe or None, vibe_tags or None, style or None, hour, signals=[]
-            )
-
-            output_dir = _music_output_dir()
-            output_dir.mkdir(parents=True, exist_ok=True)
-
-            vibe_slug = _slugify(vibe) if vibe else "none"
-            style_slug = _slugify(style) if style else "none"
-            timestamp = time.strftime("%Y%m%d_%H%M%S")
-            filename = f"{timestamp}_{vibe_slug}_{style_slug}.mp3"
-            output_path = output_dir / filename
-
-            from punt_vox.providers.elevenlabs_music import ElevenLabsMusicProvider
-
-            provider = ElevenLabsMusicProvider()
-            track = await provider.generate_track(
-                prompt, _MUSIC_DURATION_MS, output_path
-            )
-
-            ctx.music_track = track
-            retry_count = 0  # Reset on successful generation.
-
-            # Kill the old track now that the new one is ready. This is
-            # the handoff point — old music played throughout generation
-            # so there was no silence gap.
-            await _kill_music_proc(ctx)
-
-            # If vibe changed during generation, consume the event and
-            # regenerate on next iteration instead of playing the stale track.
-            if ctx.music_changed.is_set():
-                logger.info("Vibe changed during generation, regenerating")
-                continue
-
-            # Loop the track until music_changed is signaled or mode turns off.
-            while ctx.music_mode == "on" and not ctx.music_changed.is_set():
-                ctx.music_state = "playing"
-                cmd = _music_player_command(track)
+            # --- Playback loop: loop current_track, generate in parallel --
+            gen_task = None
+            while ctx.music_mode == "on":
+                ctx.music_state = "playing" if gen_task is None else "generating"
+                cmd = _music_player_command(current_track)
                 proc = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdin=asyncio.subprocess.DEVNULL,
@@ -1793,40 +1805,89 @@ async def _music_loop(ctx: DaemonContext) -> None:
                 )
                 ctx.music_proc = proc
 
-                # Wait for subprocess to finish or music_changed to fire.
+                # Build the set of futures to race.
                 wait_task = asyncio.create_task(proc.wait())
                 changed_task = asyncio.create_task(ctx.music_changed.wait())
+                waitables: set[asyncio.Task[object]] = {wait_task, changed_task}
+                if gen_task is not None:
+                    waitables.add(gen_task)
+
                 _done, pending = await asyncio.wait(
-                    {wait_task, changed_task},
+                    waitables,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
-                for task in pending:
-                    task.cancel()
+                for t in pending:
+                    # Don't cancel the generation task — it may still be
+                    # running and we want it to finish across iterations.
+                    if t is gen_task:
+                        continue
+                    t.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
-                        await task
+                        await t
 
+                # --- /music off: kill everything immediately --------------
                 if ctx.music_mode != "on":
+                    if gen_task is not None and not gen_task.done():
+                        gen_task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await gen_task
+                        gen_task = None
                     await _kill_music_proc(ctx)
-                    break
-                if ctx.music_changed.is_set():
-                    # Vibe changed — break out of the playback loop but
-                    # keep the old track playing. The outer loop will
-                    # generate the new track while the old one continues,
-                    # then kill it right before starting the new playback.
+                    current_track = None
                     break
 
-                # Playback ended naturally — loop the same track.
+                # --- Generation task completed: handoff -------------------
+                if gen_task is not None and gen_task.done():
+                    exc = gen_task.exception()
+                    if exc is not None:
+                        gen_task = None
+                        raise exc
+                    new_track = gen_task.result()
+                    gen_task = None
+                    ctx.music_track = new_track
+                    retry_count = 0
+                    await _kill_music_proc(ctx)
+                    current_track = new_track
+                    # Clear the event that triggered this generation, then
+                    # check whether ANOTHER change arrived in the meantime.
+                    ctx.music_changed.clear()
+                    if ctx.music_changed.is_set():
+                        # Rare: yet another vibe change during handoff.
+                        logger.info("Vibe changed during handoff, regenerating")
+                    # Re-enter playback loop with new track (or regenerate
+                    # if music_changed was set again).
+                    continue
+
+                # --- Vibe changed: start/restart generation ---------------
+                if ctx.music_changed.is_set():
+                    ctx.music_changed.clear()
+                    if gen_task is not None and not gen_task.done():
+                        gen_task.cancel()
+                        with contextlib.suppress(asyncio.CancelledError):
+                            await gen_task
+                    ctx.music_state = "generating"
+                    gen_task = asyncio.create_task(_generate_music_track(ctx))
+                    # Don't break — keep looping the old track.
+                    continue
+
+                # --- Subprocess ended naturally: loop same track ----------
                 rc = proc.returncode
                 if rc != 0:
                     logger.warning(
                         "Music playback ended with rc=%s for %s",
                         rc,
-                        track.name,
+                        current_track.name,
                     )
 
         except asyncio.CancelledError:
+            if gen_task is not None and not gen_task.done():
+                gen_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await gen_task
+                gen_task = None
             await _kill_music_proc(ctx)
             ctx.music_state = "idle"
+            current_track = None
             raise
         except Exception:
             logger.exception(
@@ -1834,8 +1895,14 @@ async def _music_loop(ctx: DaemonContext) -> None:
                 retry_count + 1,
                 _MUSIC_MAX_RETRIES,
             )
+            if gen_task is not None and not gen_task.done():
+                gen_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await gen_task
+                gen_task = None
             await _kill_music_proc(ctx)
             ctx.music_state = "idle"
+            current_track = None
             retry_count += 1
             if retry_count >= _MUSIC_MAX_RETRIES:
                 logger.error(

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1792,6 +1792,7 @@ async def _music_loop(ctx: DaemonContext) -> None:
                     continue
 
             # --- Playback loop: loop current_track, generate in parallel --
+            assert current_track is not None  # guaranteed by initial generation above
             gen_task = None
             while ctx.music_mode == "on":
                 ctx.music_state = "playing" if gen_task is None else "generating"
@@ -1808,17 +1809,18 @@ async def _music_loop(ctx: DaemonContext) -> None:
                 # Wait on this subprocess, re-entering the wait when
                 # only a vibe change fired (the proc is still alive).
                 proc_done = False
+                handoff_occurred = False
                 while not proc_done:
                     wait_task = asyncio.create_task(proc.wait())
                     changed_task = asyncio.create_task(
                         ctx.music_changed.wait(),
                     )
-                    waitables: set[asyncio.Task[object]] = {
-                        wait_task,
-                        changed_task,
+                    waitables: set[asyncio.Future[object]] = {
+                        cast("asyncio.Future[object]", wait_task),
+                        cast("asyncio.Future[object]", changed_task),
                     }
                     if gen_task is not None:
-                        waitables.add(gen_task)
+                        waitables.add(cast("asyncio.Future[object]", gen_task))
 
                     _done, pending = await asyncio.wait(
                         waitables,
@@ -1859,7 +1861,10 @@ async def _music_loop(ctx: DaemonContext) -> None:
                         retry_count = 0
                         await _kill_music_proc(ctx)
                         current_track = new_track
-                        ctx.music_changed.clear()
+                        # Don't clear music_changed here — a vibe change
+                        # may have arrived during generation.  The next
+                        # iteration's is_set() check will catch it.
+                        handoff_occurred = True
                         proc_done = True
                         break
 
@@ -1890,13 +1895,16 @@ async def _music_loop(ctx: DaemonContext) -> None:
                 if current_track is None:
                     break
 
-                rc = proc.returncode
-                if rc is not None and rc != 0:
-                    logger.warning(
-                        "Music playback ended with rc=%s for %s",
-                        rc,
-                        current_track.name,
-                    )
+                # After handoff, the old proc was killed intentionally —
+                # non-zero rc is expected, not worth warning about.
+                if not handoff_occurred:
+                    rc = proc.returncode
+                    if rc is not None and rc != 0:
+                        logger.warning(
+                            "Music playback ended with rc=%s for %s",
+                            rc,
+                            current_track.name,
+                        )
 
         except asyncio.CancelledError:
             if gen_task is not None and not gen_task.done():

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1769,8 +1769,13 @@ async def _music_loop(ctx: DaemonContext) -> None:
             ctx.music_track = track
             retry_count = 0  # Reset on successful generation.
 
+            # Kill the old track now that the new one is ready. This is
+            # the handoff point — old music played throughout generation
+            # so there was no silence gap.
+            await _kill_music_proc(ctx)
+
             # If vibe changed during generation, consume the event and
-            # regenerate on next iteration instead of playing a stale track.
+            # regenerate on next iteration instead of playing the stale track.
             if ctx.music_changed.is_set():
                 logger.info("Vibe changed during generation, regenerating")
                 continue
@@ -1800,8 +1805,14 @@ async def _music_loop(ctx: DaemonContext) -> None:
                     with contextlib.suppress(asyncio.CancelledError):
                         await task
 
-                if ctx.music_changed.is_set() or ctx.music_mode != "on":
+                if ctx.music_mode != "on":
                     await _kill_music_proc(ctx)
+                    break
+                if ctx.music_changed.is_set():
+                    # Vibe changed — break out of the playback loop but
+                    # keep the old track playing. The outer loop will
+                    # generate the new track while the old one continues,
+                    # then kill it right before starting the new playback.
                     break
 
                 # Playback ended naturally — loop the same track.

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1805,74 +1805,93 @@ async def _music_loop(ctx: DaemonContext) -> None:
                 )
                 ctx.music_proc = proc
 
-                # Build the set of futures to race.
-                wait_task = asyncio.create_task(proc.wait())
-                changed_task = asyncio.create_task(ctx.music_changed.wait())
-                waitables: set[asyncio.Task[object]] = {wait_task, changed_task}
-                if gen_task is not None:
-                    waitables.add(gen_task)
+                # Wait on this subprocess, re-entering the wait when
+                # only a vibe change fired (the proc is still alive).
+                proc_done = False
+                while not proc_done:
+                    wait_task = asyncio.create_task(proc.wait())
+                    changed_task = asyncio.create_task(
+                        ctx.music_changed.wait(),
+                    )
+                    waitables: set[asyncio.Task[object]] = {
+                        wait_task,
+                        changed_task,
+                    }
+                    if gen_task is not None:
+                        waitables.add(gen_task)
 
-                _done, pending = await asyncio.wait(
-                    waitables,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                for t in pending:
-                    # Don't cancel the generation task — it may still be
-                    # running and we want it to finish across iterations.
-                    if t is gen_task:
-                        continue
-                    t.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await t
-
-                # --- /music off: kill everything immediately --------------
-                if ctx.music_mode != "on":
-                    if gen_task is not None and not gen_task.done():
-                        gen_task.cancel()
+                    _done, pending = await asyncio.wait(
+                        waitables,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for t in pending:
+                        # Don't cancel the generation task — it may
+                        # still be running and we want it to finish.
+                        if t is gen_task:
+                            continue
+                        t.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
-                            await gen_task
+                            await t
+
+                    # --- /music off: kill everything immediately ----------
+                    if ctx.music_mode != "on":
+                        if gen_task is not None and not gen_task.done():
+                            gen_task.cancel()
+                            with contextlib.suppress(
+                                asyncio.CancelledError,
+                            ):
+                                await gen_task
+                            gen_task = None
+                        await _kill_music_proc(ctx)
+                        current_track = None
+                        proc_done = True
+                        break
+
+                    # --- Generation task completed: handoff ---------------
+                    if gen_task is not None and gen_task.done():
+                        exc = gen_task.exception()
+                        if exc is not None:
+                            gen_task = None
+                            raise exc
+                        new_track = gen_task.result()
                         gen_task = None
-                    await _kill_music_proc(ctx)
-                    current_track = None
+                        ctx.music_track = new_track
+                        retry_count = 0
+                        await _kill_music_proc(ctx)
+                        current_track = new_track
+                        ctx.music_changed.clear()
+                        proc_done = True
+                        break
+
+                    # --- Vibe changed: start/restart generation -----------
+                    if ctx.music_changed.is_set():
+                        ctx.music_changed.clear()
+                        if gen_task is not None and not gen_task.done():
+                            gen_task.cancel()
+                            with contextlib.suppress(
+                                asyncio.CancelledError,
+                            ):
+                                await gen_task
+                        ctx.music_state = "generating"
+                        gen_task = asyncio.create_task(
+                            _generate_music_track(ctx),
+                        )
+                        # Don't kill the proc — let it keep looping.
+                        # Re-enter this inner wait loop so we race
+                        # the same proc against the new gen_task.
+                        continue
+
+                    # --- Subprocess ended naturally -----------------------
+                    proc_done = True
+
+                # If music was turned off, the outer while condition
+                # handles exiting.  Otherwise fall through to respawn
+                # the subprocess (same or new track).
+                if current_track is None:
                     break
 
-                # --- Generation task completed: handoff -------------------
-                if gen_task is not None and gen_task.done():
-                    exc = gen_task.exception()
-                    if exc is not None:
-                        gen_task = None
-                        raise exc
-                    new_track = gen_task.result()
-                    gen_task = None
-                    ctx.music_track = new_track
-                    retry_count = 0
-                    await _kill_music_proc(ctx)
-                    current_track = new_track
-                    # Clear the event that triggered this generation, then
-                    # check whether ANOTHER change arrived in the meantime.
-                    ctx.music_changed.clear()
-                    if ctx.music_changed.is_set():
-                        # Rare: yet another vibe change during handoff.
-                        logger.info("Vibe changed during handoff, regenerating")
-                    # Re-enter playback loop with new track (or regenerate
-                    # if music_changed was set again).
-                    continue
-
-                # --- Vibe changed: start/restart generation ---------------
-                if ctx.music_changed.is_set():
-                    ctx.music_changed.clear()
-                    if gen_task is not None and not gen_task.done():
-                        gen_task.cancel()
-                        with contextlib.suppress(asyncio.CancelledError):
-                            await gen_task
-                    ctx.music_state = "generating"
-                    gen_task = asyncio.create_task(_generate_music_track(ctx))
-                    # Don't break — keep looping the old track.
-                    continue
-
-                # --- Subprocess ended naturally: loop same track ----------
                 rc = proc.returncode
-                if rc != 0:
+                if rc is not None and rc != 0:
                     logger.warning(
                         "Music playback ended with rc=%s for %s",
                         rc,

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -2763,6 +2763,200 @@ class TestMusicLoopStateTransitions:
         assert generation_count >= 2
 
 
+class TestMusicLoopGaplessHandoff:
+    """Old track must keep looping while generation runs concurrently."""
+
+    def test_old_track_loops_during_generation(self) -> None:
+        """Playback subprocess stays alive the entire time generation runs.
+
+        Simulates a slow generation (~0.15s) and verifies the playback
+        subprocess is NOT killed until the new track is ready.
+        """
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "[calm]")
+        ctx.music_changed.set()
+
+        generation_count = 0
+        play_count = 0
+        # Track which procs were alive during generation.
+        procs_alive_during_gen: list[bool] = []
+
+        async def slow_generate(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal generation_count
+            generation_count += 1
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake-music-data")
+
+            if generation_count == 2:
+                # Second generation (triggered by vibe change). The old
+                # playback proc should still be alive during this window.
+                proc = ctx.music_proc
+                is_alive = proc is not None and proc.returncode is None
+                procs_alive_during_gen.append(is_alive)
+                # Simulate slow generation.
+                await asyncio.sleep(0.1)
+                # Check again after the sleep.
+                proc = ctx.music_proc
+                is_alive = proc is not None and proc.returncode is None
+                procs_alive_during_gen.append(is_alive)
+
+            return output_path
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            nonlocal play_count
+            play_count += 1
+            proc = MagicMock()
+            proc.returncode = None  # Still running.
+
+            async def _wait() -> int:
+                # Simulate a long track so it doesn't end naturally.
+                await asyncio.sleep(5.0)
+                proc.returncode = 0
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock(side_effect=lambda: setattr(proc, "returncode", -9))
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider"
+                    ".generate_track",
+                    slow_generate,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-handoff"),
+                ),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                # Let initial generation + first playback start.
+                await asyncio.sleep(0.05)
+
+                # Trigger a vibe change while the first track is playing.
+                ctx.music_vibe = ("happy", "[warm]")
+                ctx.music_changed.set()
+
+                # Wait for second generation to complete + handoff.
+                await asyncio.sleep(0.3)
+
+                # Shut down.
+                ctx.music_mode = "off"
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert generation_count >= 2, (
+            f"expected >=2 generations, got {generation_count}"
+        )
+        assert play_count >= 2, f"expected >=2 playback spawns, got {play_count}"
+        # The old playback proc was alive during the entire generation window.
+        assert all(procs_alive_during_gen), (
+            f"old track was killed during generation: {procs_alive_during_gen}"
+        )
+
+    def test_second_vibe_change_cancels_inflight_generation(self) -> None:
+        """A second vibe change during generation cancels the first and starts fresh."""
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "[calm]")
+        ctx.music_changed.set()
+
+        generation_vibes: list[str] = []
+        gen_event = asyncio.Event()
+
+        async def tracking_generate(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            vibe, _ = ctx.music_vibe
+            generation_vibes.append(vibe)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"fake-music-data")
+
+            if len(generation_vibes) == 2:
+                # Signal that second generation started, then simulate slow work.
+                gen_event.set()
+                await asyncio.sleep(0.5)
+            elif len(generation_vibes) == 3:
+                # Third generation — the replacement after cancel.
+                pass
+
+            return output_path
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = None
+
+            async def _wait() -> int:
+                await asyncio.sleep(5.0)
+                proc.returncode = 0
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock(side_effect=lambda: setattr(proc, "returncode", -9))
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music.ElevenLabsMusicProvider"
+                    ".generate_track",
+                    tracking_generate,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-cancel"),
+                ),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                await asyncio.sleep(0.05)
+
+                # First vibe change triggers generation #2.
+                ctx.music_vibe = ("happy", "[warm]")
+                ctx.music_changed.set()
+                # Wait for second generation to start.
+                await asyncio.wait_for(gen_event.wait(), timeout=1.0)
+
+                # Second vibe change while #2 is in-flight — should cancel it.
+                ctx.music_vibe = ("energetic", "[upbeat]")
+                ctx.music_changed.set()
+                await asyncio.sleep(0.3)
+
+                ctx.music_mode = "off"
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert len(generation_vibes) >= 3, (
+            f"expected >=3 generation attempts, got "
+            f"{len(generation_vibes)}: {generation_vibes}"
+        )
+        # The third generation should have the latest vibe.
+        assert generation_vibes[-1] == "energetic"
+
+
 class TestKillMusicProc:
     """_kill_music_proc safely terminates the music subprocess."""
 

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -2814,6 +2814,10 @@ class TestMusicLoopGaplessHandoff:
 
             async def _wait() -> int:
                 # Simulate a long track so it doesn't end naturally.
+                # Return immediately if the process was already killed,
+                # mirroring real OS behavior after SIGKILL.
+                if proc.returncode is not None:
+                    return int(proc.returncode)
                 await asyncio.sleep(5.0)
                 proc.returncode = 0
                 return 0
@@ -2902,6 +2906,8 @@ class TestMusicLoopGaplessHandoff:
             proc.returncode = None
 
             async def _wait() -> int:
+                if proc.returncode is not None:
+                    return int(proc.returncode)
                 await asyncio.sleep(5.0)
                 proc.returncode = 0
                 return 0


### PR DESCRIPTION
Old track continues looping while the new one generates on vibe change — no silence gap. Subprocess killed only after new track is ready.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the music playback loop to coordinate concurrent generation and subprocess handoff, which is timing- and cancellation-sensitive and could introduce edge-case hangs or leaked subprocesses.
> 
> **Overview**
> Implements **gapless music regeneration** in `voxd` by running track generation as a concurrent `asyncio.Task` and only killing the existing playback subprocess once the new track is ready (with cancellation/restart when vibes change again mid-generation).
> 
> Extracts `_generate_music_track()` and reworks `_music_loop` control flow to handle `/music off` cleanup, handoff vs natural exit warnings, and retry/error paths consistently. Adds focused tests asserting the old track stays alive during generation and that an in-flight generation is cancelled on a second vibe change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224ebb9167a70e4f582aa4a6357928d801d4a0f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->