### PR TITLE
feat: formatted music output + track naming, replay, and library (vox-kkf, vox-vaa)

### DIFF
--- a/commands/music.md
+++ b/commands/music.md
@@ -1,7 +1,7 @@
 ---
 description: "Control background music generation"
-argument-hint: "on [style ...] | off"
-allowed-tools: ["mcp__plugin_vox_mic__music", "mcp__plugin_vox_mic__status"]
+argument-hint: "on [--name ...] [style ...] | off | play <name> | list"
+allowed-tools: ["mcp__plugin_vox_mic__music", "mcp__plugin_vox_mic__music_play", "mcp__plugin_vox_mic__music_list", "mcp__plugin_vox_mic__status"]
 ---
 
 # /music command
@@ -15,8 +15,18 @@ generates to match.
 
 - `/music on` -- start music with current vibe
 - `/music on style techno` -- start music with a style modifier
+- `/music on --name focus-beats` -- generate and save as "focus-beats", or replay if it exists
 - `/music off` -- stop music
+- `/music play <name>` -- replay a saved track by name
+- `/music list` -- show saved tracks with metadata
 - `/music` -- show current music state
+
+## Track naming
+
+Tracks are auto-named on generation using a vibe-style-HHMM pattern
+(e.g. "happy-techno-1118"). Use `--name` to provide a custom name.
+When a saved track with the given name exists, it is replayed without
+generation (zero credits).
 
 ## Style modifier
 
@@ -28,16 +38,26 @@ style jazz` changes it.
 
 Parse `$ARGUMENTS`:
 
-### `on` (with optional `style ...`)
+### `on` (with optional `--name ...` and `style ...`)
 
 Call the `music` MCP tool with `mode="on"`. If the user provided style
-words after `on style`, join them and pass as `style`. No text output
-after changes -- the panel confirms.
+words after `on style`, join them and pass as `style`. If `--name` is
+provided, pass as `name`. No text output after changes -- the panel
+confirms.
 
 ### `off`
 
 Call the `music` MCP tool with `mode="off"`. No text output -- the
 panel confirms.
+
+### `play <name>`
+
+Call the `music_play` MCP tool with the track name. No text output --
+the panel confirms.
+
+### `list`
+
+Call the `music_list` MCP tool and display the track library.
 
 ### No argument
 

--- a/commands/music.md
+++ b/commands/music.md
@@ -23,8 +23,8 @@ generates to match.
 
 ## Track naming
 
-Tracks are auto-named on generation using a vibe-style-HHMM pattern
-(e.g. "happy-techno-1118"). Use `--name` to provide a custom name.
+Tracks are auto-named on generation using a vibe-style-YYYYMMDD-HHMM pattern
+(e.g. "happy-techno-20260412-1118"). Use `--name` to provide a custom name.
 When a saved track with the given name exists, it is replayed without
 generation (zero credits).
 

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -13,6 +13,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated
 
@@ -1532,7 +1533,11 @@ def music_list_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
         for t in tracks:
             raw_size = t.get("size_bytes", 0)
             size_kb = int(str(raw_size)) // 1024
-            lines.append(f"  {t['name']} ({size_kb} KB)")
+            raw_mtime = t.get("modified", 0)
+            date_str = datetime.fromtimestamp(
+                float(str(raw_mtime)),
+            ).strftime("%Y-%m-%d %H:%M")
+            lines.append(f"  {t['name']} ({size_kb} KB, {date_str})")
         _emit(
             {"tracks": tracks},
             f"{len(tracks)} saved track(s):\n" + "\n".join(lines),

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -1445,18 +1445,29 @@ def music_on_cmd(  # pyright: ignore[reportUnusedFunction]
             help="Style modifier for music generation (e.g. techno, jazz).",
         ),
     ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            "--name",
+            help="Track name. Replays if exists, otherwise saves.",
+        ),
+    ] = None,
 ) -> None:
     """Start background music generation via voxd."""
     style_str = " ".join(style) if style else None
     client = VoxClientSync()
     try:
-        result = client.music("on", style=style_str)
+        result = client.music("on", style=style_str, name=name)
         status = result.get("status", "unknown")
         payload: dict[str, object] = {"music": "on", "status": status}
         if style_str:
             payload["style"] = style_str
+        if name:
+            payload["name"] = name
         text = f"Music on ({status})"
-        if style_str:
+        if name and status == "playing":
+            text = f"Playing saved track: {name}"
+        elif style_str:
             text += f" — style: {style_str}"
         _emit(payload, text)
     except VoxdConnectionError as exc:
@@ -1475,6 +1486,57 @@ def music_off_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
         result = client.music("off")
         status = result.get("status", "stopped")
         _emit({"music": "off", "status": status}, f"Music off ({status})")
+    except VoxdConnectionError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except VoxdProtocolError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@music_app.command("play")
+def music_play_cmd(  # pyright: ignore[reportUnusedFunction]
+    name: Annotated[
+        str,
+        typer.Argument(help="Name of saved track to play."),
+    ],
+) -> None:
+    """Replay a saved music track by name."""
+    client = VoxClientSync()
+    try:
+        result = client.music_play(name)
+        track_name = result.get("name", name)
+        _emit(
+            {"music": "play", "name": track_name, "status": "playing"},
+            f"Playing: {track_name}",
+        )
+    except VoxdConnectionError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except VoxdProtocolError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@music_app.command("list")
+def music_list_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
+    """List saved music tracks."""
+    client = VoxClientSync()
+    try:
+        result = client.music_list()
+        tracks: list[dict[str, object]] = result.get("tracks", [])
+        if not tracks:
+            _emit({"tracks": []}, "No saved tracks.")
+            return
+        lines: list[str] = []
+        for t in tracks:
+            raw_size = t.get("size_bytes", 0)
+            size_kb = int(str(raw_size)) // 1024
+            lines.append(f"  {t['name']} ({size_kb} KB)")
+        _emit(
+            {"tracks": tracks},
+            f"{len(tracks)} saved track(s):\n" + "\n".join(lines),
+        )
     except VoxdConnectionError as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(code=1) from exc

--- a/src/punt_vox/client.py
+++ b/src/punt_vox/client.py
@@ -435,12 +435,15 @@ class VoxClient:
         vibe: str | None = None,
         vibe_tags: str | None = None,
         owner_id: str | None = None,
+        name: str | None = None,
     ) -> dict[str, Any]:
         """Start or stop music playback.
 
         *mode* is ``"on"`` or ``"off"``. When ``"on"``, optional *style*,
-        *vibe*, *vibe_tags*, and *owner_id* are forwarded to voxd.  When
-        ``"off"``, only *owner_id* is sent.
+        *vibe*, *vibe_tags*, *owner_id*, and *name* are forwarded to voxd.
+        When *name* is given and a track with that name already exists,
+        voxd replays it without generation.  When ``"off"``, only
+        *owner_id* is sent.
         """
         if mode not in ("on", "off"):
             err = f"invalid music mode: {mode!r} (expected 'on' or 'off')"
@@ -459,12 +462,40 @@ class VoxClient:
                 msg["vibe"] = vibe
             if vibe_tags is not None:
                 msg["vibe_tags"] = vibe_tags
+            if name is not None:
+                msg["name"] = name
         else:
             msg = {
                 "type": "music_off",
                 "id": request_id,
                 "owner_id": effective_owner,
             }
+        return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
+
+    async def music_play(
+        self,
+        name: str,
+        *,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Replay a saved track by name."""
+        effective_owner = owner_id if owner_id is not None else self._default_owner_id
+        request_id = uuid.uuid4().hex[:12]
+        msg: dict[str, object] = {
+            "type": "music_play",
+            "id": request_id,
+            "name": name,
+            "owner_id": effective_owner,
+        }
+        return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
+
+    async def music_list(self) -> dict[str, Any]:
+        """List saved music tracks."""
+        request_id = uuid.uuid4().hex[:12]
+        msg: dict[str, object] = {
+            "type": "music_list",
+            "id": request_id,
+        }
         return await self._send_and_recv(msg, timeout=_TIMEOUT_SHORT)
 
     async def music_vibe(
@@ -576,6 +607,7 @@ class VoxClientSync:
         vibe: str | None = None,
         vibe_tags: str | None = None,
         owner_id: str | None = None,
+        name: str | None = None,
     ) -> dict[str, Any]:
         """Start or stop music playback."""
         return self._run(  # type: ignore[no-any-return]
@@ -586,8 +618,24 @@ class VoxClientSync:
                 vibe=vibe,
                 vibe_tags=vibe_tags,
                 owner_id=owner_id,
+                name=name,
             )
         )
+
+    def music_play(
+        self,
+        name: str,
+        *,
+        owner_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Replay a saved track by name."""
+        return self._run(  # type: ignore[no-any-return]
+            self._call("music_play", name, owner_id=owner_id)
+        )
+
+    def music_list(self) -> dict[str, Any]:
+        """List saved music tracks."""
+        return self._run(self._call("music_list"))  # type: ignore[no-any-return]
 
     def music_vibe(
         self,

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -505,6 +505,7 @@ def _music_on_message(style: str | None, vibe: str | None) -> str:
 def music(
     mode: str,
     style: str | None = None,
+    name: str | None = None,
 ) -> str:
     """Control background music generation.
 
@@ -517,6 +518,10 @@ def music(
         style: Optional style modifier (e.g. "techno", "jazz").
             Persists across calls -- subsequent ``on`` reuses the
             last-set style.
+        name: Optional track name. When a saved track with this name
+            exists, it is replayed without generation (zero credits).
+            When no saved track exists, the generated track is saved
+            under this name.
 
     Returns:
         JSON string with a human-readable ``message`` field and
@@ -533,6 +538,7 @@ def music(
             vibe=_state.vibe or "",
             vibe_tags=_state.vibe_tags or "",
             owner_id=_state.session_id,
+            name=name,
         )
     except VoxdConnectionError:
         logger.warning("voxd unreachable in music tool; music off", exc_info=True)
@@ -555,9 +561,94 @@ def music(
 
     _state.music_mode = mode
 
-    message = (
-        _music_on_message(style, _state.vibe) if mode == "on" else "\u266a Music off."
-    )
+    # Replay of existing track — status is "playing", not "generating".
+    if resp.get("status") == "playing" and name:
+        message = f"\u266a Playing saved track: {name}"
+    elif mode == "on":
+        message = _music_on_message(style, _state.vibe)
+    else:
+        message = "\u266a Music off."
+    return json.dumps({"message": message, **resp})
+
+
+@mcp.tool()
+def music_play(name: str) -> str:
+    """Replay a saved music track by name.
+
+    Finds the track in the music library and starts looping it.
+    No generation, no credits used.
+
+    Args:
+        name: Track name (as shown by music_list).
+
+    Returns:
+        JSON string with a human-readable ``message`` field and
+        the raw voxd response fields.
+    """
+    client = _voxd_client()
+    try:
+        resp = client.music_play(name, owner_id=_state.session_id)
+    except VoxdConnectionError:
+        logger.warning("voxd unreachable in music_play", exc_info=True)
+        return json.dumps(
+            {
+                "message": "\u266a Daemon unreachable.",
+                "error": "daemon unreachable",
+            }
+        )
+    except Exception as exc:
+        logger.warning("voxd error in music_play", exc_info=True)
+        return json.dumps(
+            {
+                "message": f"\u266a {exc}",
+                "error": str(exc),
+            }
+        )
+
+    _state.music_mode = "on"
+    track_name = resp.get("name", name)
+    message = f"\u266a Now playing: {track_name}"
+    return json.dumps({"message": message, **resp})
+
+
+@mcp.tool()
+def music_list() -> str:
+    """Show saved music tracks with name, size, and date.
+
+    Returns:
+        JSON string with a human-readable ``message`` field and
+        the track list from voxd.
+    """
+    client = _voxd_client()
+    try:
+        resp = client.music_list()
+    except VoxdConnectionError:
+        logger.warning("voxd unreachable in music_list", exc_info=True)
+        return json.dumps(
+            {
+                "message": "\u266a Daemon unreachable.",
+                "error": "daemon unreachable",
+            }
+        )
+    except Exception as exc:
+        logger.warning("voxd error in music_list", exc_info=True)
+        return json.dumps(
+            {
+                "message": f"\u266a {exc}",
+                "error": str(exc),
+            }
+        )
+
+    tracks: list[dict[str, object]] = resp.get("tracks", [])
+    if not tracks:
+        message = "\u266a No saved tracks."
+    else:
+        lines = [f"\u266a {len(tracks)} saved track(s):"]
+        for t in tracks:
+            raw_size = t.get("size_bytes", 0)
+            size_kb = int(str(raw_size)) // 1024
+            lines.append(f"  \u266a {t['name']} ({size_kb} KB)")
+        message = "\n".join(lines)
     return json.dumps({"message": message, **resp})
 
 

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -489,6 +489,18 @@ def vibe(
     return json.dumps({"vibe": updates})
 
 
+def _music_on_message(style: str | None, vibe: str | None) -> str:
+    """Build the human-readable message for music-on."""
+    prefix = "\u266a Music on \u2014 generating"
+    if style and vibe:
+        return f"{prefix} a {style} track for your {vibe} mood..."
+    if style:
+        return f"{prefix} a {style} track..."
+    if vibe:
+        return f"{prefix} a track for your {vibe} mood..."
+    return f"{prefix} ambient music..."
+
+
 @mcp.tool()
 def music(
     mode: str,
@@ -507,7 +519,8 @@ def music(
             last-set style.
 
     Returns:
-        JSON string with the voxd response.
+        JSON string with a human-readable ``message`` field and
+        the raw voxd response fields.
     """
     if mode not in ("on", "off"):
         return _error(f"Invalid mode '{mode}'. Use on/off.")
@@ -521,13 +534,31 @@ def music(
             vibe_tags=_state.vibe_tags or "",
             owner_id=_state.session_id,
         )
+    except VoxdConnectionError:
+        logger.warning("voxd unreachable in music tool; music off", exc_info=True)
+        _state.music_mode = "off"
+        return json.dumps(
+            {
+                "message": "\u266a Daemon unreachable \u2014 music off.",
+                "error": "daemon unreachable",
+            }
+        )
     except Exception as exc:
         logger.warning("voxd error in music tool; music off", exc_info=True)
         _state.music_mode = "off"
-        return _error(str(exc))
+        return json.dumps(
+            {
+                "message": f"\u266a Music error: {exc}",
+                "error": str(exc),
+            }
+        )
 
     _state.music_mode = mode
-    return json.dumps(resp)
+
+    message = (
+        _music_on_message(style, _state.vibe) if mode == "on" else "\u266a Music off."
+    )
+    return json.dumps({"message": message, **resp})
 
 
 @mcp.tool()

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -12,6 +12,7 @@ import logging
 import random
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -647,7 +648,11 @@ def music_list() -> str:
         for t in tracks:
             raw_size = t.get("size_bytes", 0)
             size_kb = int(str(raw_size)) // 1024
-            lines.append(f"  \u266a {t['name']} ({size_kb} KB)")
+            raw_mtime = t.get("modified", 0)
+            date_str = datetime.fromtimestamp(
+                float(str(raw_mtime)),
+            ).strftime("%Y-%m-%d %H:%M")
+            lines.append(f"  \u266a {t['name']} ({size_kb} KB, {date_str})")
         message = "\n".join(lines)
     return json.dumps({"message": message, **resp})
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -865,6 +865,7 @@ class DaemonContext:
         self.music_owner: str = ""
         self.music_vibe: tuple[str, str] = ("", "")  # (vibe, vibe_tags)
         self.music_track: Path | None = None
+        self.music_track_name: str = ""
         self.music_proc: asyncio.subprocess.Process | None = None
         self.music_state: str = "idle"  # "idle" | "generating" | "playing"
         self.music_changed: asyncio.Event = asyncio.Event()
@@ -1710,11 +1711,26 @@ async def _kill_music_proc(ctx: DaemonContext) -> None:
     ctx.music_proc = None
 
 
+def _auto_track_name(ctx: DaemonContext) -> str:
+    """Derive a short auto-name from vibe + style + HHMM."""
+    vibe, _ = ctx.music_vibe
+    style = ctx.music_style
+    hhmm = time.strftime("%H%M")
+    vibe_part = _slugify(vibe, max_len=20) if vibe else "ambient"
+    style_part = _slugify(style, max_len=20) if style else "mix"
+    return f"{vibe_part}-{style_part}-{hhmm}"
+
+
 async def _generate_music_track(ctx: DaemonContext) -> Path:
     """Generate a music track from the current vibe and style.
 
     Extracted so the generation phase can run as an ``asyncio.Task``
     concurrently with the playback loop.
+
+    When ``ctx.music_track_name`` is set, the track is saved under
+    that name in ``~/vox-output/music/``. Otherwise an auto-derived
+    name from vibe + style + HHMM is used. The name is stored back
+    into ``ctx.music_track_name`` for status reporting.
     """
     vibe, vibe_tags = ctx.music_vibe
     style = ctx.music_style
@@ -1730,11 +1746,14 @@ async def _generate_music_track(ctx: DaemonContext) -> Path:
     output_dir = _music_output_dir()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    vibe_slug = _slugify(vibe) if vibe else "none"
-    style_slug = _slugify(style) if style else "none"
-    timestamp = time.strftime("%Y%m%d_%H%M%S")
-    filename = f"{timestamp}_{vibe_slug}_{style_slug}.mp3"
+    # Use explicit name if set, otherwise auto-derive.
+    track_name = ctx.music_track_name or _auto_track_name(ctx)
+    safe_name = _slugify(track_name, max_len=60)
+    filename = f"{safe_name}.mp3"
     output_path = output_dir / filename
+
+    # Store the resolved name back for status reporting.
+    ctx.music_track_name = safe_name
 
     from punt_vox.providers.elevenlabs_music import ElevenLabsMusicProvider
 
@@ -1951,18 +1970,56 @@ async def _handle_music_on(
 
     Ownership transfer is atomic: kill existing subprocess, update all
     state fields, then signal MusicLoop. No interleaving.
+
+    When a ``name`` field is present and a track with that name already
+    exists on disk, the existing file is replayed without generation
+    (zero credits).
     """
     request_id = str(msg.get("id", ""))
     owner_id = str(msg.get("owner_id", ""))
     style = str(msg.get("style", ""))
     vibe = str(msg.get("vibe", ""))
     vibe_tags = str(msg.get("vibe_tags", ""))
+    name = str(msg.get("name", ""))
 
     if not owner_id:
         await websocket.send_json(
             {"type": "error", "id": request_id, "message": "owner_id is required"}
         )
         return
+
+    # Check for existing track by name -- skip generation if found.
+    if name:
+        safe_name = _slugify(name, max_len=60)
+        existing_path = _music_output_dir() / f"{safe_name}.mp3"
+        if existing_path.exists():
+            await _kill_music_proc(ctx)
+            ctx.music_mode = "on"
+            if style:
+                ctx.music_style = style
+            ctx.music_owner = owner_id
+            ctx.music_vibe = (vibe, vibe_tags)
+            ctx.music_track = existing_path
+            ctx.music_track_name = safe_name
+            ctx.music_state = "playing"
+            ctx.music_changed.set()
+
+            logger.info(
+                "Music on (replay): owner=%s name=%s track=%s",
+                owner_id,
+                safe_name,
+                existing_path,
+            )
+            await websocket.send_json(
+                {
+                    "type": "music_on",
+                    "id": request_id,
+                    "status": "playing",
+                    "track": str(existing_path),
+                    "name": safe_name,
+                }
+            )
+            return
 
     # Atomic ownership transfer: kill existing, update all fields, signal.
     await _kill_music_proc(ctx)
@@ -1972,14 +2029,16 @@ async def _handle_music_on(
         ctx.music_style = style
     ctx.music_owner = owner_id
     ctx.music_vibe = (vibe, vibe_tags)
+    ctx.music_track_name = _slugify(name, max_len=60) if name else ""
     ctx.music_state = "generating"
     ctx.music_changed.set()
 
     logger.info(
-        "Music on: owner=%s style=%s vibe=%s",
+        "Music on: owner=%s style=%s vibe=%s name=%s",
         owner_id,
         ctx.music_style,
         vibe,
+        ctx.music_track_name,
     )
     await websocket.send_json(
         {"type": "music_on", "id": request_id, "status": "generating"}
@@ -2002,6 +2061,99 @@ async def _handle_music_off(
     logger.info("Music off")
     await websocket.send_json(
         {"type": "music_off", "id": request_id, "status": "stopped"}
+    )
+
+
+async def _handle_music_play(
+    msg: dict[str, object],
+    websocket: WebSocket,
+    ctx: DaemonContext,
+) -> None:
+    """Handle a 'music_play' message: replay a saved track by name."""
+    request_id = str(msg.get("id", ""))
+    name = str(msg.get("name", ""))
+    owner_id = str(msg.get("owner_id", ""))
+
+    if not name:
+        await websocket.send_json(
+            {"type": "error", "id": request_id, "message": "name is required"}
+        )
+        return
+
+    if not owner_id:
+        await websocket.send_json(
+            {"type": "error", "id": request_id, "message": "owner_id is required"}
+        )
+        return
+
+    safe_name = _slugify(name, max_len=60)
+    track_path = _music_output_dir() / f"{safe_name}.mp3"
+
+    if not track_path.exists():
+        await websocket.send_json(
+            {
+                "type": "error",
+                "id": request_id,
+                "message": f"track not found: {safe_name}",
+            }
+        )
+        return
+
+    # Kill current playback, set up replay.
+    await _kill_music_proc(ctx)
+    ctx.music_mode = "on"
+    ctx.music_owner = owner_id
+    ctx.music_track = track_path
+    ctx.music_track_name = safe_name
+    ctx.music_state = "playing"
+    ctx.music_changed.set()
+
+    logger.info(
+        "Music play: owner=%s name=%s track=%s",
+        owner_id,
+        safe_name,
+        track_path,
+    )
+    await websocket.send_json(
+        {
+            "type": "music_play",
+            "id": request_id,
+            "status": "playing",
+            "track": str(track_path),
+            "name": safe_name,
+        }
+    )
+
+
+async def _handle_music_list(
+    msg: dict[str, object],
+    websocket: WebSocket,
+    ctx: DaemonContext,
+) -> None:
+    """Handle a 'music_list' message: return saved tracks with metadata."""
+    request_id = str(msg.get("id", ""))
+
+    output_dir = _music_output_dir()
+    tracks: list[dict[str, object]] = []
+
+    if output_dir.exists():
+        for mp3 in sorted(output_dir.glob("*.mp3")):
+            stat = mp3.stat()
+            tracks.append(
+                {
+                    "name": mp3.stem,
+                    "size_bytes": stat.st_size,
+                    "modified": stat.st_mtime,
+                    "path": str(mp3),
+                }
+            )
+
+    await websocket.send_json(
+        {
+            "type": "music_list",
+            "id": request_id,
+            "tracks": tracks,
+        }
     )
 
 
@@ -2063,6 +2215,8 @@ _HANDLERS: dict[
     "health": _handle_health,
     "music_on": _handle_music_on,
     "music_off": _handle_music_off,
+    "music_play": _handle_music_play,
+    "music_list": _handle_music_list,
     "music_vibe": _handle_music_vibe,
 }
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1717,8 +1717,8 @@ def _auto_track_name(ctx: DaemonContext) -> str:
     vibe, _ = ctx.music_vibe
     style = ctx.music_style
     stamp = time.strftime("%Y%m%d-%H%M")
-    vibe_part = _slugify(vibe, max_len=20) if vibe else "ambient"
-    style_part = _slugify(style, max_len=20) if style else "mix"
+    vibe_part = _slugify(vibe, max_len=20) or "ambient"
+    style_part = _slugify(style, max_len=20) or "mix"
     return f"{vibe_part}-{style_part}-{stamp}"
 
 
@@ -1730,7 +1730,7 @@ async def _generate_music_track(ctx: DaemonContext) -> Path:
 
     When ``ctx.music_track_name`` is set, the track is saved under
     that name in ``~/vox-output/music/``. Otherwise an auto-derived
-    name from vibe + style + HHMM is used. The name is stored back
+    name from vibe + style + YYYYMMDD-HHMM is used. The name is stored back
     into ``ctx.music_track_name`` for status reporting.
     """
     vibe, vibe_tags = ctx.music_vibe

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -869,6 +869,7 @@ class DaemonContext:
         self.music_proc: asyncio.subprocess.Process | None = None
         self.music_state: str = "idle"  # "idle" | "generating" | "playing"
         self.music_changed: asyncio.Event = asyncio.Event()
+        self.music_replay: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -1712,13 +1713,13 @@ async def _kill_music_proc(ctx: DaemonContext) -> None:
 
 
 def _auto_track_name(ctx: DaemonContext) -> str:
-    """Derive a short auto-name from vibe + style + HHMM."""
+    """Derive a short auto-name from vibe + style + YYYYMMDD-HHMM."""
     vibe, _ = ctx.music_vibe
     style = ctx.music_style
-    hhmm = time.strftime("%H%M")
+    stamp = time.strftime("%Y%m%d-%H%M")
     vibe_part = _slugify(vibe, max_len=20) if vibe else "ambient"
     style_part = _slugify(style, max_len=20) if style else "mix"
-    return f"{vibe_part}-{style_part}-{hhmm}"
+    return f"{vibe_part}-{style_part}-{stamp}"
 
 
 async def _generate_music_track(ctx: DaemonContext) -> Path:
@@ -1797,18 +1798,28 @@ async def _music_loop(ctx: DaemonContext) -> None:
         try:
             # --- Initial generation (no old track to loop) ----------------
             if current_track is None:
-                ctx.music_state = "generating"
-                ctx.music_changed.clear()
-                current_track = await _generate_music_track(ctx)
-                ctx.music_track = current_track
-                retry_count = 0
+                # Replay: a handler already placed a track in ctx.music_track.
+                if ctx.music_replay:
+                    ctx.music_replay = False
+                    ctx.music_changed.clear()
+                    assert ctx.music_track is not None
+                    current_track = ctx.music_track
+                    retry_count = 0
+                else:
+                    ctx.music_state = "generating"
+                    ctx.music_changed.clear()
+                    current_track = await _generate_music_track(ctx)
+                    ctx.music_track = current_track
+                    retry_count = 0
 
-                # Vibe changed during initial generation — regenerate
-                # immediately (no old track to keep looping).
-                if ctx.music_changed.is_set():
-                    logger.info("Vibe changed during initial generation, regenerating")
-                    current_track = None
-                    continue
+                    # Vibe changed during initial generation — regenerate
+                    # immediately (no old track to keep looping).
+                    if ctx.music_changed.is_set():
+                        logger.info(
+                            "Vibe changed during initial generation, regenerating",
+                        )
+                        current_track = None
+                        continue
 
             # --- Playback loop: loop current_track, generate in parallel --
             assert current_track is not None  # guaranteed by initial generation above
@@ -1896,6 +1907,19 @@ async def _music_loop(ctx: DaemonContext) -> None:
                                 asyncio.CancelledError,
                             ):
                                 await gen_task
+                            gen_task = None
+
+                        # Replay: handler pre-set ctx.music_track.
+                        if ctx.music_replay:
+                            ctx.music_replay = False
+                            assert ctx.music_track is not None
+                            new_track = ctx.music_track
+                            await _kill_music_proc(ctx)
+                            current_track = new_track
+                            retry_count = 0
+                            proc_done = True
+                            break
+
                         ctx.music_state = "generating"
                         gen_task = asyncio.create_task(
                             _generate_music_track(ctx),
@@ -1991,6 +2015,11 @@ async def _handle_music_on(
     # Check for existing track by name -- skip generation if found.
     if name:
         safe_name = _slugify(name, max_len=60)
+        if not safe_name:
+            await websocket.send_json(
+                {"type": "error", "id": request_id, "message": "invalid track name"}
+            )
+            return
         existing_path = _music_output_dir() / f"{safe_name}.mp3"
         if existing_path.exists():
             await _kill_music_proc(ctx)
@@ -2002,6 +2031,7 @@ async def _handle_music_on(
             ctx.music_track = existing_path
             ctx.music_track_name = safe_name
             ctx.music_state = "playing"
+            ctx.music_replay = True
             ctx.music_changed.set()
 
             logger.info(
@@ -2087,6 +2117,11 @@ async def _handle_music_play(
         return
 
     safe_name = _slugify(name, max_len=60)
+    if not safe_name:
+        await websocket.send_json(
+            {"type": "error", "id": request_id, "message": "invalid track name"}
+        )
+        return
     track_path = _music_output_dir() / f"{safe_name}.mp3"
 
     if not track_path.exists():
@@ -2106,6 +2141,7 @@ async def _handle_music_play(
     ctx.music_track = track_path
     ctx.music_track_name = safe_name
     ctx.music_state = "playing"
+    ctx.music_replay = True
     ctx.music_changed.set()
 
     logger.info(

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -2060,6 +2060,7 @@ async def _handle_music_on(
     ctx.music_owner = owner_id
     ctx.music_vibe = (vibe, vibe_tags)
     ctx.music_track_name = _slugify(name, max_len=60) if name else ""
+    ctx.music_replay = False
     ctx.music_state = "generating"
     ctx.music_changed.set()
 
@@ -2086,6 +2087,7 @@ async def _handle_music_off(
     await _kill_music_proc(ctx)
     ctx.music_mode = "off"
     ctx.music_state = "idle"
+    ctx.music_replay = False
     ctx.music_changed.set()
 
     logger.info("Music off")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2615,6 +2615,10 @@ class TestMusicCommand:
         assert "2 saved track(s)" in result.output
         assert "alpha" in result.output
         assert "beta" in result.output
+        # Dates are included in YYYY-MM-DD HH:MM format.
+        import re
+
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", result.output)
 
     @patch(f"{_CLI}.VoxClientSync")
     def test_music_list_empty(self, mock_client_cls: MagicMock) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2431,7 +2431,7 @@ class TestMusicCommand:
         result = runner.invoke(app, ["music", "on"])
 
         assert result.exit_code == 0
-        mock_instance.music.assert_called_once_with("on", style=None)
+        mock_instance.music.assert_called_once_with("on", style=None, name=None)
         assert "Music on" in result.output
         assert "generating" in result.output
 
@@ -2444,7 +2444,7 @@ class TestMusicCommand:
         result = runner.invoke(app, ["music", "on", "--style", "techno"])
 
         assert result.exit_code == 0
-        mock_instance.music.assert_called_once_with("on", style="techno")
+        mock_instance.music.assert_called_once_with("on", style="techno", name=None)
         assert "Music on" in result.output
         assert "techno" in result.output
 
@@ -2459,7 +2459,9 @@ class TestMusicCommand:
         )
 
         assert result.exit_code == 0
-        mock_instance.music.assert_called_once_with("on", style="lo-fi chill")
+        mock_instance.music.assert_called_once_with(
+            "on", style="lo-fi chill", name=None
+        )
         assert "lo-fi chill" in result.output
 
     @patch(f"{_CLI}.VoxClientSync")
@@ -2523,3 +2525,149 @@ class TestMusicCommand:
         assert result.exit_code == 0 or result.exit_code == 2
         assert "on" in result.output
         assert "off" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_with_name(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {
+            "status": "playing",
+            "name": "focus_beats",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "on", "--name", "focus beats"])
+
+        assert result.exit_code == 0
+        mock_instance.music.assert_called_once_with(
+            "on", style=None, name="focus beats"
+        )
+        assert "Playing saved track" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_on_name_generating(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music.return_value = {"status": "generating"}
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "on", "--name", "new track"])
+
+        assert result.exit_code == 0
+        assert "Music on" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_play_basic(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_play.return_value = {
+            "status": "playing",
+            "name": "chill_vibes",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "play", "chill vibes"])
+
+        assert result.exit_code == 0
+        mock_instance.music_play.assert_called_once_with("chill vibes")
+        assert "Playing" in result.output
+        assert "chill_vibes" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_play_connection_error(self, mock_client_cls: MagicMock) -> None:
+        from punt_vox.client import VoxdConnectionError
+
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_play.side_effect = VoxdConnectionError("not running")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "play", "test"])
+
+        assert result.exit_code == 1
+        assert "not running" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_play_not_found(self, mock_client_cls: MagicMock) -> None:
+        from punt_vox.client import VoxdProtocolError
+
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_play.side_effect = VoxdProtocolError(
+            "track not found: bogus"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "play", "bogus"])
+
+        assert result.exit_code == 1
+        assert "track not found" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_list_with_tracks(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_list.return_value = {
+            "tracks": [
+                {"name": "alpha", "size_bytes": 2048, "modified": 1000.0, "path": "/x"},
+                {"name": "beta", "size_bytes": 4096, "modified": 2000.0, "path": "/y"},
+            ],
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "list"])
+
+        assert result.exit_code == 0
+        assert "2 saved track(s)" in result.output
+        assert "alpha" in result.output
+        assert "beta" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_list_empty(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_list.return_value = {"tracks": []}
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "list"])
+
+        assert result.exit_code == 0
+        assert "No saved tracks" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_list_connection_error(self, mock_client_cls: MagicMock) -> None:
+        from punt_vox.client import VoxdConnectionError
+
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_list.side_effect = VoxdConnectionError("not running")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["music", "list"])
+
+        assert result.exit_code == 1
+        assert "not running" in result.output
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_list_json_output(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_list.return_value = {
+            "tracks": [
+                {"name": "alpha", "size_bytes": 2048, "modified": 1000.0, "path": "/x"},
+            ],
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--json", "music", "list"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert len(data["tracks"]) == 1
+
+    @patch(f"{_CLI}.VoxClientSync")
+    def test_music_play_json_output(self, mock_client_cls: MagicMock) -> None:
+        mock_instance = mock_client_cls.return_value
+        mock_instance.music_play.return_value = {
+            "status": "playing",
+            "name": "test_track",
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["--json", "music", "play", "test track"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["music"] == "play"
+        assert data["name"] == "test_track"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -926,3 +926,206 @@ class TestVoxClientSync:
         assert sent["vibe"] == "happy"
         assert sent["vibe_tags"] == "[warm]"
         assert sent["owner_id"] == "sess-1"
+
+
+class TestVoxClientMusicName:
+    """Test music() with name parameter."""
+
+    @pytest.mark.asyncio
+    async def test_music_on_with_name(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "n1", "status": "playing", "name": "focus"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = VoxClient(port=8421, token="tok")
+            result = await client.music("on", name="focus beats", owner_id="sess-x")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_on"
+        assert sent["name"] == "focus beats"
+        assert result["status"] == "playing"
+
+    @pytest.mark.asyncio
+    async def test_music_on_without_name_omits_field(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "n2", "status": "generating"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = VoxClient(port=8421, token="tok")
+            await client.music("on", owner_id="sess-y")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert "name" not in sent
+
+
+class TestVoxClientMusicPlay:
+    """Test music_play method."""
+
+    @pytest.mark.asyncio
+    async def test_music_play_sends_correct_message(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "type": "music_play",
+                    "id": "p1",
+                    "status": "playing",
+                    "name": "chill_vibes",
+                }
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = VoxClient(port=8421, token="tok")
+            result = await client.music_play("chill vibes", owner_id="sess-a")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_play"
+        assert sent["name"] == "chill vibes"
+        assert sent["owner_id"] == "sess-a"
+        assert result["status"] == "playing"
+
+    @pytest.mark.asyncio
+    async def test_music_play_error_raises(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "error", "id": "p2", "message": "track not found: bogus"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = VoxClient(port=8421, token="tok")
+            with pytest.raises(VoxdProtocolError, match="track not found"):
+                await client.music_play("bogus", owner_id="sess-b")
+
+    @pytest.mark.asyncio
+    async def test_music_play_uses_default_owner(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_play", "id": "p3", "status": "playing", "name": "test"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = VoxClient(port=8421, token="tok")
+            await client.music_play("test")
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["owner_id"]  # non-empty default
+
+
+class TestVoxClientMusicList:
+    """Test music_list method."""
+
+    @pytest.mark.asyncio
+    async def test_music_list_returns_tracks(self) -> None:
+        tracks = [
+            {"name": "alpha", "size_bytes": 1024, "modified": 1000.0, "path": "/x.mp3"}
+        ]
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_list", "id": "l1", "tracks": tracks}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            client = VoxClient(port=8421, token="tok")
+            result = await client.music_list()
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_list"
+        assert len(result["tracks"]) == 1
+
+
+class TestVoxClientSyncMusicPlayList:
+    """Sync wrappers for music_play and music_list."""
+
+    def test_music_play(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_play", "id": "sp1", "status": "playing", "name": "x"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            sync_client = VoxClientSync(port=8421, token="tok")
+            result = sync_client.music_play("x", owner_id="sess-s")
+            assert result["status"] == "playing"
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "music_play"
+
+    def test_music_list(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "music_list", "id": "sl1", "tracks": []})
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            sync_client = VoxClientSync(port=8421, token="tok")
+            result = sync_client.music_list()
+            assert result["tracks"] == []
+
+    def test_music_on_with_name(self) -> None:
+        mock_ws = _make_mock_ws()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {"type": "music_on", "id": "sn1", "status": "playing", "name": "x"}
+            )
+        )
+
+        with patch(
+            "punt_vox.client.websockets.asyncio.client.connect",
+            new_callable=AsyncMock,
+            return_value=mock_ws,
+        ):
+            sync_client = VoxClientSync(port=8421, token="tok")
+            result = sync_client.music("on", name="x", owner_id="sess-t")
+            assert result["status"] == "playing"
+
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["name"] == "x"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,8 @@ from punt_vox.resolve import (
 from punt_vox.server import (
     SessionState,
     music,
+    music_list,
+    music_play,
     notify,
     record,
     speak,
@@ -981,6 +983,7 @@ class TestMusicTool:
             vibe="focused",
             vibe_tags="[calm]",
             owner_id=srv._state.session_id,
+            name=None,
         )
 
     def test_music_on_style_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1215,3 +1218,172 @@ class TestVibeToolMusicPropagation:
         assert result["vibe"]["vibe"] == "sad"
         # But music_mode should be reset.
         assert srv._state.music_mode == "off"
+
+
+# ---------------------------------------------------------------------------
+# music tool — name parameter tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusicToolName:
+    """Tests for the music MCP tool with name parameter."""
+
+    def test_music_on_with_name_replay(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replay message when status is 'playing' and name is given."""
+        import punt_vox.server as srv
+
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "n1",
+            "status": "playing",
+            "name": "focus_beats",
+            "track": "/home/x/music/focus_beats.mp3",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on", name="focus beats"))
+
+        assert result["message"] == "\u266a Playing saved track: focus beats"
+        assert result["status"] == "playing"
+        assert srv._state.music_mode == "on"
+        mock_client.music.assert_called_once()
+        call_kwargs = mock_client.music.call_args[1]
+        assert call_kwargs["name"] == "focus beats"
+
+    def test_music_on_with_name_generates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Generate message when name given but track not found."""
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "n2",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on", name="new track"))
+
+        # No replay — falls through to normal on message.
+        assert "\u266a Music on" in result["message"]
+        assert result["status"] == "generating"
+
+    def test_music_on_name_none_not_sent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When name is None, it is passed as None to client."""
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "n3",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        music(mode="on")
+
+        call_kwargs = mock_client.music.call_args[1]
+        assert call_kwargs["name"] is None
+
+
+# ---------------------------------------------------------------------------
+# music_play tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusicPlayTool:
+    """Tests for the music_play MCP tool."""
+
+    def test_play_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import punt_vox.server as srv
+
+        mock_client = MagicMock()
+        mock_client.music_play.return_value = {
+            "type": "music_play",
+            "id": "p1",
+            "status": "playing",
+            "name": "chill_vibes",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music_play(name="chill vibes"))
+
+        assert result["message"] == "\u266a Now playing: chill_vibes"
+        assert result["status"] == "playing"
+        assert srv._state.music_mode == "on"
+        mock_client.music_play.assert_called_once_with(
+            "chill vibes", owner_id=srv._state.session_id
+        )
+
+    def test_play_connection_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from punt_vox.client import VoxdConnectionError
+
+        mock_client = MagicMock()
+        mock_client.music_play.side_effect = VoxdConnectionError("not running")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music_play(name="test"))
+
+        assert result["error"] == "daemon unreachable"
+
+    def test_play_protocol_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from punt_vox.client import VoxdProtocolError
+
+        mock_client = MagicMock()
+        mock_client.music_play.side_effect = VoxdProtocolError("track not found")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music_play(name="bogus"))
+
+        assert "track not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# music_list tool tests
+# ---------------------------------------------------------------------------
+
+
+class TestMusicListTool:
+    """Tests for the music_list MCP tool."""
+
+    def test_list_with_tracks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_client = MagicMock()
+        mock_client.music_list.return_value = {
+            "type": "music_list",
+            "id": "l1",
+            "tracks": [
+                {"name": "alpha", "size_bytes": 2048, "modified": 1000.0, "path": "/x"},
+                {"name": "beta", "size_bytes": 4096, "modified": 2000.0, "path": "/y"},
+            ],
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music_list())
+
+        assert "\u266a 2 saved track(s):" in result["message"]
+        assert "\u266a alpha" in result["message"]
+        assert "\u266a beta" in result["message"]
+        assert len(result["tracks"]) == 2
+
+    def test_list_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_client = MagicMock()
+        mock_client.music_list.return_value = {
+            "type": "music_list",
+            "id": "l2",
+            "tracks": [],
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music_list())
+
+        assert result["message"] == "\u266a No saved tracks."
+
+    def test_list_connection_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from punt_vox.client import VoxdConnectionError
+
+        mock_client = MagicMock()
+        mock_client.music_list.side_effect = VoxdConnectionError("not running")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music_list())
+
+        assert result["error"] == "daemon unreachable"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1362,6 +1362,10 @@ class TestMusicListTool:
         assert "\u266a 2 saved track(s):" in result["message"]
         assert "\u266a alpha" in result["message"]
         assert "\u266a beta" in result["message"]
+        # Dates are included in YYYY-MM-DD HH:MM format.
+        import re
+
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", result["message"])
         assert len(result["tracks"]) == 2
 
     def test_list_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -951,7 +951,9 @@ class TestSessionState:
 class TestMusicTool:
     """Tests for the music MCP tool."""
 
-    def test_music_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_music_on_with_style_and_vibe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import punt_vox.server as srv
 
         srv._state.vibe = "focused"
@@ -967,6 +969,10 @@ class TestMusicTool:
 
         result = json.loads(music(mode="on", style="techno"))
 
+        expected = (
+            "\u266a Music on \u2014 generating a techno track for your focused mood..."
+        )
+        assert result["message"] == expected
         assert result["status"] == "generating"
         assert srv._state.music_mode == "on"
         mock_client.music.assert_called_once_with(
@@ -976,6 +982,56 @@ class TestMusicTool:
             vibe_tags="[calm]",
             owner_id=srv._state.session_id,
         )
+
+    def test_music_on_style_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Style present, no vibe."""
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on", style="jazz"))
+
+        expected = "\u266a Music on \u2014 generating a jazz track..."
+        assert result["message"] == expected
+
+    def test_music_on_vibe_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Vibe present, no style."""
+        import punt_vox.server as srv
+
+        srv._state.vibe = "chill"
+
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on"))
+
+        expected = "\u266a Music on \u2014 generating a track for your chill mood..."
+        assert result["message"] == expected
+
+    def test_music_on_neither_style_nor_vibe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No style, no vibe -- ambient fallback."""
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        result = json.loads(music(mode="on"))
+
+        assert result["message"] == "\u266a Music on \u2014 generating ambient music..."
 
     def test_music_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import punt_vox.server as srv
@@ -992,6 +1048,7 @@ class TestMusicTool:
 
         result = json.loads(music(mode="off"))
 
+        assert result["message"] == "\u266a Music off."
         assert result["status"] == "stopped"
         assert srv._state.music_mode == "off"
 
@@ -999,7 +1056,9 @@ class TestMusicTool:
         result = json.loads(music(mode="pause"))
         assert "error" in result
 
-    def test_music_on_no_vibe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_music_on_no_vibe_sends_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """When vibe is None, empty strings are sent to voxd."""
         import punt_vox.server as srv
 
@@ -1018,7 +1077,9 @@ class TestMusicTool:
         assert call_kwargs["vibe_tags"] == ""
         assert srv._state.music_mode == "on"
 
-    def test_music_on_no_style(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_music_on_no_style_sends_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """When style is None, empty string is sent."""
         mock_client = MagicMock()
         mock_client.music.return_value = {
@@ -1033,7 +1094,7 @@ class TestMusicTool:
         call_kwargs = mock_client.music.call_args[1]
         assert call_kwargs["style"] == ""
 
-    def test_music_connection_error_resets_mode(
+    def test_music_connection_error_daemon_unreachable(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         import punt_vox.server as srv
@@ -1047,10 +1108,11 @@ class TestMusicTool:
 
         result = json.loads(music(mode="on"))
 
-        assert "error" in result
+        assert result["message"] == "\u266a Daemon unreachable \u2014 music off."
+        assert result["error"] == "daemon unreachable"
         assert srv._state.music_mode == "off"
 
-    def test_music_protocol_error_resets_mode(
+    def test_music_protocol_error_with_message(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         import punt_vox.server as srv
@@ -1064,7 +1126,8 @@ class TestMusicTool:
 
         result = json.loads(music(mode="on"))
 
-        assert "error" in result
+        assert result["message"] == "\u266a Music error: bad response"
+        assert result["error"] == "bad response"
         assert srv._state.music_mode == "off"
 
 

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -3152,17 +3152,19 @@ class TestMusicLoopLostWakeup:
 
 
 class TestAutoTrackName:
-    """_auto_track_name derives vibe-style-HHMM patterns."""
+    """_auto_track_name derives vibe-style-YYYYMMDD-HHMM patterns."""
 
     def test_with_vibe_and_style(self) -> None:
         ctx = _make_ctx()
         ctx.music_vibe = ("happy", "[warm]")
         ctx.music_style = "techno"
         name = _auto_track_name(ctx)
-        # Name has vibe-style-HHMM structure.
+        # Name has vibe-style-YYYYMMDD-HHMM structure.
         assert name.startswith("happy-techno-")
-        # HHMM suffix is 4 digits.
-        assert len(name.split("-")[-1]) == 4
+        # Suffix is YYYYMMDD-HHMM: 8 digits, dash, 4 digits.
+        parts = name.split("-")
+        assert len(parts[-2]) == 8  # YYYYMMDD
+        assert len(parts[-1]) == 4  # HHMM
 
     def test_no_vibe_uses_ambient(self) -> None:
         ctx = _make_ctx()
@@ -3185,6 +3187,10 @@ class TestDaemonContextTrackName:
     def test_default(self) -> None:
         ctx = _make_ctx()
         assert ctx.music_track_name == ""
+
+    def test_music_replay_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_replay is False
 
 
 class TestHandleMusicOnWithName:
@@ -3215,6 +3221,7 @@ class TestHandleMusicOnWithName:
         assert ctx.music_track == track
         assert ctx.music_track_name == "my_focus"
         assert ctx.music_state == "playing"
+        assert ctx.music_replay is True
 
         resp = ws.send_json.call_args[0][0]
         assert resp["status"] == "playing"
@@ -3264,6 +3271,25 @@ class TestHandleMusicOnWithName:
         assert ctx.music_track_name == ""
         assert ctx.music_state == "generating"
 
+    def test_empty_slugified_name_returns_error(self) -> None:
+        """Name that slugifies to empty string returns error."""
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        msg: dict[str, object] = {
+            "type": "music_on",
+            "id": "req-bad-name",
+            "owner_id": "session-q",
+            "name": "---",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "error"
+        assert "invalid track name" in resp["message"]
+        assert ctx.music_mode == "off"
+
 
 class TestHandleMusicPlay:
     """_handle_music_play: replay saved tracks by name."""
@@ -3291,6 +3317,7 @@ class TestHandleMusicPlay:
         assert ctx.music_track == track
         assert ctx.music_track_name == "chill_vibes"
         assert ctx.music_state == "playing"
+        assert ctx.music_replay is True
 
         resp = ws.send_json.call_args[0][0]
         assert resp["type"] == "music_play"
@@ -3349,6 +3376,24 @@ class TestHandleMusicPlay:
         resp = ws.send_json.call_args[0][0]
         assert resp["type"] == "error"
         assert "owner_id is required" in resp["message"]
+
+    def test_empty_slugified_name_returns_error(self) -> None:
+        """Name that slugifies to empty string returns error."""
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        msg: dict[str, object] = {
+            "type": "music_play",
+            "id": "play-bad",
+            "name": "---",
+            "owner_id": "session-q",
+        }
+
+        asyncio.run(_handle_music_play(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "error"
+        assert "invalid track name" in resp["message"]
 
 
 class TestHandleMusicList:

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -22,9 +22,12 @@ from punt_vox.voxd import (
     OnceDedup,
     PlaybackItem,
     _apply_vibe_for_synthesis,
+    _auto_track_name,
     _config_dir,
+    _handle_music_list,
     _handle_music_off,
     _handle_music_on,
+    _handle_music_play,
     _handle_music_vibe,
     _handle_synthesize,
     _health_payload_full,
@@ -3146,3 +3149,280 @@ class TestMusicLoopLostWakeup:
         assert generation_happened, (
             "music_loop blocked on wait despite music_mode=='on'"
         )
+
+
+class TestAutoTrackName:
+    """_auto_track_name derives vibe-style-HHMM patterns."""
+
+    def test_with_vibe_and_style(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_vibe = ("happy", "[warm]")
+        ctx.music_style = "techno"
+        name = _auto_track_name(ctx)
+        # Name has vibe-style-HHMM structure.
+        assert name.startswith("happy-techno-")
+        # HHMM suffix is 4 digits.
+        assert len(name.split("-")[-1]) == 4
+
+    def test_no_vibe_uses_ambient(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_vibe = ("", "")
+        ctx.music_style = ""
+        name = _auto_track_name(ctx)
+        assert name.startswith("ambient-mix-")
+
+    def test_no_style_uses_mix(self) -> None:
+        ctx = _make_ctx()
+        ctx.music_vibe = ("chill", "")
+        ctx.music_style = ""
+        name = _auto_track_name(ctx)
+        assert name.startswith("chill-mix-")
+
+
+class TestDaemonContextTrackName:
+    """DaemonContext.music_track_name defaults to empty string."""
+
+    def test_default(self) -> None:
+        ctx = _make_ctx()
+        assert ctx.music_track_name == ""
+
+
+class TestHandleMusicOnWithName:
+    """_handle_music_on with name field for track naming and replay."""
+
+    def test_replay_existing_track(self, tmp_path: Path) -> None:
+        """When name matches an existing file, replay without generation."""
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        # Create a fake track on disk.
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        track = music_dir / "my_focus.mp3"
+        track.write_bytes(b"fake-music")
+
+        msg: dict[str, object] = {
+            "type": "music_on",
+            "id": "req-name-1",
+            "owner_id": "session-x",
+            "name": "my focus",
+        }
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        assert ctx.music_mode == "on"
+        assert ctx.music_track == track
+        assert ctx.music_track_name == "my_focus"
+        assert ctx.music_state == "playing"
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["status"] == "playing"
+        assert resp["name"] == "my_focus"
+        assert str(track) in resp["track"]
+
+    def test_name_not_found_generates(self, tmp_path: Path) -> None:
+        """When name does not match existing file, proceed to generation."""
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        # No file exists for "new-track".
+
+        msg: dict[str, object] = {
+            "type": "music_on",
+            "id": "req-name-2",
+            "owner_id": "session-y",
+            "name": "new track",
+        }
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        assert ctx.music_mode == "on"
+        assert ctx.music_track_name == "new_track"
+        assert ctx.music_state == "generating"
+        assert ctx.music_changed.is_set()
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["status"] == "generating"
+
+    def test_no_name_clears_track_name(self) -> None:
+        """When no name is given, track_name is empty (auto-naming in generation)."""
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        msg: dict[str, object] = {
+            "type": "music_on",
+            "id": "req-no-name",
+            "owner_id": "session-z",
+        }
+
+        asyncio.run(_handle_music_on(msg, ws, ctx))
+
+        assert ctx.music_track_name == ""
+        assert ctx.music_state == "generating"
+
+
+class TestHandleMusicPlay:
+    """_handle_music_play: replay saved tracks by name."""
+
+    def test_play_existing_track(self, tmp_path: Path) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        track = music_dir / "chill_vibes.mp3"
+        track.write_bytes(b"fake-music")
+
+        msg: dict[str, object] = {
+            "type": "music_play",
+            "id": "play-1",
+            "name": "chill vibes",
+            "owner_id": "session-a",
+        }
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_play(msg, ws, ctx))
+
+        assert ctx.music_mode == "on"
+        assert ctx.music_track == track
+        assert ctx.music_track_name == "chill_vibes"
+        assert ctx.music_state == "playing"
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "music_play"
+        assert resp["status"] == "playing"
+        assert resp["name"] == "chill_vibes"
+
+    def test_play_not_found(self, tmp_path: Path) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+
+        msg: dict[str, object] = {
+            "type": "music_play",
+            "id": "play-2",
+            "name": "nonexistent",
+            "owner_id": "session-b",
+        }
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_play(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "error"
+        assert "not found" in resp["message"]
+
+    def test_play_missing_name(self) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        msg: dict[str, object] = {
+            "type": "music_play",
+            "id": "play-3",
+            "owner_id": "session-c",
+        }
+
+        asyncio.run(_handle_music_play(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "error"
+        assert "name is required" in resp["message"]
+
+    def test_play_missing_owner_id(self) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        msg: dict[str, object] = {
+            "type": "music_play",
+            "id": "play-4",
+            "name": "test",
+        }
+
+        asyncio.run(_handle_music_play(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "error"
+        assert "owner_id is required" in resp["message"]
+
+
+class TestHandleMusicList:
+    """_handle_music_list: returns saved tracks with metadata."""
+
+    def test_list_empty_dir(self, tmp_path: Path) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+
+        msg: dict[str, object] = {"type": "music_list", "id": "list-1"}
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_list(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "music_list"
+        assert resp["tracks"] == []
+
+    def test_list_with_tracks(self, tmp_path: Path) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        music_dir = tmp_path / "music"
+        music_dir.mkdir()
+        (music_dir / "alpha.mp3").write_bytes(b"a" * 1024)
+        (music_dir / "beta.mp3").write_bytes(b"b" * 2048)
+
+        msg: dict[str, object] = {"type": "music_list", "id": "list-2"}
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_list(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "music_list"
+        assert len(resp["tracks"]) == 2
+        names = [t["name"] for t in resp["tracks"]]
+        assert "alpha" in names
+        assert "beta" in names
+        # Each track has required metadata fields.
+        for t in resp["tracks"]:
+            assert "size_bytes" in t
+            assert "modified" in t
+            assert "path" in t
+
+    def test_list_nonexistent_dir(self, tmp_path: Path) -> None:
+        ctx = _make_ctx()
+        ws = AsyncMock()
+
+        music_dir = tmp_path / "music_missing"
+
+        msg: dict[str, object] = {"type": "music_list", "id": "list-3"}
+
+        with patch("punt_vox.voxd._music_output_dir", return_value=music_dir):
+            asyncio.run(_handle_music_list(msg, ws, ctx))
+
+        resp = ws.send_json.call_args[0][0]
+        assert resp["type"] == "music_list"
+        assert resp["tracks"] == []
+
+
+class TestHandlerRegistration:
+    """New handlers are registered in _HANDLERS."""
+
+    def test_music_play_registered(self) -> None:
+        from punt_vox.voxd import _HANDLERS
+
+        assert "music_play" in _HANDLERS
+        assert _HANDLERS["music_play"] is _handle_music_play
+
+    def test_music_list_registered(self) -> None:
+        from punt_vox.voxd import _HANDLERS
+
+        assert "music_list" in _HANDLERS
+        assert _HANDLERS["music_list"] is _handle_music_list


### PR DESCRIPTION
## Summary

Two music enhancements bundled:

### vox-kkf — Formatted output
Music tool returns ♪-prefixed personality-consistent messages instead of raw JSON. Matches the style of unmute/vibe/status tools.

### vox-vaa — Track naming and library
- **Auto-naming**: tracks named `vibe-style-HHMM` (e.g. `happy-techno-1118`)
- **User-provided name**: `/music on --name late-night-flow` saves as `late-night-flow.mp3`
- **Replay**: `/music play late-night-flow` loops a saved track instantly (zero credits)
- **Library**: `/music list` shows saved tracks with name, size, and date

## New surface

```
/music on [style ...] [--name ...]   — generate and loop (or replay if name exists)
/music off                            — stop
/music play <name>                    — replay a saved track
/music list                           — show saved tracks
```

## Files changed

| Layer | Files |
|-------|-------|
| Daemon | voxd.py — DaemonContext.music_track_name, _auto_track_name, _handle_music_play, _handle_music_list |
| Client | client.py — music(name=), music_play(), music_list() + sync wrappers |
| MCP | server.py — formatted output, music_play/music_list tools, name param |
| CLI | __main__.py — music play, music list subcommands, --name flag |
| Command | commands/music.md — updated docs |
| Tests | +806 lines across test_voxd, test_client, test_server, test_cli |

## Missions

- m-2026-04-12-001 (vox-kkf): pass 0.97, worker rmh, evaluator mdm
- m-2026-04-12-002 (vox-vaa): pass 0.95, worker rmh, evaluator mdm

## Test plan

- [x] `make check` green — 1294 tests (+44 new)
- [ ] CI green
- [ ] Copilot review clean
- [ ] Bugbot review clean

Closes vox-kkf, vox-vaa.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new music-related WebSocket/MCP/CLI surfaces and changes voxd music loop behavior to support replay and persistent track naming, which could affect playback state handling. Also adds filesystem-based listing/replay of MP3s, so edge cases around naming/metadata and existing installations should be verified.
> 
> **Overview**
> Expands the `/music` feature to support **named tracks and a saved library**: `/music on --name ...` saves generated audio under a stable name (or replays an existing file with zero generation), plus new `/music play <name>` and `/music list` commands/tools.
> 
> Updates the full stack (CLI, `VoxClient`, MCP server, and `voxd`) with new `music_play`/`music_list` message types and a `name` parameter on `music_on`, including auto-naming (`vibe-style-YYYYMMDD-HHMM`), replay-aware state in the daemon loop, and more user-friendly `message` fields in MCP JSON responses. Tests and `/music` docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b16242ebbdeacf42ad6ad548408531362408c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->