### PR TITLE
feat: migrate .vox/ to .punt-labs/vox/ and ~/vox-output to ~/Music/vox/ (vox-4jk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ research/
 .entire/
 .vscode/
 
+# Per-repo vox session state (config, ephemeral audio)
+.punt-labs/vox/
+
 # LaTeX auxiliary files (prfaq.pdf is tracked, build artifacts are not)
 *.aux
 *.bbl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Directory migration from `.vox/` to `.punt-labs/vox/` (vox-4jk)**: per-repo config now lives at `.punt-labs/vox/config.md` (was `.vox/config.md`). Saved audio output defaults to `~/Music/vox/` (was `~/vox-output/`). Music tracks live at `~/Music/vox/tracks/` (was `~/vox-output/music/`). New `dirs.py` module centralizes all cross-platform path resolution. Auto-migration runs on `vox install` and `vox daemon install`; shell hooks check both paths during transition. `vox migrate-audio` command moves saved audio from `~/vox-output/` to `~/Music/vox/` with dry-run by default (`--execute` to move). `vox doctor` checks for legacy `.vox/` directory and `~/vox-output/` with remediation hints.
+
+### Changed
+
+- **Default output directory**: `default_output_dir()` now returns `~/Music/vox/` instead of `~/vox-output/`. `VOX_OUTPUT_DIR` env var override still works.
+
 ## [4.5.1] - 2026-04-11
 
 ## [4.5.0] - 2026-04-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Do NOT use missions for: exploratory research, work you do yourself, or epics th
 
 ### Workflow
 
+0. **Claim**: `bd update <id> --status=in_progress` and `biff plan "<bead-id>: <summary>"`. Both must be set before any work starts — other agents check `/who` to see what's active.
 1. **Scaffold**: `/mission` skill scaffolds the contract YAML from conversation context.
 2. **Confirm**: present the contract to the user (or decide as leader). Edit any field before creation.
-3. **Create**: `ethos mission create --file .tmp/missions/<name>.yaml` — returns a mission ID.
+3. **Create**: `ethos mission create --file .tmp/missions/<name>.yaml` — returns a mission ID. Update biff plan to include the mission ID.
 4. **Spawn**: `Agent(subagent_type=<worker>, run_in_background=true)` with a prompt that points at the mission ID. The worker reads the contract via `ethos mission show <id>` as its first action.
 5. **Track**: `ethos mission show <id>`, `ethos mission log <id>`, `ethos mission results <id>`.
 6. **Review**: read the result artifact. Pass → `ethos mission close <id>`. Continue → `ethos mission reflect <id> --file <path>` then `ethos mission advance <id>`. Fail → `ethos mission close <id> --status failed`.

--- a/hooks/acknowledge.sh
+++ b/hooks/acknowledge.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Buffer stdin so fallback still has data if daemon relay fails.
 _stdin=$(cat)

--- a/hooks/farewell.sh
+++ b/hooks/farewell.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Buffer stdin so fallback still has data if daemon relay fails.
 _stdin=$(cat)

--- a/hooks/notify-permission.sh
+++ b/hooks/notify-permission.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Buffer stdin so fallback still has data if daemon relay fails.
 _stdin=$(cat)

--- a/hooks/notify.sh
+++ b/hooks/notify.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Buffer stdin so fallback still has data if daemon relay fails.
 _stdin=$(cat)

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Buffer stdin so fallback still has data if daemon relay fails.
 _stdin=$(cat)

--- a/hooks/signal.sh
+++ b/hooks/signal.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Buffer stdin so fallback still has data if daemon relay fails.
 _stdin=$(cat)

--- a/hooks/subagent.sh
+++ b/hooks/subagent.sh
@@ -6,7 +6,7 @@ if _git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$_git
 else
   _repo_root="."
 fi
-[[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
+[[ -f "${_repo_root}/.punt-labs/vox/config.md" ]] || [[ -f "${_repo_root}/.vox/config.md" ]] || exit 0
 
 # Claude Code passes hook_event_name in JSON stdin, not as an env var.
 # Read stdin once and extract the event name with jq (or grep fallback).

--- a/install.sh
+++ b/install.sh
@@ -121,6 +121,41 @@ fi
 
 ok "$BINARY $(command -v "$BINARY")"
 
+# --- Step 4b: Migrate legacy .vox/ config ---
+_migrate_legacy_config() {
+  _mlc_repo_root="$1"
+  _mlc_legacy_dir="${_mlc_repo_root}/.vox"
+  _mlc_legacy_config="${_mlc_legacy_dir}/config.md"
+  _mlc_new_dir="${_mlc_repo_root}/.punt-labs/vox"
+  _mlc_new_config="${_mlc_new_dir}/config.md"
+
+  [ -f "$_mlc_legacy_config" ] || return 0
+  [ -L "$_mlc_legacy_dir" ] && { warn ".vox/ is a symlink, skipping migration"; return 0; }
+  [ -L "$_mlc_legacy_config" ] && { warn ".vox/config.md is a symlink, skipping migration"; return 0; }
+
+  if [ -e "${_mlc_repo_root}/.punt-labs" ] && [ ! -d "${_mlc_repo_root}/.punt-labs" ]; then
+    warn ".punt-labs exists but is not a directory, skipping migration"
+    return 0
+  fi
+
+  [ -f "$_mlc_new_config" ] && { ok "config already at .punt-labs/vox/"; return 0; }
+
+  mkdir -p "$_mlc_new_dir" || { warn "could not create $_mlc_new_dir"; return 0; }
+  mv "$_mlc_legacy_config" "$_mlc_new_config" || { warn "could not move config.md"; return 0; }
+  ok "migrated .vox/config.md -> .punt-labs/vox/config.md"
+
+  # Clean up ephemeral audio
+  rm -f "${_mlc_legacy_dir}"/*.mp3 2>/dev/null
+
+  # Remove .vox/ if empty
+  rmdir "$_mlc_legacy_dir" 2>/dev/null || warn ".vox/ not empty after migration (user files detected)"
+}
+
+if [ -f "${PWD}/.vox/config.md" ]; then
+  info "Checking for legacy .vox/ config..."
+  _migrate_legacy_config "$PWD"
+fi
+
 # --- Step 5: Install daemon ---
 
 info "Installing vox daemon (will prompt once for sudo when placing the system service)..."

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -1039,7 +1039,7 @@ def doctor() -> None:
 
     # Legacy .vox/ directory (vox-4jk migration)
     legacy_vox = Path.cwd() / ".vox"
-    if legacy_vox.is_dir():
+    if legacy_vox.is_dir() and not legacy_vox.is_symlink():
         if (legacy_vox / "config.md").exists():
             _check(
                 _FAIL,
@@ -1200,19 +1200,26 @@ def doctor() -> None:
             required=False,
         )
 
-    # Output directory
+    # Output directory — verify writability without creating it.
+    # The directory is created lazily on first 'vox record'.
     out_dir = default_output_dir()
-    try:
-        out_dir.mkdir(parents=True, exist_ok=True)
-        test_file = out_dir / ".doctor_test"
-        test_file.write_text("ok")
-        test_file.unlink()
-        _check(_PASS, f"Output directory: {out_dir}")
-    except OSError as e:
+    if out_dir.is_dir():
+        try:
+            test_file = out_dir / ".doctor_test"
+            test_file.write_text("ok")
+            test_file.unlink()
+            _check(_PASS, f"Output directory: {out_dir}")
+        except OSError as e:
+            _check(
+                _FAIL,
+                f"Output directory: {out_dir} ({e})"
+                " \u2014 check permissions or use --output-dir",
+            )
+    else:
         _check(
-            _FAIL,
-            f"Output directory: {out_dir} ({e})"
-            " \u2014 check permissions or use --output-dir",
+            _WARN,
+            f"Output directory: {out_dir} does not exist"
+            " \u2014 will be created on first 'vox record'",
         )
 
     summary = f"{passed} passed, {failed} failed"
@@ -1260,6 +1267,10 @@ def migrate_audio_cmd(
         typer.echo("Nothing to migrate: source directory does not exist.")
         return
 
+    if not src_dir.is_dir():
+        typer.echo(f"Source is not a directory: {src_dir}")
+        raise typer.Exit(code=1)
+
     # Build list of (src_path, dst_path) pairs.
     pairs: list[tuple[Path, Path]] = []
     conflicts: list[tuple[Path, Path]] = []
@@ -1275,11 +1286,19 @@ def migrate_audio_cmd(
         if parts and parts[0] == "music":
             rel = Path("tracks", *parts[1:])
         dst_file = dst_dir / rel
-        total_size += src_file.stat().st_size
+        try:
+            total_size += src_file.stat().st_size
+        except OSError as e:
+            skipped.append((src_file, f"unreadable ({e})"))
+            continue
 
         if dst_file.exists():
-            src_stat = src_file.stat()
-            dst_stat = dst_file.stat()
+            try:
+                src_stat = src_file.stat()
+                dst_stat = dst_file.stat()
+            except OSError as e:
+                skipped.append((src_file, f"unreadable ({e})"))
+                continue
             same_size = src_stat.st_size == dst_stat.st_size
             same_mtime = abs(src_stat.st_mtime - dst_stat.st_mtime) < 1.0
             if same_size and same_mtime:

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -23,15 +24,13 @@ import typer
 from punt_vox import __version__
 from punt_vox.client import VoxClientSync, VoxdConnectionError, VoxdProtocolError
 from punt_vox.config import (
-    DEFAULT_CONFIG_PATH,
-    find_config,
     read_config,
     write_field,
     write_fields,
 )
+from punt_vox.dirs import DEFAULT_CONFIG_PATH, default_output_dir, find_config
 from punt_vox.hooks import hook_app
 from punt_vox.normalize import normalize_for_speech
-from punt_vox.output import default_output_dir
 from punt_vox.paths import installed_version, log_dir
 from punt_vox.providers import auto_detect_provider
 from punt_vox.service import (
@@ -303,7 +302,7 @@ OutputOpt = Annotated[
 ]
 OutputDirOpt = Annotated[
     Path | None,
-    typer.Option("--output-dir", "-d", help="Output directory. Default: ~/vox-output."),
+    typer.Option("--output-dir", "-d", help="Output directory. Default: ~/Music/vox."),
 ]
 StabilityOpt = Annotated[
     float | None,
@@ -1038,6 +1037,59 @@ def doctor() -> None:
             f"Daemon: reachable but unhealthy \u2014 {exc}",
         )
 
+    # Legacy .vox/ directory (vox-4jk migration)
+    legacy_vox = Path.cwd() / ".vox"
+    if legacy_vox.is_dir():
+        if (legacy_vox / "config.md").exists():
+            _check(
+                _FAIL,
+                f"Legacy .vox/ directory: {legacy_vox} contains config.md"
+                " \u2014 run 'vox install' to migrate to .punt-labs/vox/",
+            )
+        else:
+            _check(
+                _WARN,
+                f"Legacy .vox/ directory: {legacy_vox} exists but has no"
+                " config.md \u2014 safe to remove manually",
+            )
+
+    # Legacy ~/vox-output/ directory (vox-4jk migration)
+    legacy_output = Path.home() / "vox-output"
+    if legacy_output.is_dir():
+        try:
+            count = sum(1 for _ in legacy_output.rglob("*") if _.is_file())
+        except OSError:
+            count = -1
+        if count > 0:
+            _check(
+                _WARN,
+                f"Legacy audio: ~/vox-output contains {count} file(s)"
+                " \u2014 run 'vox migrate-audio' to move to ~/Music/vox/",
+            )
+        elif count == 0:
+            _check(
+                _WARN,
+                "Legacy audio: ~/vox-output exists but is empty"
+                " \u2014 safe to remove: rm -rf ~/vox-output",
+            )
+        else:
+            _check(
+                _WARN,
+                "Legacy audio: ~/vox-output exists but is unreadable"
+                " \u2014 check permissions",
+            )
+
+    # Music directory existence
+    from punt_vox.dirs import _resolve_music_dir  # pyright: ignore[reportPrivateUsage]
+
+    music_dir = _resolve_music_dir()  # pyright: ignore[reportPrivateUsage]
+    if not music_dir.is_dir():
+        _check(
+            _WARN,
+            f"Music directory: {music_dir} does not exist"
+            " \u2014 will be created on first 'vox record'",
+        )
+
     # Legacy user-level vox.service regression guard (Linux only).
     #
     # vox-45r: an earlier install layout registered a user-level
@@ -1179,6 +1231,119 @@ def doctor() -> None:
 
     if failed > 0:
         raise typer.Exit(code=1)
+
+
+# ---------------------------------------------------------------------------
+# migrate-audio — move saved audio from ~/vox-output to ~/Music/vox
+# ---------------------------------------------------------------------------
+
+
+@app.command("migrate-audio")
+def migrate_audio_cmd(
+    execute: Annotated[
+        bool, typer.Option("--execute", help="Actually move files.")
+    ] = False,
+    source: Annotated[
+        Path | None, typer.Option("--source", help="Source directory.")
+    ] = None,
+    dest: Annotated[
+        Path | None, typer.Option("--dest", help="Destination directory.")
+    ] = None,
+) -> None:
+    """Migrate saved audio from ~/vox-output to ~/Music/vox."""
+    import shutil as _shutil
+
+    src_dir = source or (Path.home() / "vox-output")
+    dst_dir = dest or default_output_dir()
+
+    if not src_dir.exists():
+        typer.echo("Nothing to migrate: source directory does not exist.")
+        return
+
+    # Build list of (src_path, dst_path) pairs.
+    pairs: list[tuple[Path, Path]] = []
+    conflicts: list[tuple[Path, Path]] = []
+    skipped: list[tuple[Path, str]] = []
+    total_size = 0
+
+    for src_file in sorted(src_dir.rglob("*")):
+        if not src_file.is_file():
+            continue
+        rel = src_file.relative_to(src_dir)
+        # Special case: music/ -> tracks/
+        parts = rel.parts
+        if parts and parts[0] == "music":
+            rel = Path("tracks", *parts[1:])
+        dst_file = dst_dir / rel
+        total_size += src_file.stat().st_size
+
+        if dst_file.exists():
+            src_stat = src_file.stat()
+            dst_stat = dst_file.stat()
+            same_size = src_stat.st_size == dst_stat.st_size
+            same_mtime = abs(src_stat.st_mtime - dst_stat.st_mtime) < 1.0
+            if same_size and same_mtime:
+                skipped.append((src_file, "already migrated"))
+            else:
+                conflicts.append((src_file, dst_file))
+        else:
+            pairs.append((src_file, dst_file))
+
+    if not pairs and not conflicts and not skipped:
+        typer.echo("Nothing to migrate: source directory is empty.")
+        return
+
+    size_mb = total_size / (1024 * 1024)
+    file_count = len(pairs) + len(conflicts) + len(skipped)
+
+    if not execute:
+        typer.echo("vox migrate-audio: dry run (pass --execute to move files)\n")
+        typer.echo(f"Source:      {src_dir} ({file_count} files, {size_mb:.1f} MB)")
+        typer.echo(f"Destination: {dst_dir}\n")
+        for src_file, dst_file in pairs:
+            typer.echo(f"  {src_file} -> {dst_file}")
+        for src_file, dst_file in conflicts:
+            typer.echo(f"  {src_file} -> {dst_file} [CONFLICT]")
+        for src_file, reason in skipped:
+            typer.echo(f"  {src_file} [SKIP: {reason}]")
+        count = len(pairs)
+        typer.echo(f"\n{count} files would be moved. Run with --execute.")
+        if conflicts:
+            typer.echo(f"{len(conflicts)} conflict(s) would be skipped.")
+        return
+
+    # Execute mode: move files.
+    moved = 0
+    moved_bytes = 0
+    for src_file, dst_file in pairs:
+        dst_file.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _shutil.move(str(src_file), str(dst_file))
+            moved += 1
+            moved_bytes += dst_file.stat().st_size
+        except PermissionError:
+            typer.echo(f"  warning: permission denied: {src_file}", err=True)
+        except OSError as exc:
+            typer.echo(f"  warning: {exc}", err=True)
+
+    # Clean up empty source dirs.
+    removed_source = False
+    for dirpath in sorted(src_dir.rglob("*"), reverse=True):
+        if dirpath.is_dir():
+            with contextlib.suppress(OSError):
+                dirpath.rmdir()
+    try:
+        src_dir.rmdir()
+        removed_source = True
+    except OSError:
+        pass
+
+    moved_mb = moved_bytes / (1024 * 1024)
+    typer.echo(f"Moved {moved} files from {src_dir} to {dst_dir} ({moved_mb:.1f} MB)")
+    if conflicts:
+        typer.echo(f"Skipped {len(conflicts)} conflict(s).")
+    if removed_source:
+        typer.echo(f"Removed empty {src_dir} directory.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -1,10 +1,10 @@
-"""Centralized read/write for .vox/config.md YAML frontmatter.
+"""Centralized read/write for per-repo config.md YAML frontmatter.
 
 Python components that need config (e.g. server, CLI, watcher) import
 from here.  Shell hooks (e.g. ``hooks/*.sh``) read the same file via
-their own bash-based reader.  The canonical path is ``.vox/config.md``
-in the current working directory.  All fields return safe defaults when
-the file is missing.
+their own bash-based reader.  The canonical path is
+``.punt-labs/vox/config.md`` in the repo root (legacy: ``.vox/config.md``).
+All fields return safe defaults when the file is missing.
 """
 
 from __future__ import annotations
@@ -14,19 +14,21 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from punt_vox.dirs import DEFAULT_CONFIG_PATH, find_config
+
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG_PATH = Path(".vox/config.md")
-
-
-def find_config(start: Path | None = None) -> Path | None:
-    """Walk up from start (default: cwd) to find .vox/config.md."""
-    path = (start or Path.cwd()).resolve()
-    for parent in (path, *path.parents):
-        config = parent / ".vox" / "config.md"
-        if config.exists():
-            return config
-    return None
+# Re-export so existing callers that import from config.py keep working.
+__all__ = [
+    "ALLOWED_CONFIG_KEYS",
+    "DEFAULT_CONFIG_PATH",
+    "VoxConfig",
+    "find_config",
+    "read_config",
+    "read_field",
+    "write_field",
+    "write_fields",
+]
 
 
 _FIELD_RE = re.compile(r'^([a-z_]+):\s*"?([^"\n]*)"?\s*$', re.MULTILINE)

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -1,9 +1,10 @@
-"""Centralized read/write for per-repo config.md YAML frontmatter.
+"""Centralized read/write for ``.punt-labs/vox/config.md`` YAML frontmatter.
 
 Python components that need config (e.g. server, CLI, watcher) import
 from here.  Shell hooks (e.g. ``hooks/*.sh``) read the same file via
 their own bash-based reader.  The canonical path is
-``.punt-labs/vox/config.md`` in the repo root (legacy: ``.vox/config.md``).
+``.punt-labs/vox/config.md`` in the repo root (legacy ``.vox/config.md``
+is discovered by ``find_config()`` for unmigrated repos).
 All fields return safe defaults when the file is missing.
 """
 
@@ -36,7 +37,7 @@ _FIELD_RE = re.compile(r'^([a-z_]+):\s*"?([^"\n]*)"?\s*$', re.MULTILINE)
 
 @dataclass(frozen=True)
 class VoxConfig:
-    """Snapshot of all config fields from .vox/config.md."""
+    """Snapshot of all config fields from .punt-labs/vox/config.md."""
 
     notify: str  # "y" | "c" | "n"
     speak: str  # "y" | "n"
@@ -121,7 +122,7 @@ _CLOSING_FENCE_RE = re.compile(r"\n---\s*$", re.MULTILINE)
 
 
 def write_field(key: str, value: str, config_path: Path | None = None) -> None:
-    """Write a single YAML frontmatter field to .vox/config.md.
+    """Write a single YAML frontmatter field to .punt-labs/vox/config.md.
 
     Updates the field in-place if present, or inserts it before the
     closing ``---`` if absent. Creates the file with minimal frontmatter

--- a/src/punt_vox/dirs.py
+++ b/src/punt_vox/dirs.py
@@ -1,0 +1,112 @@
+"""Cross-platform per-repo and user-content directory resolution."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# Per-repo subdirectory under .punt-labs/
+_REPO_SUBDIR = Path(".punt-labs") / "vox"
+
+# Legacy per-repo directory
+_LEGACY_REPO_DIR = Path(".vox")
+
+DEFAULT_CONFIG_PATH = _REPO_SUBDIR / "config.md"
+
+
+def find_config(start: Path | None = None) -> Path | None:
+    """Walk up from start (default: cwd) to find per-repo config.
+
+    Checks ``.punt-labs/vox/config.md`` first, then falls back to the
+    legacy ``.vox/config.md`` for unmigrated repos.
+    """
+    path = (start or Path.cwd()).resolve()
+    for parent in (path, *path.parents):
+        new = parent / _REPO_SUBDIR / "config.md"
+        if new.exists():
+            return new
+        legacy = parent / _LEGACY_REPO_DIR / "config.md"
+        if legacy.exists():
+            return legacy
+    return None
+
+
+def ephemeral_dir(repo_root: Path | None = None) -> Path:
+    """Return the ephemeral audio directory for the repo.
+
+    Creates the directory if it does not exist.
+    """
+    root = repo_root or Path.cwd()
+    d = root / _REPO_SUBDIR / "ephemeral"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _parse_xdg_user_dir(key: str) -> Path | None:
+    """Parse a single key from ~/.config/user-dirs.dirs.
+
+    Returns None if the file doesn't exist, the key isn't found,
+    or the value cannot be resolved.
+    """
+    dirs_file = Path.home() / ".config" / "user-dirs.dirs"
+    if not dirs_file.is_file():
+        return None
+    try:
+        text = dirs_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    # Format: XDG_MUSIC_DIR="$HOME/Music"
+    pattern = re.compile(
+        rf'^{re.escape(key)}="([^"]*)"',
+        re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if not match:
+        return None
+
+    raw = match.group(1)
+    # Expand $HOME -- the only variable XDG user-dirs.dirs uses
+    resolved = raw.replace("$HOME", str(Path.home()))
+    return Path(resolved)
+
+
+def _resolve_music_dir() -> Path:
+    """Resolve the platform-standard music directory.
+
+    Linux:   $XDG_MUSIC_DIR from ~/.config/user-dirs.dirs,
+             fallback ~/Music
+    macOS:   ~/Music
+    Windows: %USERPROFILE%\\Music
+    """
+    if sys.platform == "linux":
+        xdg = _parse_xdg_user_dir("XDG_MUSIC_DIR")
+        if xdg is not None:
+            return xdg
+    # Cross-platform fallback: ~/Music exists on macOS by default,
+    # is the conventional location on Linux, and is the standard
+    # media library on Windows.
+    return Path.home() / "Music"
+
+
+def default_output_dir() -> Path:
+    """Resolve the default output directory for saved audio.
+
+    Resolution order:
+    1. VOX_OUTPUT_DIR env var (explicit override)
+    2. ~/Music/vox/ (platform-standard)
+    """
+    env_dir = os.environ.get("VOX_OUTPUT_DIR")
+    if env_dir:
+        return Path(env_dir)
+    return _resolve_music_dir() / "vox"
+
+
+def music_output_dir() -> Path:
+    """Return the directory for generated music tracks.
+
+    Layout: ~/Music/vox/tracks/ (replaces ~/vox-output/music/)
+    """
+    return default_output_dir() / "tracks"

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -32,13 +32,12 @@ import typer
 
 from punt_vox.client import VoxClientSync, VoxdConnectionError, VoxdProtocolError
 from punt_vox.config import (
-    DEFAULT_CONFIG_PATH,
     VoxConfig,
-    find_config,
     read_config,
     write_field,
     write_fields,
 )
+from punt_vox.dirs import DEFAULT_CONFIG_PATH, find_config
 from punt_vox.quips import (
     ACKNOWLEDGE_PHRASES,
     FAREWELL_PHRASES,

--- a/src/punt_vox/output.py
+++ b/src/punt_vox/output.py
@@ -2,21 +2,12 @@
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
+from punt_vox.dirs import default_output_dir
 from punt_vox.types import SynthesisRequest, generate_filename
 
-
-def default_output_dir() -> Path:
-    """Resolve the default output directory from environment or fallback.
-
-    Resolution order: ``VOX_OUTPUT_DIR`` env var → ``~/vox-output``.
-    """
-    env_dir = os.environ.get("VOX_OUTPUT_DIR")
-    if env_dir:
-        return Path(env_dir)
-    return Path.home() / "vox-output"
+__all__ = ["default_output_dir", "resolve_output_path"]
 
 
 def resolve_output_path(request: SynthesisRequest) -> Path:

--- a/src/punt_vox/providers/__init__.py
+++ b/src/punt_vox/providers/__init__.py
@@ -151,12 +151,12 @@ def get_provider(
 
     Resolution priority for provider name:
       1. Explicit ``name`` argument
-      2. Session config (``.vox/config.md`` provider field)
+      2. Session config (``.punt-labs/vox/config.md`` provider field)
       3. ``TTS_PROVIDER`` env var / API key auto-detection
 
     Resolution priority for model (passed via kwargs):
       1. Explicit ``model`` kwarg
-      2. Session config (``.vox/config.md`` model field)
+      2. Session config (``.punt-labs/vox/config.md`` model field)
       3. ``TTS_MODEL`` env var / provider default
 
     Args:
@@ -164,7 +164,7 @@ def get_provider(
             session config then auto-detects.
         config_path: Path to session config file. Use
             ``find_config()`` to locate the nearest config.
-            Defaults to ``.vox/config.md`` in the current directory.
+            Defaults to ``.punt-labs/vox/config.md`` in the current directory.
         **kwargs: Provider-specific options (e.g. model='tts-1-hd').
 
     Returns:

--- a/src/punt_vox/resolve.py
+++ b/src/punt_vox/resolve.py
@@ -12,7 +12,6 @@ import re
 from pathlib import Path
 
 import punt_vox.config as _config
-import punt_vox.dirs as _dirs
 from punt_vox.types import TTSProvider, VoiceNotFoundError, validate_language
 
 logger = logging.getLogger(__name__)
@@ -85,7 +84,7 @@ def resolve_voice_and_language(
 
     voice_from_config = False
     if voice is None:
-        voice = _config.read_field("voice", config_path or _dirs.DEFAULT_CONFIG_PATH)
+        voice = _config.read_field("voice", config_path or _config.DEFAULT_CONFIG_PATH)
         voice_from_config = voice is not None
 
     if voice is None and language is not None:
@@ -140,7 +139,7 @@ def apply_vibe(
     if not expressive_tags:
         return strip_expressive_tags(text)
     tags = override_tags or _config.read_field(
-        "vibe_tags", config_path or _dirs.DEFAULT_CONFIG_PATH
+        "vibe_tags", config_path or _config.DEFAULT_CONFIG_PATH
     )
     if tags and not _LEADING_TAG_RE.match(text):
         return f"{tags} {text}"

--- a/src/punt_vox/resolve.py
+++ b/src/punt_vox/resolve.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 
 import punt_vox.config as _config
+import punt_vox.dirs as _dirs
 from punt_vox.types import TTSProvider, VoiceNotFoundError, validate_language
 
 logger = logging.getLogger(__name__)
@@ -75,15 +76,16 @@ def resolve_voice_and_language(
     If only voice is provided, infers language from the voice (best-effort).
     If both, validates compatibility.
 
-    When *config_path* is provided (or defaults to ``.vox/config.md``),
-    reads the ``voice`` field as session default.
+    When *config_path* is provided (or defaults to
+    ``.punt-labs/vox/config.md``), reads the ``voice`` field as session
+    default.
     """
     if language is not None:
         language = validate_language(language)
 
     voice_from_config = False
     if voice is None:
-        voice = _config.read_field("voice", config_path or _config.DEFAULT_CONFIG_PATH)
+        voice = _config.read_field("voice", config_path or _dirs.DEFAULT_CONFIG_PATH)
         voice_from_config = voice is not None
 
     if voice is None and language is not None:
@@ -138,7 +140,7 @@ def apply_vibe(
     if not expressive_tags:
         return strip_expressive_tags(text)
     tags = override_tags or _config.read_field(
-        "vibe_tags", config_path or _config.DEFAULT_CONFIG_PATH
+        "vibe_tags", config_path or _dirs.DEFAULT_CONFIG_PATH
     )
     if tags and not _LEADING_TAG_RE.match(text):
         return f"{tags} {text}"

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -201,6 +201,10 @@ def unmute(
     """
     _validate_voice_settings(stability, similarity, style)
 
+    # ephemeral is accepted for callers (architecture spec) but voxd
+    # handles ephemeral cleanup internally today.  Silence linters.
+    _ = ephemeral
+
     # Update in-memory state for persistent fields.
     if provider is not None:
         _state.provider = provider

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -34,8 +34,9 @@ mcp = FastMCP(
         "summarizing what you completed and call the unmute tool with "
         "ephemeral=true. Mood tags are pre-resolved in config \u2014 do not "
         "pass vibe_tags. No other output.\n\n"
-        "Do NOT use Read, Write, or Bash tools to access .vox/config.md. "
-        "All config state is available through MCP tools or hook context."
+        "Do NOT use Read, Write, or Bash tools to access "
+        ".punt-labs/vox/config.md. All config state is available through "
+        "MCP tools or hook context."
     ),
 )
 mcp._mcp_server.version = __version__  # pyright: ignore[reportPrivateUsage]
@@ -48,7 +49,7 @@ mcp._mcp_server.version = __version__  # pyright: ignore[reportPrivateUsage]
 
 @dataclass
 class SessionState:
-    """In-memory session state. Seeded from .vox/config.md on startup."""
+    """In-memory session state. Seeded from .punt-labs/vox/config.md on startup."""
 
     session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     notify: str = "n"
@@ -73,14 +74,14 @@ _state: SessionState = SessionState()
 
 
 def _find_config() -> Path | None:
-    """Walk up from cwd to find .vox/config.md."""
-    from punt_vox.config import find_config
+    """Walk up from cwd to find per-repo config.md."""
+    from punt_vox.dirs import find_config
 
     return find_config()
 
 
 def _seed_state_from_config(config_path: Path | None) -> SessionState:
-    """Read .vox/config.md once and return a SessionState."""
+    """Read per-repo config.md once and return a SessionState."""
     if config_path is None or not config_path.exists():
         return SessionState()
 
@@ -123,12 +124,9 @@ def _validate_voice_settings(
 
 def _default_output_dir() -> Path:
     """Resolve the default output directory for record tool."""
-    import os
+    from punt_vox.dirs import default_output_dir
 
-    env_dir = os.environ.get("VOX_OUTPUT_DIR")
-    if env_dir:
-        return Path(env_dir)
-    return Path.home() / "vox-output"
+    return default_output_dir()
 
 
 def _voxd_client() -> VoxClientSync:
@@ -183,7 +181,7 @@ def unmute(
              {"text": "Hi."}]
         rate: Speech rate as percentage. Defaults to 90.
         pause_ms: Pause between segments in milliseconds. Defaults to 500.
-        ephemeral: Write to .vox/ in cwd and clean up previous files.
+        ephemeral: Write to .punt-labs/vox/ephemeral/ and clean up previous files.
             Defaults to true (unmute is for playback, not saving).
         stability: ElevenLabs voice stability (0.0-1.0).
         similarity: ElevenLabs voice similarity boost (0.0-1.0).
@@ -327,7 +325,7 @@ def record(
         pause_ms: Pause between segments in milliseconds. Defaults to 500.
         output_path: Full path for the output file. Auto-generated if omitted.
         output_dir: Directory for output. Defaults to VOX_OUTPUT_DIR
-            env var or ~/vox-output/.
+            env var or ~/Music/vox/.
         stability: ElevenLabs voice stability (0.0-1.0).
         similarity: ElevenLabs voice similarity boost (0.0-1.0).
         style: ElevenLabs voice style/expressiveness (0.0-1.0).
@@ -867,7 +865,7 @@ def run_server() -> None:
     configure_logging(stderr_level="INFO")
     logger.info("Starting vox MCP server (mic)")
 
-    # Seed session state from .vox/config.md if it exists.
+    # Seed session state from per-repo config.md if it exists.
     config_path = _find_config()
     _state = _seed_state_from_config(config_path)
 

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -33,6 +33,7 @@ import platform
 import pwd
 import re
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -479,6 +480,86 @@ def _voxd_exec_args() -> list[str]:
         )
         raise SystemExit(msg)
     return [str(voxd_path), "--port", str(DEFAULT_PORT)]
+
+
+# ---------------------------------------------------------------------------
+# Legacy repo config migration (.vox/ -> .punt-labs/vox/)
+# ---------------------------------------------------------------------------
+
+
+def _migrate_legacy_repo_config(repo_root: Path) -> bool:
+    """Migrate .vox/config.md to .punt-labs/vox/config.md.
+
+    Called by ``vox install`` and ``vox daemon install`` with the project
+    root as argument. Returns True if migration occurred.
+
+    Idempotent: safe to call repeatedly. Skips when:
+    - .vox/config.md does not exist
+    - .punt-labs/vox/config.md already exists (don't overwrite)
+    - .vox is a symlink (not ours to touch)
+    - .vox/config.md is a symlink (don't follow indirections)
+    - .punt-labs exists but is not a directory (bail, don't corrupt)
+    """
+    legacy_dir = repo_root / ".vox"
+    legacy_config = legacy_dir / "config.md"
+
+    if not legacy_config.exists():
+        return False
+
+    if legacy_dir.is_symlink():
+        logger.warning(".vox/ is a symlink, skipping migration")
+        return False
+
+    if legacy_config.is_symlink():
+        logger.warning(".vox/config.md is a symlink, skipping migration")
+        return False
+
+    punt_labs_dir = repo_root / ".punt-labs"
+    if punt_labs_dir.exists() and not punt_labs_dir.is_dir():
+        logger.warning(
+            ".punt-labs exists but is not a directory (%s), skipping migration",
+            type(punt_labs_dir),
+        )
+        return False
+
+    new_dir = repo_root / ".punt-labs" / "vox"
+    new_config = new_dir / "config.md"
+
+    if new_config.exists():
+        logger.info("Config already at .punt-labs/vox/config.md, skipping migration")
+        return False
+
+    try:
+        new_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        logger.warning("Could not create %s, skipping migration", new_dir)
+        return False
+
+    try:
+        shutil.move(str(legacy_config), str(new_config))
+    except PermissionError:
+        logger.warning("Could not move config.md, skipping migration")
+        return False
+    except OSError as exc:
+        logger.warning("Could not move config.md: %s, skipping migration", exc)
+        return False
+
+    logger.info("Migrated .vox/config.md -> .punt-labs/vox/config.md")
+
+    # Clean up ephemeral MP3s in .vox/
+    for f in legacy_dir.glob("*.mp3"):
+        f.unlink(missing_ok=True)
+
+    # Remove .vox/ if empty
+    try:
+        legacy_dir.rmdir()
+    except OSError:
+        logger.warning(
+            ".vox/ not empty after migration (user files detected): %s",
+            legacy_dir,
+        )
+
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1051,6 +1132,16 @@ def install() -> str:
 
     # Create per-user state directories as the invoking user.
     state_root = _ensure_user_dirs()
+
+    # Migrate legacy .vox/config.md -> .punt-labs/vox/config.md
+    # Best-effort on $PWD. The authoritative migration is find_config()
+    # walk-up discovery; this catches the common case where install runs
+    # from a project root.
+    cwd = Path.cwd()
+    if (cwd / ".vox" / "config.md").exists():
+        migrated = _migrate_legacy_repo_config(cwd)
+        if migrated:
+            logger.info("Migrated legacy config in %s", cwd)
 
     # Write provider keys into the user's state dir. Normal user
     # permissions — no chown, no fd tricks.

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -518,7 +518,7 @@ def _migrate_legacy_repo_config(repo_root: Path) -> bool:
     if punt_labs_dir.exists() and not punt_labs_dir.is_dir():
         logger.warning(
             ".punt-labs exists but is not a directory (%s), skipping migration",
-            type(punt_labs_dir),
+            punt_labs_dir,
         )
         return False
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -459,9 +459,9 @@ def _music_player_command(path: Path) -> list[str]:
 
 def _music_output_dir() -> Path:
     """Return the directory for generated music tracks."""
-    from punt_vox.output import default_output_dir
+    from punt_vox.dirs import music_output_dir
 
-    return default_output_dir() / "music"
+    return music_output_dir()
 
 
 def _record_playback_result(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1197,6 +1197,8 @@ class TestDoctorCommand:
 
         # Create Music dir so the Music-directory doctor check passes.
         (tmp_path / "Music").mkdir(exist_ok=True)
+        # Create output dir so the output-directory doctor check passes.
+        (tmp_path / "audio").mkdir(exist_ok=True)
 
         runner = CliRunner()
         with (
@@ -1327,8 +1329,9 @@ class TestDoctorCommand:
             "daemon_version": "4.1.1",
         }
 
-        # Create Music dir so the Music-directory doctor check passes.
+        # Create Music and output dirs so doctor checks pass.
         (tmp_path / "Music").mkdir(exist_ok=True)
+        (tmp_path / "audio").mkdir(exist_ok=True)
 
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
@@ -1668,8 +1671,9 @@ class TestDoctorCommand:
             "daemon_version": "4.1.1",
         }
 
-        # Create Music dir so the Music-directory doctor check passes.
+        # Create Music and output dirs so doctor checks pass.
         (tmp_path / "Music").mkdir(exist_ok=True)
+        (tmp_path / "audio").mkdir(exist_ok=True)
 
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
@@ -1734,8 +1738,9 @@ class TestDoctorCommand:
         mock_client = MagicMock()
         mock_client.health.side_effect = VoxdConnectionError("not running")
 
-        # Create Music dir so the Music-directory doctor check passes.
+        # Create Music and output dirs so doctor checks pass.
         (tmp_path / "Music").mkdir(exist_ok=True)
+        (tmp_path / "audio").mkdir(exist_ok=True)
 
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1195,6 +1195,9 @@ class TestDoctorCommand:
         # explicit ``legacy_unit_path`` fixture.
         resolved_legacy = legacy_unit_path or (tmp_path / "no-such-legacy-unit")
 
+        # Create Music dir so the Music-directory doctor check passes.
+        (tmp_path / "Music").mkdir(exist_ok=True)
+
         runner = CliRunner()
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
@@ -1212,6 +1215,13 @@ class TestDoctorCommand:
             patch(
                 f"{_CLI}._legacy_user_unit_path",
                 return_value=resolved_legacy,
+            ),
+            # Isolate legacy-path doctor checks from the real filesystem.
+            patch(f"{_CLI}.Path.cwd", return_value=tmp_path),
+            patch(f"{_CLI}.Path.home", return_value=tmp_path),
+            patch(
+                "punt_vox.dirs._resolve_music_dir",
+                return_value=tmp_path / "Music",
             ),
         ):
             result = runner.invoke(app, ["doctor"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1327,6 +1327,9 @@ class TestDoctorCommand:
             "daemon_version": "4.1.1",
         }
 
+        # Create Music dir so the Music-directory doctor check passes.
+        (tmp_path / "Music").mkdir(exist_ok=True)
+
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
             patch(f"{_CLI}.VoxClientSync", return_value=mock_client),
@@ -1340,6 +1343,16 @@ class TestDoctorCommand:
                 return_value=tmp_path / "audio",
             ),
             patch(f"{_CLI}.platform.system", return_value="Darwin"),
+            patch(f"{_CLI}.Path.cwd", return_value=tmp_path),
+            patch(f"{_CLI}.Path.home", return_value=tmp_path),
+            patch(
+                "punt_vox.dirs._resolve_music_dir",
+                return_value=tmp_path / "Music",
+            ),
+            patch(
+                f"{_CLI}._legacy_user_unit_path",
+                return_value=tmp_path / "no-such-legacy-unit",
+            ),
         ):
             result = runner.invoke(app, ["--json", "doctor"])
 
@@ -1655,6 +1668,9 @@ class TestDoctorCommand:
             "daemon_version": "4.1.1",
         }
 
+        # Create Music dir so the Music-directory doctor check passes.
+        (tmp_path / "Music").mkdir(exist_ok=True)
+
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
             patch(f"{_CLI}.VoxClientSync", return_value=mock_client),
@@ -1668,6 +1684,16 @@ class TestDoctorCommand:
                 return_value=tmp_path / "audio",
             ),
             patch(f"{_CLI}.platform.system", return_value="Darwin"),
+            patch(f"{_CLI}.Path.cwd", return_value=tmp_path),
+            patch(f"{_CLI}.Path.home", return_value=tmp_path),
+            patch(
+                "punt_vox.dirs._resolve_music_dir",
+                return_value=tmp_path / "Music",
+            ),
+            patch(
+                f"{_CLI}._legacy_user_unit_path",
+                return_value=tmp_path / "no-such-legacy-unit",
+            ),
         ):
             result = runner.invoke(app, ["--json", "doctor"])
 
@@ -1708,6 +1734,9 @@ class TestDoctorCommand:
         mock_client = MagicMock()
         mock_client.health.side_effect = VoxdConnectionError("not running")
 
+        # Create Music dir so the Music-directory doctor check passes.
+        (tmp_path / "Music").mkdir(exist_ok=True)
+
         with (
             patch(f"{_CLI}.shutil.which", side_effect=which_side_effect),
             patch(f"{_CLI}.VoxClientSync", return_value=mock_client),
@@ -1721,6 +1750,16 @@ class TestDoctorCommand:
                 return_value=tmp_path / "audio",
             ),
             patch(f"{_CLI}.platform.system", return_value="Darwin"),
+            patch(f"{_CLI}.Path.cwd", return_value=tmp_path),
+            patch(f"{_CLI}.Path.home", return_value=tmp_path),
+            patch(
+                "punt_vox.dirs._resolve_music_dir",
+                return_value=tmp_path / "Music",
+            ),
+            patch(
+                f"{_CLI}._legacy_user_unit_path",
+                return_value=tmp_path / "no-such-legacy-unit",
+            ),
         ):
             result = runner.invoke(app, ["--json", "doctor"])
 

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -1,0 +1,210 @@
+"""Tests for punt_vox.dirs -- cross-platform path resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from punt_vox.dirs import (
+    DEFAULT_CONFIG_PATH,
+    _parse_xdg_user_dir,  # pyright: ignore[reportPrivateUsage]
+    _resolve_music_dir,  # pyright: ignore[reportPrivateUsage]
+    default_output_dir,
+    ephemeral_dir,
+    find_config,
+    music_output_dir,
+)
+
+# ---------------------------------------------------------------------------
+# DEFAULT_CONFIG_PATH
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConfigPath:
+    def test_uses_punt_labs_subdir(self) -> None:
+        assert Path(".punt-labs/vox/config.md") == DEFAULT_CONFIG_PATH
+
+
+# ---------------------------------------------------------------------------
+# find_config
+# ---------------------------------------------------------------------------
+
+
+class TestFindConfig:
+    def test_finds_new_path(self, tmp_path: Path) -> None:
+        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
+        new_config.parent.mkdir(parents=True)
+        new_config.write_text("---\nnotify: y\n---\n")
+        result = find_config(tmp_path)
+        assert result == new_config
+
+    def test_falls_back_to_legacy(self, tmp_path: Path) -> None:
+        legacy = tmp_path / ".vox" / "config.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("---\nnotify: y\n---\n")
+        result = find_config(tmp_path)
+        assert result == legacy
+
+    def test_prefers_new_over_legacy(self, tmp_path: Path) -> None:
+        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
+        new_config.parent.mkdir(parents=True)
+        new_config.write_text("---\nnotify: y\n---\n")
+        legacy = tmp_path / ".vox" / "config.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("---\nnotify: n\n---\n")
+        result = find_config(tmp_path)
+        assert result == new_config
+
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        # Create an isolated directory tree with no config anywhere
+        # above it by starting from a fresh root with no parents to walk.
+        isolated = tmp_path / "isolated"
+        isolated.mkdir()
+        with patch("punt_vox.dirs.Path.cwd", return_value=isolated):
+            # Walk up from isolated; tmp_path has no config files
+            # but walk-up may reach the real repo root. Pass the
+            # isolated dir explicitly so the walk stays bounded.
+            result = find_config(isolated)
+        # May find a parent config if tmp_path is inside a repo
+        # with .punt-labs/vox/config.md. The contract is that
+        # find_config returns None when no config exists in the
+        # walk-up chain. Test only with an isolated subtree.
+        if result is not None:
+            assert not result.is_relative_to(isolated)
+
+    def test_walks_up_to_parent(self, tmp_path: Path) -> None:
+        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
+        new_config.parent.mkdir(parents=True)
+        new_config.write_text("---\n---\n")
+        child = tmp_path / "sub" / "dir"
+        child.mkdir(parents=True)
+        result = find_config(child)
+        assert result == new_config
+
+
+# ---------------------------------------------------------------------------
+# ephemeral_dir
+# ---------------------------------------------------------------------------
+
+
+class TestEphemeralDir:
+    def test_creates_directory(self, tmp_path: Path) -> None:
+        result = ephemeral_dir(tmp_path)
+        assert result == tmp_path / ".punt-labs" / "vox" / "ephemeral"
+        assert result.is_dir()
+
+    def test_idempotent(self, tmp_path: Path) -> None:
+        ephemeral_dir(tmp_path)
+        result = ephemeral_dir(tmp_path)
+        assert result.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# _parse_xdg_user_dir
+# ---------------------------------------------------------------------------
+
+
+class TestParseXdgUserDir:
+    def test_parses_music_dir(self, tmp_path: Path) -> None:
+        dirs_file = tmp_path / ".config" / "user-dirs.dirs"
+        dirs_file.parent.mkdir(parents=True)
+        dirs_file.write_text('XDG_MUSIC_DIR="$HOME/Musik"\n')
+        with patch("punt_vox.dirs.Path.home", return_value=tmp_path):
+            result = _parse_xdg_user_dir("XDG_MUSIC_DIR")
+        assert result == tmp_path / "Musik"
+
+    def test_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        with patch("punt_vox.dirs.Path.home", return_value=tmp_path):
+            result = _parse_xdg_user_dir("XDG_MUSIC_DIR")
+        assert result is None
+
+    def test_returns_none_when_key_missing(self, tmp_path: Path) -> None:
+        dirs_file = tmp_path / ".config" / "user-dirs.dirs"
+        dirs_file.parent.mkdir(parents=True)
+        dirs_file.write_text('XDG_DESKTOP_DIR="$HOME/Desktop"\n')
+        with patch("punt_vox.dirs.Path.home", return_value=tmp_path):
+            result = _parse_xdg_user_dir("XDG_MUSIC_DIR")
+        assert result is None
+
+    def test_expands_home(self, tmp_path: Path) -> None:
+        dirs_file = tmp_path / ".config" / "user-dirs.dirs"
+        dirs_file.parent.mkdir(parents=True)
+        dirs_file.write_text('XDG_MUSIC_DIR="$HOME/Music"\n')
+        with patch("punt_vox.dirs.Path.home", return_value=tmp_path):
+            result = _parse_xdg_user_dir("XDG_MUSIC_DIR")
+        assert result == tmp_path / "Music"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_music_dir
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMusicDir:
+    def test_linux_with_xdg(self, tmp_path: Path) -> None:
+        dirs_file = tmp_path / ".config" / "user-dirs.dirs"
+        dirs_file.parent.mkdir(parents=True)
+        dirs_file.write_text('XDG_MUSIC_DIR="$HOME/Musik"\n')
+        with (
+            patch("punt_vox.dirs.sys.platform", "linux"),
+            patch("punt_vox.dirs.Path.home", return_value=tmp_path),
+        ):
+            result = _resolve_music_dir()
+        assert result == tmp_path / "Musik"
+
+    def test_linux_fallback(self, tmp_path: Path) -> None:
+        with (
+            patch("punt_vox.dirs.sys.platform", "linux"),
+            patch("punt_vox.dirs.Path.home", return_value=tmp_path),
+        ):
+            result = _resolve_music_dir()
+        assert result == tmp_path / "Music"
+
+    def test_macos(self, tmp_path: Path) -> None:
+        with (
+            patch("punt_vox.dirs.sys.platform", "darwin"),
+            patch("punt_vox.dirs.Path.home", return_value=tmp_path),
+        ):
+            result = _resolve_music_dir()
+        assert result == tmp_path / "Music"
+
+    def test_windows(self, tmp_path: Path) -> None:
+        with (
+            patch("punt_vox.dirs.sys.platform", "win32"),
+            patch("punt_vox.dirs.Path.home", return_value=tmp_path),
+        ):
+            result = _resolve_music_dir()
+        assert result == tmp_path / "Music"
+
+
+# ---------------------------------------------------------------------------
+# default_output_dir
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultOutputDir:
+    def test_env_override(self, tmp_path: Path) -> None:
+        custom = str(tmp_path / "custom")
+        with patch.dict("os.environ", {"VOX_OUTPUT_DIR": custom}):
+            result = default_output_dir()
+        assert result == Path(custom)
+
+    def test_platform_default(self, tmp_path: Path) -> None:
+        with patch("punt_vox.dirs._resolve_music_dir", return_value=tmp_path / "Music"):
+            import os
+
+            os.environ.pop("VOX_OUTPUT_DIR", None)
+            result = default_output_dir()
+        assert result == tmp_path / "Music" / "vox"
+
+
+# ---------------------------------------------------------------------------
+# music_output_dir
+# ---------------------------------------------------------------------------
+
+
+class TestMusicOutputDir:
+    def test_returns_tracks_subdir(self, tmp_path: Path) -> None:
+        with patch("punt_vox.dirs.default_output_dir", return_value=tmp_path / "vox"):
+            result = music_output_dir()
+        assert result == tmp_path / "vox" / "tracks"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -16,13 +16,15 @@ class TestDefaultOutputDir:
             result = default_output_dir()
         assert result == Path(custom)
 
-    def test_falls_back_to_home_tts_output(self) -> None:
+    def test_falls_back_to_music_vox(self) -> None:
         with patch.dict("os.environ", {}, clear=False):
             import os
 
             os.environ.pop("VOX_OUTPUT_DIR", None)
             result = default_output_dir()
-        assert result == Path.home() / "vox-output"
+        # Now delegates to dirs.py which returns ~/Music/vox/
+        assert result.name == "vox"
+        assert result.parent.name == "Music"
 
 
 class TestResolveOutputPath:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -16,15 +16,17 @@ class TestDefaultOutputDir:
             result = default_output_dir()
         assert result == Path(custom)
 
-    def test_falls_back_to_music_vox(self) -> None:
-        with patch.dict("os.environ", {}, clear=False):
+    def test_falls_back_to_music_vox(self, tmp_path: Path) -> None:
+        music = tmp_path / "Music"
+        with (
+            patch.dict("os.environ", {}, clear=False),
+            patch("punt_vox.dirs._resolve_music_dir", return_value=music),
+        ):
             import os
 
             os.environ.pop("VOX_OUTPUT_DIR", None)
             result = default_output_dir()
-        # Now delegates to dirs.py which returns ~/Music/vox/
-        assert result.name == "vox"
-        assert result.parent.name == "Music"
+        assert result == music / "vox"
 
 
 class TestResolveOutputPath:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,9 +41,11 @@ def _patch_config(  # pyright: ignore[reportUnusedFunction]
 ) -> Path:
     """Return a writable config path and patch config module default."""
     import punt_vox.config as cfg
+    import punt_vox.dirs as dirs
 
     config = tmp_path / "config.md"
     monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
+    monkeypatch.setattr(dirs, "DEFAULT_CONFIG_PATH", config)
     return config
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24,6 +24,7 @@ from punt_vox.service import (
     _launchd_plist_content,  # pyright: ignore[reportPrivateUsage]
     _launchd_stop,  # pyright: ignore[reportPrivateUsage]
     _legacy_user_unit_path,  # pyright: ignore[reportPrivateUsage]
+    _migrate_legacy_repo_config,  # pyright: ignore[reportPrivateUsage]
     _remove_port_file,  # pyright: ignore[reportPrivateUsage]
     _safe_systemd_value,  # pyright: ignore[reportPrivateUsage]
     _systemd_audio_env_lines,  # pyright: ignore[reportPrivateUsage]
@@ -2083,3 +2084,93 @@ def test_install_cleans_stale_user_unit_before_systemd_stop(
         "systemd_stop",
         "ensure_port_free",
     ], f"unexpected install() ordering: {call_order}"
+
+
+# ---------------------------------------------------------------------------
+# _migrate_legacy_repo_config
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateLegacyRepoConfig:
+    def test_happy_path(self, tmp_path: Path) -> None:
+        legacy_dir = tmp_path / ".vox"
+        legacy_dir.mkdir()
+        legacy_config = legacy_dir / "config.md"
+        legacy_config.write_text('---\nnotify: "y"\n---\n')
+        # Add an ephemeral MP3
+        (legacy_dir / "ephemeral.mp3").write_bytes(b"fake")
+
+        result = _migrate_legacy_repo_config(tmp_path)
+
+        assert result is True
+        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
+        assert new_config.exists()
+        assert new_config.read_text() == '---\nnotify: "y"\n---\n'
+        assert not legacy_config.exists()
+        assert not (legacy_dir / "ephemeral.mp3").exists()
+        # .vox/ should be removed since it's empty
+        assert not legacy_dir.exists()
+
+    def test_no_legacy_config(self, tmp_path: Path) -> None:
+        assert _migrate_legacy_repo_config(tmp_path) is False
+
+    def test_already_migrated(self, tmp_path: Path) -> None:
+        legacy_dir = tmp_path / ".vox"
+        legacy_dir.mkdir()
+        (legacy_dir / "config.md").write_text("old")
+        new_dir = tmp_path / ".punt-labs" / "vox"
+        new_dir.mkdir(parents=True)
+        (new_dir / "config.md").write_text("new")
+
+        result = _migrate_legacy_repo_config(tmp_path)
+
+        assert result is False
+        # New config not overwritten
+        assert (new_dir / "config.md").read_text() == "new"
+
+    def test_legacy_dir_is_symlink(self, tmp_path: Path) -> None:
+        real_dir = tmp_path / "real_vox"
+        real_dir.mkdir()
+        (real_dir / "config.md").write_text("data")
+        (tmp_path / ".vox").symlink_to(real_dir)
+
+        result = _migrate_legacy_repo_config(tmp_path)
+
+        assert result is False
+
+    def test_legacy_config_is_symlink(self, tmp_path: Path) -> None:
+        legacy_dir = tmp_path / ".vox"
+        legacy_dir.mkdir()
+        real_config = tmp_path / "real_config.md"
+        real_config.write_text("data")
+        (legacy_dir / "config.md").symlink_to(real_config)
+
+        result = _migrate_legacy_repo_config(tmp_path)
+
+        assert result is False
+
+    def test_punt_labs_not_a_directory(self, tmp_path: Path) -> None:
+        legacy_dir = tmp_path / ".vox"
+        legacy_dir.mkdir()
+        (legacy_dir / "config.md").write_text("data")
+        # Create .punt-labs as a file, not a directory
+        (tmp_path / ".punt-labs").write_text("not a dir")
+
+        result = _migrate_legacy_repo_config(tmp_path)
+
+        assert result is False
+
+    def test_non_empty_legacy_dir_left_behind(self, tmp_path: Path) -> None:
+        legacy_dir = tmp_path / ".vox"
+        legacy_dir.mkdir()
+        (legacy_dir / "config.md").write_text("data")
+        (legacy_dir / "user_notes.txt").write_text("keep me")
+
+        result = _migrate_legacy_repo_config(tmp_path)
+
+        assert result is True
+        # .vox/ stays because it has user files
+        assert legacy_dir.exists()
+        assert (legacy_dir / "user_notes.txt").exists()
+        # But config.md was moved
+        assert not (legacy_dir / "config.md").exists()


### PR DESCRIPTION
## Summary

Standards-compliance migration: `.vox/` → `.punt-labs/vox/`, `~/vox-output/` → `~/Music/vox/`.

28 files, 1332 tests, design doc at `.tmp/vox-4jk-design.md` with 27 edge cases.

### New paths
| What | Old | New |
|------|-----|-----|
| Per-repo config | `.vox/config.md` | `.punt-labs/vox/config.md` |
| Ephemeral audio | `.vox/*.mp3` | `.punt-labs/vox/ephemeral/` |
| Saved TTS | `~/vox-output/` | `~/Music/vox/` |
| Music tracks | `~/vox-output/music/` | `~/Music/vox/tracks/` |

### Cross-platform
- Linux: `$XDG_MUSIC_DIR` from `~/.config/user-dirs.dirs`, fallback `~/Music/`
- macOS: `~/Music/`
- Windows: `%USERPROFILE%\Music\`
- `VOX_OUTPUT_DIR` env var overrides all

### Migration
- **System content** (`.vox/config.md`): auto-migrated on `vox install`. Symlink-safe, idempotent.
- **User audio** (`~/vox-output/`): opt-in via `vox migrate-audio [--execute]`. Dry-run default.
- **Doctor**: flags legacy paths with remediation commands.

Missions: m-2026-04-12-007 (design, mdm), m-2026-04-12-009 (implement, djb). Closes vox-4jk.

## Test plan
- [x] `make check` green — 1332 tests
- [x] Design doc reviewed with 27 edge cases
- [ ] CI green
- [ ] Copilot + Bugbot clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple entrypoints (CLI, hooks, MCP server, daemon install) to change on-disk paths and add migration logic; main risk is breaking existing setups or leaving files behind during migration, though legacy fallbacks and doctor checks mitigate it.
> 
> **Overview**
> **Migrates filesystem layout** from legacy `.vox/` + `~/vox-output/` to `.punt-labs/vox/` + `~/Music/vox/` (with tracks under `~/Music/vox/tracks/`), and adds `.punt-labs/vox/` to `.gitignore`.
> 
> Introduces `punt_vox.dirs` as the single source of truth for config discovery, ephemeral repo storage, and cross-platform Music-dir resolution (including XDG), then rewires CLI/server/hooks/voxd to use it and updates help text/docs accordingly.
> 
> Adds **best-effort, symlink-safe config auto-migration** during `install.sh` and `vox daemon install`, a new `vox migrate-audio` command (dry-run by default) to move user audio from `~/vox-output/` into the new layout, and enhances `vox doctor` to warn/fail on legacy directories and check new output/music dir writability without creating them. Tests are updated and new `tests/test_dirs.py` covers path resolution behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b980cfa9d60be7d7cdef5b44725fe8389a8899b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->