### PR TITLE
fix(voxd): scale playback timeout to audio duration (vox-ddf)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1392,3 +1392,55 @@ If a user runs `sudo vox daemon install` out of habit, the three wrong things ha
 ### Why This Deletes More Code Than It Adds
 
 The initial refactor commit shipped -443 net lines across 10 files. The deletions were all the defensive code that no longer has anything to defend: `_reject_symlinks`, `_chown_to_user`, `_user_keys_env_file_for`, `_user_state_dir_for`, `_installing_user`, the `target_uid`/`target_gid` parameters of `_write_keys_env`, the `_open_new`/`_open_existing`/`O_NOFOLLOW`/`O_EXCL`/`fstat`/`fchown` dance, the `SUDO_USER` environment lookup, the parent-symlink check, the `os.lchown` calls in `_ensure_user_dirs`, and every test that exercised those code paths. The only defensive code that survived is the control-character validation in `_write_keys_env` (rejecting `\n`/`\r`/`\x00` in env values) — that is input sanitization, not a privilege defense, and applies equally when the process runs as the user.
+
+## DES-030: Music Playback — Separate Subprocess at Reduced Volume
+
+**Status:** SETTLED
+
+### Problem
+
+Music tracks loop for minutes. The existing `_playback_consumer` queue and `_playback_mutex` handle short audio (chimes, TTS) with a 30-second timeout. If music used the same queue, it would hold the mutex for the entire track duration, blocking all chimes and speech.
+
+### Rejected Alternatives
+
+1. **SIGSTOP/SIGCONT** — pause the music subprocess when speech needs to play, resume after. POSIX-portable, but creates an unnatural silence gap. Users don't stop their music when someone talks to them; they turn it down.
+2. **PulseAudio/PipeWire dynamic ducking** — lower the music stream's volume via `pactl set-sink-input-volume` when speech fires. Correct UX, but requires runtime PulseAudio/PipeWire detection, stream identification, and volume state management. Complexity disproportionate to v1.
+3. **Shared playback queue with long timeout** — raise the timeout to 5 minutes. Simple, but blocks all TTS for the entire track duration since `_playback_mutex` is held.
+
+### Decision
+
+Music plays via its own ffplay subprocess at `-volume 30` (Linux) / `--volume 0.3` (macOS), completely outside the existing playback queue. Speech and chimes play at full volume through the normal queue and overlay on top. No pausing, no ducking, no mutex contention. The volume differential makes speech intelligible over the background music without any runtime coordination. Dynamic ducking via PulseAudio is a future enhancement.
+
+## DES-031: Music Session Ownership Model
+
+**Status:** SETTLED
+
+### Problem
+
+voxd is shared across all Claude Code sessions and CLI users. Music is daemon-wide (one set of speakers, one music loop). When multiple sessions are active, which session's vibe drives the music?
+
+### Rejected Alternatives
+
+1. **Last-active session wins** — whichever session most recently changed its vibe sends that to voxd. Simple, but jarring: switching terminals flips the music based on which one you last typed in.
+2. **Music has its own vibe, independent of per-repo vibe** — `/music on style techno` sets a music-specific mood on voxd. Per-repo `/vibe` stays separate. Simplest to implement but loses the reactive-to-vibe behavior.
+
+### Decision
+
+The session that runs `/music on` **owns** the music. That session's vibe drives the music prompt. Other sessions' vibe changes do not affect the music. Ownership transfers when another session explicitly runs `/music on` (which claims it) or `/music off` (which stops it). Each MCP server generates a `session_id` (UUID) at startup, sent as `owner_id` with every music message. voxd rejects `music_vibe` messages from non-owning sessions.
+
+## DES-032: Duration-Proportional Playback Timeout
+
+**Status:** SETTLED
+
+### Problem
+
+`_PLAYBACK_TIMEOUT_S = 30.0` was a fixed constant that killed ffplay after 30 seconds. Set when vox only played short chimes and quips. A 480-character recap generates 34.3 seconds of speech at ElevenLabs default rate — the timeout fires at 87%, cutting mid-word. Any TTS over ~450 characters is silently truncated.
+
+### Rejected Alternatives
+
+1. **Raise the fixed timeout to 120s** — simple, but leaves a hard ceiling that longer content will eventually hit again. Also means a stuck ffplay process takes 2 minutes to detect instead of 30 seconds.
+2. **No timeout** — removes the safety net for hung processes entirely. A single stuck ffplay would block the playback queue permanently.
+
+### Decision
+
+Probe the file duration via `ffprobe -v quiet -show_entries format=duration` before spawning the player. Set timeout to `max(duration + 10s, 30s)`. A 34s file gets 44s. A 2-minute file gets 130s. Short files keep the 30s floor. Probe failure degrades gracefully to the 30s default. The probe runs in <10ms for local files and adds negligible latency.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1444,3 +1444,54 @@ The session that runs `/music on` **owns** the music. That session's vibe drives
 ### Decision
 
 Probe the file duration via `ffprobe -v quiet -show_entries format=duration` before spawning the player. Set timeout to `max(duration + 10s, 30s)`. A 34s file gets 44s. A 2-minute file gets 130s. Short files keep the 30s floor. Probe failure degrades gracefully to the 30s default. The probe runs in <10ms for local files and adds negligible latency.
+
+## DES-033: Gapless Music Handoff on Vibe Change
+
+**Status:** SETTLED
+
+### Problem
+
+When the session vibe changes while music is playing, a new track must be generated (~10-30s). The naive approach — kill the old track, generate, play the new one — creates an audible silence gap during generation.
+
+### Rejected Alternatives
+
+1. **Kill immediately, accept the silence** — the first implementation (PR #194 commit ae79d9f). Simple but produces 10-30s of dead air every time the vibe changes. Users expect continuous background music.
+2. **Break out of the playback loop, generate, then restart** — old track finishes its current iteration but doesn't re-loop during generation. If generation takes longer than the remaining track duration, silence returns. Also orphans the ffplay subprocess (Bugbot caught this).
+3. **Pre-generate the next track speculatively** — generate a track for every possible vibe in advance. Wastes credits on tracks that may never play.
+
+### Decision
+
+Run generation as a concurrent `asyncio.Task` while the playback loop continues looping the old track. On each playback iteration, the loop races `proc.wait()`, `music_changed.wait()`, and the generation task. Handoff (kill old proc, switch to new track) happens only when the generation task completes. A second vibe change during generation cancels the in-flight task and starts a fresh one — old track keeps looping throughout. The old track plays continuously from the moment `/music on` fires until `/music off` or a new track is ready.
+
+## DES-034: Peer-Closed WebSocket — State Check vs Widened Exception
+
+**Status:** SETTLED
+
+### Problem
+
+After the vox-ehf fix in v4.3.0, chime/unmute clients return on the `"playing"` ack and close the WebSocket. The next `receive_text()` call raises `RuntimeError` (not `WebSocketDisconnect`), logging a full traceback on every chime.
+
+### Rejected Alternatives
+
+1. **Widen the except clause to `(WebSocketDisconnect, RuntimeError)`** — the initial fix (PR #185 commit a191a3c). Correct for the specific case, but catches *any* RuntimeError in the handler chain. Copilot flagged it: a future handler raising RuntimeError for a real bug would be silently swallowed. The widened surface was unnecessarily broad for a fix that only needed to handle the disconnect state.
+
+### Decision
+
+Check `websocket.application_state != WebSocketState.CONNECTED` at the top of the receive loop, before `receive_text()` is called. If disconnected, `break` cleanly. The outer `except` clause stays narrow (`WebSocketDisconnect` only). A genuine `RuntimeError` from a handler still surfaces as an ERROR log. Two complementary tests document the narrowing guarantee: one verifies the state check preempts a disconnected-socket error, the other verifies an unexpected RuntimeError still logs as an error.
+
+## DES-035: Track Naming and Zero-Credit Replay
+
+**Status:** SETTLED
+
+### Problem
+
+Generated music tracks are saved to `~/vox-output/music/` but only identifiable by timestamped filenames. Users can't find a track they liked, can't replay it without regenerating (burning credits), and can't build a personal library.
+
+### Rejected Alternatives
+
+1. **Hash-based naming** — name tracks by content hash (MD5/SHA256 of the audio). Unique and collision-free, but human-unreadable. A user can't find "that techno track from Tuesday" by scanning filenames.
+2. **No replay — always regenerate** — simplest implementation, but ElevenLabs generation is non-deterministic (same prompt produces different tracks). A track the user liked is gone forever once the loop moves on. Also wastes ~2000 credits per replay.
+
+### Decision
+
+Auto-name tracks as `{vibe}-{style}-{YYYYMMDD-HHMM}` (e.g. `happy-techno-20260412-1118`). Users can provide custom names via `/music on --name late-night-flow`. When a name matches an existing file in `~/vox-output/music/`, skip generation entirely and loop the saved track — zero credits, instant playback. `/music play <name>` replays any saved track. `/music list` shows the library with name, size, and date. The `music_replay` flag in `DaemonContext` tells `MusicLoop` to skip generation and go straight to the playback loop.

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -496,6 +496,7 @@ async def _probe_duration(path: Path) -> float | None:
         "csv=p=0",
         str(path),
     ]
+    proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -507,9 +508,10 @@ async def _probe_duration(path: Path) -> float | None:
             proc.communicate(), timeout=_PROBE_TIMEOUT_S
         )
     except TimeoutError:
-        proc.kill()
-        with contextlib.suppress(Exception):
-            await proc.wait()
+        if proc is not None:
+            proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
         return None
     except (FileNotFoundError, OSError):
         return None

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -511,7 +511,8 @@ async def _probe_duration(path: Path) -> float | None:
         )
     except TimeoutError:
         if proc is not None:
-            proc.kill()
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
             with contextlib.suppress(Exception):
                 await proc.wait()
         return None

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -380,7 +380,8 @@ _AUDIO_ENV_KEYS: tuple[str, ...] = (
 # Playback under 50ms is a "success" that almost certainly played nothing.
 _SUSPICIOUS_ELAPSED_S = 0.05
 
-_PLAYBACK_TIMEOUT_S = 30.0
+_PLAYBACK_TIMEOUT_DEFAULT_S = 30.0
+_PROBE_TIMEOUT_S = 5.0
 
 # Cap on the stderr blob we keep per playback. ffplay without -loglevel
 # quiet can emit kilobytes of progress lines; we want enough for triage
@@ -479,6 +480,42 @@ def _record_playback_result(
     }
 
 
+async def _probe_duration(path: Path) -> float | None:
+    """Return the duration in seconds of an audio file, or None on failure.
+
+    Uses ffprobe with a 5-second timeout. Returns None if ffprobe is not
+    installed, the file is unreadable, or the output is not a valid float.
+    """
+    cmd = [
+        "ffprobe",
+        "-v",
+        "quiet",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "csv=p=0",
+        str(path),
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout_bytes, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=_PROBE_TIMEOUT_S
+        )
+    except (FileNotFoundError, OSError, TimeoutError):
+        return None
+    try:
+        duration = float((stdout_bytes or b"").strip())
+    except ValueError:
+        return None
+    logger.debug("Probed duration for %s: %.3fs", path.name, duration)
+    return duration
+
+
 async def _play_audio(path: Path, ctx: DaemonContext) -> None:
     """Play an audio file and record a rich result in ``ctx.last_playback``.
 
@@ -509,11 +546,19 @@ async def _play_audio(path: Path, ctx: DaemonContext) -> None:
         )
         return
 
+    duration = await _probe_duration(path)
+    timeout = (
+        max(duration + 10.0, _PLAYBACK_TIMEOUT_DEFAULT_S)
+        if duration is not None
+        else _PLAYBACK_TIMEOUT_DEFAULT_S
+    )
+
     logger.info(
-        "Playback spawn: cmd=%s size=%d audio_env=%s",
+        "Playback spawn: cmd=%s size=%d audio_env=%s timeout=%.1fs",
         cmd,
         size,
         env_snapshot,
+        timeout,
     )
 
     start = _monotonic()
@@ -556,14 +601,12 @@ async def _play_audio(path: Path, ctx: DaemonContext) -> None:
         return
 
     try:
-        _, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=_PLAYBACK_TIMEOUT_S
-        )
+        _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except TimeoutError:
         elapsed = _monotonic() - start
         logger.error(
             "Playback FAILED: timed out after %.1fs for %s audio_env=%s",
-            _PLAYBACK_TIMEOUT_S,
+            timeout,
             path.name,
             env_snapshot,
         )
@@ -575,7 +618,7 @@ async def _play_audio(path: Path, ctx: DaemonContext) -> None:
             path=path,
             rc=-1,
             elapsed=elapsed,
-            stderr=f"timeout after {_PLAYBACK_TIMEOUT_S}s",
+            stderr=f"timeout after {timeout}s",
         )
         return
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -12,6 +12,7 @@ import base64
 import contextlib
 import hashlib
 import hmac
+import math
 import importlib.resources
 import json
 import logging
@@ -381,6 +382,7 @@ _AUDIO_ENV_KEYS: tuple[str, ...] = (
 _SUSPICIOUS_ELAPSED_S = 0.05
 
 _PLAYBACK_TIMEOUT_DEFAULT_S = 30.0
+_PLAYBACK_TIMEOUT_PADDING_S = 10.0
 _PROBE_TIMEOUT_S = 5.0
 
 # Cap on the stderr blob we keep per playback. ffplay without -loglevel
@@ -554,11 +556,10 @@ async def _play_audio(path: Path, ctx: DaemonContext) -> None:
         return
 
     duration = await _probe_duration(path)
-    timeout = (
-        max(duration + 10.0, _PLAYBACK_TIMEOUT_DEFAULT_S)
-        if duration is not None
-        else _PLAYBACK_TIMEOUT_DEFAULT_S
-    )
+    if duration is not None and math.isfinite(duration) and duration > 0:
+        timeout = max(duration + _PLAYBACK_TIMEOUT_PADDING_S, _PLAYBACK_TIMEOUT_DEFAULT_S)
+    else:
+        timeout = _PLAYBACK_TIMEOUT_DEFAULT_S
 
     logger.info(
         "Playback spawn: cmd=%s size=%d audio_env=%s timeout=%.1fs",
@@ -625,7 +626,7 @@ async def _play_audio(path: Path, ctx: DaemonContext) -> None:
             path=path,
             rc=-1,
             elapsed=elapsed,
-            stderr=f"timeout after {timeout}s",
+            stderr=f"timeout after {timeout:.1f}s",
         )
         return
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -557,7 +557,10 @@ async def _play_audio(path: Path, ctx: DaemonContext) -> None:
 
     duration = await _probe_duration(path)
     if duration is not None and math.isfinite(duration) and duration > 0:
-        timeout = max(duration + _PLAYBACK_TIMEOUT_PADDING_S, _PLAYBACK_TIMEOUT_DEFAULT_S)
+        timeout = max(
+            duration + _PLAYBACK_TIMEOUT_PADDING_S,
+            _PLAYBACK_TIMEOUT_DEFAULT_S,
+        )
     else:
         timeout = _PLAYBACK_TIMEOUT_DEFAULT_S
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -506,7 +506,12 @@ async def _probe_duration(path: Path) -> float | None:
         stdout_bytes, _ = await asyncio.wait_for(
             proc.communicate(), timeout=_PROBE_TIMEOUT_S
         )
-    except (FileNotFoundError, OSError, TimeoutError):
+    except TimeoutError:
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        return None
+    except (FileNotFoundError, OSError):
         return None
     try:
         duration = float((stdout_bytes or b"").strip())

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -12,11 +12,11 @@ import base64
 import contextlib
 import hashlib
 import hmac
-import math
 import importlib.resources
 import json
 import logging
 import logging.config
+import math
 import os
 import platform
 import secrets

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -16,6 +16,7 @@ from conftest import _get_valid_mp3_bytes  # pyright: ignore[reportPrivateUsage]
 
 from punt_vox.paths import ensure_user_dirs
 from punt_vox.voxd import (
+    _PLAYBACK_TIMEOUT_DEFAULT_S,
     ChimeDedup,
     DaemonContext,
     DedupHit,
@@ -40,6 +41,7 @@ from punt_vox.voxd import (
     _music_loop,
     _music_player_command,
     _play_audio,
+    _probe_duration,
     _run_dir,
     _try_direct_play,
 )
@@ -168,6 +170,151 @@ class TestPlayAudioObservability:
         assert ctx.last_playback["rc"] == 0
         assert ctx.last_playback["elapsed_s"] == 0.5
         assert ctx.last_playback["file"] == str(audio)
+
+
+class TestProbeDuration:
+    """``_probe_duration`` extracts audio duration via ffprobe."""
+
+    def test_returns_duration_for_valid_audio(self, tmp_path: Path) -> None:
+        audio = tmp_path / "silence.mp3"
+        audio.write_bytes(_get_valid_mp3_bytes())
+        duration = asyncio.run(_probe_duration(audio))
+        assert duration is not None
+        assert duration > 0.0
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.mp3"
+        duration = asyncio.run(_probe_duration(missing))
+        assert duration is None
+
+    def test_returns_none_for_bad_format(self, tmp_path: Path) -> None:
+        bad = tmp_path / "garbage.mp3"
+        bad.write_bytes(b"not audio data at all")
+        duration = asyncio.run(_probe_duration(bad))
+        # ffprobe may return None or an error; either way, no crash
+        assert duration is None or isinstance(duration, float)
+
+    def test_returns_none_when_ffprobe_missing(self, tmp_path: Path) -> None:
+        audio = tmp_path / "silence.mp3"
+        audio.write_bytes(_get_valid_mp3_bytes())
+        with patch(
+            "punt_vox.voxd.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=FileNotFoundError("ffprobe")),
+        ):
+            duration = asyncio.run(_probe_duration(audio))
+        assert duration is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        audio = tmp_path / "silence.mp3"
+        audio.write_bytes(_get_valid_mp3_bytes())
+        proc = MagicMock()
+        proc.communicate = AsyncMock(side_effect=TimeoutError)
+        with patch(
+            "punt_vox.voxd.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            duration = asyncio.run(_probe_duration(audio))
+        assert duration is None
+
+    def test_logs_duration_at_debug(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        audio = tmp_path / "silence.mp3"
+        audio.write_bytes(_get_valid_mp3_bytes())
+        with caplog.at_level(logging.DEBUG, logger="punt_vox.voxd"):
+            duration = asyncio.run(_probe_duration(audio))
+        if duration is not None:
+            assert "Probed duration" in caplog.text
+
+
+class TestPlayAudioProportionalTimeout:
+    """``_play_audio`` uses probed duration for its timeout."""
+
+    def test_uses_probed_duration_for_timeout(self, tmp_path: Path) -> None:
+        """A 34s file gets timeout = max(34+10, 30) = 44s, not 30s."""
+        audio = tmp_path / "out.mp3"
+        audio.write_bytes(b"\xff\xfbfake mp3 body")
+        ctx = _make_ctx()
+        proc = _fake_proc(rc=0, stderr=b"")
+        ticks = iter([100.0, 100.5])
+
+        captured_timeout: list[float] = []
+        original_wait_for = asyncio.wait_for
+
+        async def spy_wait_for(coro: object, *, timeout: float) -> object:
+            captured_timeout.append(timeout)
+            return await original_wait_for(coro, timeout=timeout)  # type: ignore[arg-type]
+
+        with (
+            patch("punt_vox.voxd._probe_duration", AsyncMock(return_value=34.3)),
+            patch(
+                "punt_vox.voxd.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=proc),
+            ),
+            patch("punt_vox.voxd._monotonic", side_effect=lambda: next(ticks)),
+            patch("punt_vox.voxd.asyncio.wait_for", side_effect=spy_wait_for),
+        ):
+            asyncio.run(_play_audio(audio, ctx))
+
+        assert len(captured_timeout) == 1
+        assert captured_timeout[0] == pytest.approx(44.3, abs=0.1)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_falls_back_to_default_when_probe_fails(self, tmp_path: Path) -> None:
+        audio = tmp_path / "out.mp3"
+        audio.write_bytes(b"\xff\xfbfake mp3 body")
+        ctx = _make_ctx()
+        proc = _fake_proc(rc=0, stderr=b"")
+        ticks = iter([100.0, 100.5])
+
+        captured_timeout: list[float] = []
+        original_wait_for = asyncio.wait_for
+
+        async def spy_wait_for(coro: object, *, timeout: float) -> object:
+            captured_timeout.append(timeout)
+            return await original_wait_for(coro, timeout=timeout)  # type: ignore[arg-type]
+
+        with (
+            patch("punt_vox.voxd._probe_duration", AsyncMock(return_value=None)),
+            patch(
+                "punt_vox.voxd.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=proc),
+            ),
+            patch("punt_vox.voxd._monotonic", side_effect=lambda: next(ticks)),
+            patch("punt_vox.voxd.asyncio.wait_for", side_effect=spy_wait_for),
+        ):
+            asyncio.run(_play_audio(audio, ctx))
+
+        assert len(captured_timeout) == 1
+        assert captured_timeout[0] == _PLAYBACK_TIMEOUT_DEFAULT_S
+
+    def test_short_duration_uses_default_minimum(self, tmp_path: Path) -> None:
+        """A 5s file gets timeout = max(5+10, 30) = 30s (default wins)."""
+        audio = tmp_path / "out.mp3"
+        audio.write_bytes(b"\xff\xfbfake mp3 body")
+        ctx = _make_ctx()
+        proc = _fake_proc(rc=0, stderr=b"")
+        ticks = iter([100.0, 100.5])
+
+        captured_timeout: list[float] = []
+        original_wait_for = asyncio.wait_for
+
+        async def spy_wait_for(coro: object, *, timeout: float) -> object:
+            captured_timeout.append(timeout)
+            return await original_wait_for(coro, timeout=timeout)  # type: ignore[arg-type]
+
+        with (
+            patch("punt_vox.voxd._probe_duration", AsyncMock(return_value=5.0)),
+            patch(
+                "punt_vox.voxd.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=proc),
+            ),
+            patch("punt_vox.voxd._monotonic", side_effect=lambda: next(ticks)),
+            patch("punt_vox.voxd.asyncio.wait_for", side_effect=spy_wait_for),
+        ):
+            asyncio.run(_play_audio(audio, ctx))
+
+        assert len(captured_timeout) == 1
+        assert captured_timeout[0] == _PLAYBACK_TIMEOUT_DEFAULT_S
 
 
 class TestHealthPayloadFull:


### PR DESCRIPTION
P1 bug fix. The fixed 30s playback timeout was killing ffplay on any TTS over ~450 chars. A 480-char recap (34.3s audio) got cut at 87% through — mid-word on 'Smalltalk'. Now probes duration via ffprobe and sets timeout to max(duration + 10s, 30s). Closes vox-ddf.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core audio playback timing by adding an `ffprobe` subprocess and dynamic timeouts, which could affect playback reliability or hang behavior if probing/timeout handling is wrong. Scope is localized and covered by new unit tests, reducing regression risk.
> 
> **Overview**
> Fixes long TTS/audio being cut off by replacing the fixed 30s playback timeout with a duration-aware timeout (`max(duration + 10s, 30s)`) computed via a new `ffprobe`-based `_probe_duration` helper.
> 
> Adds logging of the computed timeout and introduces unit tests covering duration probing edge cases (missing `ffprobe`, invalid files, timeouts) and verifying `_play_audio` uses the proportional timeout with a safe fallback to the default. Documents the decision in `DESIGN.md` (DES-032).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3561d749fb9e70c6ebe466a1d1b662456332de02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->