### PR TITLE
fix(voxd): keep old track playing on generation failure (vox-m2l)

### DIFF
--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1744,9 +1744,24 @@ _MUSIC_DURATION_MS = 120_000
 _MUSIC_MAX_RETRIES = 3
 
 
-async def _music_backoff_sleep(seconds: float) -> None:
-    """Sleep for backoff in the music loop. Patchable by tests."""
-    await asyncio.sleep(seconds)
+async def _music_backoff_sleep(seconds: float, ctx: DaemonContext) -> None:
+    """Sleep for backoff in the music loop, interruptible by music_changed.
+
+    Returns immediately if ``music_changed`` fires or ``music_mode``
+    becomes ``"off"`` during the wait.  This lets ``/music off`` and
+    vibe changes break out of exponential backoff without blocking
+    for the full sleep duration.
+    """
+    sleep_task = asyncio.create_task(asyncio.sleep(seconds))
+    changed_task = asyncio.create_task(ctx.music_changed.wait())
+    _done, pending = await asyncio.wait(
+        {sleep_task, changed_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    for t in pending:
+        t.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await t
 
 
 def _slugify(text: str, max_len: int = 40) -> str:
@@ -1947,7 +1962,7 @@ async def _music_loop(ctx: DaemonContext) -> None:
                             # music proc) when max retries are exceeded.
                             gen_task = None
                             retry_count += 1
-                            logger.exception(
+                            logger.error(
                                 "Generation failed during playback "
                                 "(attempt %d/%d), old track continues",
                                 retry_count,
@@ -1970,6 +1985,7 @@ async def _music_loop(ctx: DaemonContext) -> None:
                             # after backoff.  The old track keeps looping.
                             await _music_backoff_sleep(
                                 2 ** (retry_count - 1),
+                                ctx,
                             )
                             gen_task = asyncio.create_task(
                                 _generate_music_track(ctx),
@@ -2073,7 +2089,7 @@ async def _music_loop(ctx: DaemonContext) -> None:
                 retry_count = 0
             else:
                 # Exponential backoff: 1s, 2s, 4s...
-                await _music_backoff_sleep(2 ** (retry_count - 1))
+                await _music_backoff_sleep(2 ** (retry_count - 1), ctx)
 
 
 async def _handle_music_on(

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1832,9 +1832,12 @@ async def _music_loop(ctx: DaemonContext) -> None:
     generation, the in-flight generation task is cancelled and a fresh
     one starts — the old track keeps looping throughout.
 
-    Crash recovery: on failure, logs the error, resets state, and
-    retries with backoff (3 attempts).  After 3 failures, sets
-    ``music_mode`` to "off".
+    Crash recovery: generation failures during playback are handled
+    inline — the old track keeps looping while the loop retries with
+    exponential backoff (up to 3 attempts).  After 3 consecutive
+    failures, ``music_mode`` is set to "off" and the old track is
+    killed.  Initial generation failures (no old track yet) propagate
+    to the outer handler which retries the entire cycle.
     """
     retry_count = 0
     current_track: Path | None = None
@@ -1938,8 +1941,41 @@ async def _music_loop(ctx: DaemonContext) -> None:
                     if gen_task is not None and gen_task.done():
                         exc = gen_task.exception()
                         if exc is not None:
+                            # Generation failed — handle inline so the
+                            # old track keeps looping.  Only propagate
+                            # to the outer handler (which kills the
+                            # music proc) when max retries are exceeded.
                             gen_task = None
-                            raise exc
+                            retry_count += 1
+                            logger.exception(
+                                "Generation failed during playback "
+                                "(attempt %d/%d), old track continues",
+                                retry_count,
+                                _MUSIC_MAX_RETRIES,
+                                exc_info=exc,
+                            )
+                            if retry_count >= _MUSIC_MAX_RETRIES:
+                                logger.error(
+                                    "Music generation failed %d times, disabling music",
+                                    _MUSIC_MAX_RETRIES,
+                                )
+                                ctx.music_mode = "off"
+                                retry_count = 0
+                                await _kill_music_proc(ctx)
+                                current_track = None
+                                ctx.music_state = "idle"
+                                proc_done = True
+                                break
+                            # Under max retries: start a new gen_task
+                            # after backoff.  The old track keeps looping.
+                            await _music_backoff_sleep(
+                                2 ** (retry_count - 1),
+                            )
+                            gen_task = asyncio.create_task(
+                                _generate_music_track(ctx),
+                            )
+                            ctx.music_state = "generating"
+                            continue
                         new_track = gen_task.result()
                         gen_task = None
                         ctx.music_track = new_track

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -3618,3 +3618,292 @@ class TestHandlerRegistration:
 
         assert "music_list" in _HANDLERS
         assert _HANDLERS["music_list"] is _handle_music_list
+
+
+class TestGenFailureKeepsOldTrack:
+    """Generation failure must not kill the old track subprocess.
+
+    Covers the fix for bead vox-m2l: when the generation task fails
+    during the playback loop, the old track keeps looping during
+    retry/backoff. Only max-retries or a successful handoff kills it.
+    """
+
+    def test_failure_then_success_old_track_alive_throughout(self) -> None:
+        """First generation (vibe change) fails, retry succeeds.
+
+        The old playback subprocess must remain alive (returncode is
+        None) during the entire failure + backoff + retry window.
+        """
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "[calm]")
+        ctx.music_changed.set()
+
+        generation_count = 0
+        # Snapshots of old-proc liveness taken during the failing gen
+        # and during the retry gen.
+        old_proc_alive_snapshots: list[bool] = []
+
+        async def fail_then_succeed(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal generation_count
+            generation_count += 1
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if generation_count == 2:
+                # Second generation (triggered by vibe change): FAIL.
+                # Snapshot old proc liveness before raising.
+                proc = ctx.music_proc
+                old_proc_alive_snapshots.append(
+                    proc is not None and proc.returncode is None,
+                )
+                msg = "network error"
+                raise RuntimeError(msg)
+
+            if generation_count == 3:
+                # Third generation (retry after failure): succeed.
+                # The old proc should STILL be alive during retry.
+                proc = ctx.music_proc
+                old_proc_alive_snapshots.append(
+                    proc is not None and proc.returncode is None,
+                )
+
+            output_path.write_bytes(b"fake-music-data")
+            return output_path
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = None
+
+            async def _wait() -> int:
+                if proc.returncode is not None:
+                    return int(proc.returncode)
+                await asyncio.sleep(5.0)
+                proc.returncode = 0
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock(
+                side_effect=lambda: setattr(proc, "returncode", -9),
+            )
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music."
+                    "ElevenLabsMusicProvider.generate_track",
+                    fail_then_succeed,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-gen-fail"),
+                ),
+                patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                # Let initial generation + first playback start.
+                await asyncio.sleep(0.05)
+
+                # Trigger vibe change — second generation will fail.
+                ctx.music_vibe = ("happy", "[warm]")
+                ctx.music_changed.set()
+
+                # Wait for failure + backoff + retry + handoff.
+                await asyncio.sleep(0.3)
+
+                ctx.music_mode = "off"
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        # Generation ran at least 3 times: initial, fail, retry.
+        assert generation_count >= 3, (
+            f"expected >=3 generations, got {generation_count}"
+        )
+        # Old track was alive during both the failing gen and the retry.
+        assert len(old_proc_alive_snapshots) >= 2, (
+            f"expected >=2 liveness snapshots, got {old_proc_alive_snapshots}"
+        )
+        assert all(old_proc_alive_snapshots), (
+            f"old track was killed during gen failure/retry: {old_proc_alive_snapshots}"
+        )
+
+    def test_max_retries_stops_music_mode(self) -> None:
+        """After max retries during playback, music_mode becomes 'off'."""
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "[calm]")
+        ctx.music_changed.set()
+
+        generation_count = 0
+
+        async def always_fail_after_first(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal generation_count
+            generation_count += 1
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if generation_count == 1:
+                # Initial generation succeeds.
+                output_path.write_bytes(b"fake-music-data")
+                return output_path
+
+            # All subsequent generations fail.
+            msg = f"generation failed (attempt {generation_count})"
+            raise RuntimeError(msg)
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = None
+
+            async def _wait() -> int:
+                if proc.returncode is not None:
+                    return int(proc.returncode)
+                await asyncio.sleep(5.0)
+                proc.returncode = 0
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock(
+                side_effect=lambda: setattr(proc, "returncode", -9),
+            )
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music."
+                    "ElevenLabsMusicProvider.generate_track",
+                    always_fail_after_first,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-gen-maxretry"),
+                ),
+                patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                # Let initial generation + first playback start.
+                await asyncio.sleep(0.05)
+
+                # Trigger vibe change — all subsequent gens will fail.
+                ctx.music_vibe = ("happy", "[warm]")
+                ctx.music_changed.set()
+
+                # Wait for 3 failures + final shutdown.
+                for _ in range(50):
+                    await asyncio.sleep(0.01)
+                    if ctx.music_mode == "off":
+                        break
+
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert ctx.music_mode == "off"
+        assert ctx.music_state == "idle"
+        # 1 initial success + 3 failures = 4 total.
+        assert generation_count == 4, (
+            f"expected 4 generations (1 ok + 3 fail), got {generation_count}"
+        )
+
+    def test_successful_handoff_after_retry_resets_counter(self) -> None:
+        """A successful handoff after one failure resets the retry counter."""
+        ctx = _make_ctx()
+        ctx.music_mode = "on"
+        ctx.music_owner = "test-session"
+        ctx.music_vibe = ("focused", "[calm]")
+        ctx.music_changed.set()
+
+        generation_count = 0
+
+        async def fail_once_then_succeed(
+            self: object, prompt: str, duration_ms: int, output_path: Path
+        ) -> Path:
+            nonlocal generation_count
+            generation_count += 1
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if generation_count == 2:
+                msg = "transient error"
+                raise RuntimeError(msg)
+
+            output_path.write_bytes(b"fake-music-data")
+            return output_path
+
+        async def fake_subprocess_exec(*args: object, **kwargs: object) -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = None
+
+            async def _wait() -> int:
+                if proc.returncode is not None:
+                    return int(proc.returncode)
+                await asyncio.sleep(5.0)
+                proc.returncode = 0
+                return 0
+
+            proc.wait = _wait
+            proc.kill = MagicMock(
+                side_effect=lambda: setattr(proc, "returncode", -9),
+            )
+            return proc
+
+        async def _drive() -> None:
+            with (
+                patch(
+                    "punt_vox.providers.elevenlabs_music."
+                    "ElevenLabsMusicProvider.generate_track",
+                    fail_once_then_succeed,
+                ),
+                patch(
+                    "punt_vox.voxd.asyncio.create_subprocess_exec",
+                    fake_subprocess_exec,
+                ),
+                patch(
+                    "punt_vox.voxd._music_output_dir",
+                    return_value=Path("/tmp/vox-test-gen-reset"),
+                ),
+                patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
+            ):
+                task = asyncio.create_task(_music_loop(ctx))
+                await asyncio.sleep(0.05)
+
+                # Trigger vibe change — gen #2 fails, #3 succeeds.
+                ctx.music_vibe = ("happy", "[warm]")
+                ctx.music_changed.set()
+                await asyncio.sleep(0.3)
+
+                # Music should still be on — the retry succeeded.
+                assert ctx.music_mode == "on"
+
+                ctx.music_mode = "off"
+                ctx.music_changed.set()
+                await asyncio.sleep(0.05)
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        asyncio.run(_drive())
+
+        assert generation_count >= 3
+        # Music stayed on because the retry succeeded.
+        # (We set it to "off" ourselves to clean up.)

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -3623,12 +3623,14 @@ class TestHandlerRegistration:
 class TestGenFailureKeepsOldTrack:
     """Generation failure must not kill the old track subprocess.
 
-    Covers the fix for bead vox-m2l: when the generation task fails
+    Covers the fix for issue vox-m2l: when the generation task fails
     during the playback loop, the old track keeps looping during
     retry/backoff. Only max-retries or a successful handoff kills it.
     """
 
-    def test_failure_then_success_old_track_alive_throughout(self) -> None:
+    def test_failure_then_success_old_track_alive_throughout(
+        self, tmp_path: Path
+    ) -> None:
         """First generation (vibe change) fails, retry succeeds.
 
         The old playback subprocess must remain alive (returncode is
@@ -3703,24 +3705,34 @@ class TestGenFailureKeepsOldTrack:
                 ),
                 patch(
                     "punt_vox.voxd._music_output_dir",
-                    return_value=Path("/tmp/vox-test-gen-fail"),
+                    return_value=tmp_path / "vox-test-gen-fail",
                 ),
                 patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
             ):
                 task = asyncio.create_task(_music_loop(ctx))
-                # Let initial generation + first playback start.
-                await asyncio.sleep(0.05)
+
+                # Poll until initial generation + first playback start.
+                for _ in range(100):
+                    await asyncio.sleep(0.01)
+                    if ctx.music_proc is not None:
+                        break
 
                 # Trigger vibe change — second generation will fail.
                 ctx.music_vibe = ("happy", "[warm]")
                 ctx.music_changed.set()
 
-                # Wait for failure + backoff + retry + handoff.
-                await asyncio.sleep(0.3)
+                # Poll until failure + backoff + retry + handoff complete.
+                for _ in range(100):
+                    await asyncio.sleep(0.01)
+                    if generation_count >= 3:
+                        break
 
                 ctx.music_mode = "off"
                 ctx.music_changed.set()
-                await asyncio.sleep(0.05)
+                for _ in range(50):
+                    await asyncio.sleep(0.01)
+                    if ctx.music_state == "idle":
+                        break
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
@@ -3739,7 +3751,7 @@ class TestGenFailureKeepsOldTrack:
             f"old track was killed during gen failure/retry: {old_proc_alive_snapshots}"
         )
 
-    def test_max_retries_stops_music_mode(self) -> None:
+    def test_max_retries_stops_music_mode(self, tmp_path: Path) -> None:
         """After max retries during playback, music_mode becomes 'off'."""
         ctx = _make_ctx()
         ctx.music_mode = "on"
@@ -3795,20 +3807,24 @@ class TestGenFailureKeepsOldTrack:
                 ),
                 patch(
                     "punt_vox.voxd._music_output_dir",
-                    return_value=Path("/tmp/vox-test-gen-maxretry"),
+                    return_value=tmp_path / "vox-test-gen-maxretry",
                 ),
                 patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
             ):
                 task = asyncio.create_task(_music_loop(ctx))
-                # Let initial generation + first playback start.
-                await asyncio.sleep(0.05)
+
+                # Poll until initial generation + first playback start.
+                for _ in range(100):
+                    await asyncio.sleep(0.01)
+                    if ctx.music_proc is not None:
+                        break
 
                 # Trigger vibe change — all subsequent gens will fail.
                 ctx.music_vibe = ("happy", "[warm]")
                 ctx.music_changed.set()
 
-                # Wait for 3 failures + final shutdown.
-                for _ in range(50):
+                # Poll for 3 failures + final shutdown.
+                for _ in range(100):
                     await asyncio.sleep(0.01)
                     if ctx.music_mode == "off":
                         break
@@ -3826,7 +3842,9 @@ class TestGenFailureKeepsOldTrack:
             f"expected 4 generations (1 ok + 3 fail), got {generation_count}"
         )
 
-    def test_successful_handoff_after_retry_resets_counter(self) -> None:
+    def test_successful_handoff_after_retry_resets_counter(
+        self, tmp_path: Path
+    ) -> None:
         """A successful handoff after one failure resets the retry counter."""
         ctx = _make_ctx()
         ctx.music_mode = "on"
@@ -3836,14 +3854,15 @@ class TestGenFailureKeepsOldTrack:
 
         generation_count = 0
 
-        async def fail_once_then_succeed(
+        async def fail_once_per_cycle(
             self: object, prompt: str, duration_ms: int, output_path: Path
         ) -> Path:
             nonlocal generation_count
             generation_count += 1
             output_path.parent.mkdir(parents=True, exist_ok=True)
 
-            if generation_count == 2:
+            # Fail once per vibe-change cycle: gen #2 and gen #4.
+            if generation_count in (2, 4):
                 msg = "transient error"
                 raise RuntimeError(msg)
 
@@ -3872,7 +3891,7 @@ class TestGenFailureKeepsOldTrack:
                 patch(
                     "punt_vox.providers.elevenlabs_music."
                     "ElevenLabsMusicProvider.generate_track",
-                    fail_once_then_succeed,
+                    fail_once_per_cycle,
                 ),
                 patch(
                     "punt_vox.voxd.asyncio.create_subprocess_exec",
@@ -3880,30 +3899,66 @@ class TestGenFailureKeepsOldTrack:
                 ),
                 patch(
                     "punt_vox.voxd._music_output_dir",
-                    return_value=Path("/tmp/vox-test-gen-reset"),
+                    return_value=tmp_path / "vox-test-gen-reset",
                 ),
                 patch("punt_vox.voxd._music_backoff_sleep", AsyncMock()),
             ):
                 task = asyncio.create_task(_music_loop(ctx))
-                await asyncio.sleep(0.05)
+
+                # Poll until initial generation + first playback start.
+                for _ in range(100):
+                    await asyncio.sleep(0.01)
+                    if ctx.music_proc is not None:
+                        break
 
                 # Trigger vibe change — gen #2 fails, #3 succeeds.
                 ctx.music_vibe = ("happy", "[warm]")
                 ctx.music_changed.set()
-                await asyncio.sleep(0.3)
+
+                # Poll until retry succeeds (generation_count >= 3).
+                for _ in range(100):
+                    await asyncio.sleep(0.01)
+                    if generation_count >= 3:
+                        break
 
                 # Music should still be on — the retry succeeded.
                 assert ctx.music_mode == "on"
 
+                # Now trigger a SECOND vibe change to prove the retry
+                # counter was actually reset. gen #4 will fail, #5
+                # will succeed. If the counter had accumulated from
+                # the first failure cycle, this second failure would
+                # push past max retries and turn music off.
+                ctx.music_vibe = ("energetic", "[bold]")
+                ctx.music_changed.set()
+
+                for _ in range(100):
+                    await asyncio.sleep(0.01)
+                    if generation_count >= 5:
+                        break
+
+                # Music is STILL on — the counter was reset by the
+                # first successful handoff and the second cycle's
+                # single failure did not exceed max retries.
+                assert ctx.music_mode == "on", (
+                    "retry counter was not reset: second failure cycle "
+                    "pushed past max retries"
+                )
+
                 ctx.music_mode = "off"
                 ctx.music_changed.set()
-                await asyncio.sleep(0.05)
+                for _ in range(50):
+                    await asyncio.sleep(0.01)
+                    if ctx.music_state == "idle":
+                        break
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
 
         asyncio.run(_drive())
 
-        assert generation_count >= 3
-        # Music stayed on because the retry succeeded.
-        # (We set it to "off" ourselves to clean up.)
+        assert generation_count >= 5, (
+            f"expected >=5 generations (2 cycles of fail+succeed), "
+            f"got {generation_count}"
+        )
+        # Music stayed on through both failure+retry cycles.


### PR DESCRIPTION
Generation failures no longer kill the old track. Exceptions caught inside the playback loop — old track keeps looping during retry/backoff. Max retries still stops music. 3 new tests. Mission m-2026-04-12-011. Closes vox-m2l.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the async music playback/generation loop and retry/backoff behavior, which could affect daemon state transitions and subprocess lifecycle under failure conditions. Changes are bounded and covered by new tests for failure, max-retry shutdown, and retry-counter reset behavior.
> 
> **Overview**
> Fixes the music playback loop so **music generation failures during an active playback no longer kill the existing track**; instead it logs the error, backs off, and retries generation inline while the old subprocess continues looping.
> 
> Updates backoff sleeping to be interruptible via `ctx.music_changed`/`music_mode` changes, and refines retry handling so only *consecutive* playback-time generation failures can disable music (and successful handoff resets the counter). Adds three targeted tests to ensure the old track stays alive across failures, max retries turns music off, and a successful retry resets the retry counter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dfd5636bb1864aec1042b2f45b57a053abfacf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->