### PR TITLE
fix(elevenlabs): add 30-minute TTL to voice cache (vox-bjw)

### DIFF
--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -67,8 +67,10 @@ def _load_voices_from_api(client: Any) -> None:  # pyright: ignore[reportExplici
     if _voices_loaded_at > 0.0 and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S:
         return
 
-    # Clear before re-fetching so deleted voices don't persist.
-    VOICES.clear()
+    # Fetch into a new dict, then swap atomically on success. If the
+    # API call raises, the old cache stays intact — no empty-cache
+    # window. The dict reference swap is atomic in CPython (GIL).
+    fresh: dict[str, str] = {}
 
     response: Any = client.voices.get_all()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     for voice in response.voices:  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
@@ -76,14 +78,18 @@ def _load_voices_from_api(client: Any) -> None:  # pyright: ignore[reportExplici
         vid: str = voice.voice_id  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         # Store full name (e.g. "adam - dominant, firm").
-        if full_name not in VOICES:
-            VOICES[full_name] = vid
+        if full_name not in fresh:
+            fresh[full_name] = vid
 
         # Also store short name (before " - ") for convenient lookup.
         short_name = full_name.split(" - ", 1)[0]
-        if short_name != full_name and short_name not in VOICES:
-            VOICES[short_name] = vid
+        if short_name != full_name and short_name not in fresh:
+            fresh[short_name] = vid
 
+    # Atomic swap: replace the cache contents in-place so existing
+    # references to the VOICES dict see the new data.
+    VOICES.clear()
+    VOICES.update(fresh)
     _voices_loaded_at = now
     logger.debug("Loaded %d voice entries from ElevenLabs API", len(VOICES))
 

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import tempfile
+import time
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -51,15 +52,23 @@ _VOICE_ID_RE = re.compile(r"^[0-9a-zA-Z]{20}$")
 # Cache of resolved voices, keyed by lowercase name → voice_id.
 VOICES: dict[str, str] = {}
 
-# Whether the voice list has been fetched from the API.
-_voices_loaded: bool = False
+# Monotonic timestamp of the last successful voice fetch (0.0 = never).
+_voices_loaded_at: float = 0.0
+
+# Voices are re-fetched after this many seconds so newly added voices
+# appear without a daemon restart.
+_VOICE_CACHE_TTL_S: int = 1800
 
 
 def _load_voices_from_api(client: Any) -> None:  # pyright: ignore[reportExplicitAny]
     """Fetch all voices from the ElevenLabs API and populate the cache."""
-    global _voices_loaded
-    if _voices_loaded:
+    global _voices_loaded_at
+    now = time.monotonic()
+    if _voices_loaded_at > 0.0 and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S:
         return
+
+    # Clear before re-fetching so deleted voices don't persist.
+    VOICES.clear()
 
     response: Any = client.voices.get_all()  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     for voice in response.voices:  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
@@ -75,7 +84,7 @@ def _load_voices_from_api(client: Any) -> None:  # pyright: ignore[reportExplici
         if short_name != full_name and short_name not in VOICES:
             VOICES[short_name] = vid
 
-    _voices_loaded = True
+    _voices_loaded_at = now
     logger.debug("Loaded %d voice entries from ElevenLabs API", len(VOICES))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,10 +176,12 @@ def mock_elevenlabs_client() -> MagicMock:
 @pytest.fixture(autouse=True)
 def _populate_elevenlabs_voice_cache() -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
     """Pre-populate the ElevenLabs voice cache so resolve_voice() never hits the API."""
+    import time
+
     import punt_vox.providers.elevenlabs as elevenlabs
 
     saved_voices = dict(elevenlabs.VOICES)
-    saved_loaded = elevenlabs._voices_loaded  # pyright: ignore[reportPrivateUsage]
+    saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
 
     elevenlabs.VOICES.update(
         {
@@ -187,13 +189,14 @@ def _populate_elevenlabs_voice_cache() -> Iterator[None]:  # pyright: ignore[rep
             "drew": "29vD33N1CtxCmqQRPOHJ",
         }
     )
-    elevenlabs._voices_loaded = True  # pyright: ignore[reportPrivateUsage]
+    # Set a recent timestamp so the cache appears fresh.
+    elevenlabs._voices_loaded_at = time.monotonic()  # pyright: ignore[reportPrivateUsage]
 
     yield
 
     elevenlabs.VOICES.clear()
     elevenlabs.VOICES.update(saved_voices)
-    elevenlabs._voices_loaded = saved_loaded  # pyright: ignore[reportPrivateUsage]
+    elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.fixture

--- a/tests/test_elevenlabs_provider.py
+++ b/tests/test_elevenlabs_provider.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from punt_vox.providers.elevenlabs import ElevenLabsProvider
+from punt_vox.providers.elevenlabs import (
+    _VOICE_CACHE_TTL_S,  # pyright: ignore[reportPrivateUsage]
+    ElevenLabsProvider,
+)
 from punt_vox.types import SynthesisRequest, VoiceNotFoundError
 
 
@@ -44,10 +48,10 @@ class TestElevenLabsProviderResolveVoice:
         import punt_vox.providers.elevenlabs as elevenlabs
 
         saved_voices = dict(elevenlabs.VOICES)
-        saved_loaded = elevenlabs._voices_loaded  # pyright: ignore[reportPrivateUsage]
+        saved_loaded = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
 
         elevenlabs.VOICES.clear()
-        elevenlabs._voices_loaded = False  # pyright: ignore[reportPrivateUsage]
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
 
         try:
             provider = ElevenLabsProvider(client=mock_elevenlabs_client)
@@ -57,7 +61,7 @@ class TestElevenLabsProviderResolveVoice:
         finally:
             elevenlabs.VOICES.clear()
             elevenlabs.VOICES.update(saved_voices)
-            elevenlabs._voices_loaded = saved_loaded  # pyright: ignore[reportPrivateUsage]
+            elevenlabs._voices_loaded_at = saved_loaded  # pyright: ignore[reportPrivateUsage]
 
     def test_resolve_short_name_from_api_with_descriptions(
         self, mock_elevenlabs_client: MagicMock
@@ -66,10 +70,10 @@ class TestElevenLabsProviderResolveVoice:
         import punt_vox.providers.elevenlabs as elevenlabs
 
         saved_voices = dict(elevenlabs.VOICES)
-        saved_loaded = elevenlabs._voices_loaded  # pyright: ignore[reportPrivateUsage]
+        saved_loaded = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
 
         elevenlabs.VOICES.clear()
-        elevenlabs._voices_loaded = False  # pyright: ignore[reportPrivateUsage]
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
 
         try:
             provider = ElevenLabsProvider(client=mock_elevenlabs_client)
@@ -84,7 +88,7 @@ class TestElevenLabsProviderResolveVoice:
         finally:
             elevenlabs.VOICES.clear()
             elevenlabs.VOICES.update(saved_voices)
-            elevenlabs._voices_loaded = saved_loaded  # pyright: ignore[reportPrivateUsage]
+            elevenlabs._voices_loaded_at = saved_loaded  # pyright: ignore[reportPrivateUsage]
 
     def test_resolve_unknown_raises(
         self, elevenlabs_provider: ElevenLabsProvider
@@ -445,3 +449,137 @@ class TestElevenLabsProviderLanguageSupport:
         request = SynthesisRequest(text="hello", voice="matilda", rate=100)
         result = elevenlabs_provider.synthesize(request, tmp_output_dir / "test.mp3")
         assert result.language is None
+
+
+class TestElevenLabsVoiceCacheTTL:
+    """Voice cache TTL: stale cache triggers re-fetch, fresh cache does not."""
+
+    def test_no_refetch_within_ttl(self, mock_elevenlabs_client: MagicMock) -> None:
+        """Within TTL, a second call does not re-fetch from the API."""
+        import punt_vox.providers.elevenlabs as elevenlabs
+
+        saved_voices = dict(elevenlabs.VOICES)
+        saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+        elevenlabs.VOICES.clear()
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+
+        try:
+            provider = ElevenLabsProvider(client=mock_elevenlabs_client)
+            # First call fetches.
+            provider.list_voices()
+            assert mock_elevenlabs_client.voices.get_all.call_count == 1
+
+            # Second call within TTL does not re-fetch.
+            provider.list_voices()
+            assert mock_elevenlabs_client.voices.get_all.call_count == 1
+        finally:
+            elevenlabs.VOICES.clear()
+            elevenlabs.VOICES.update(saved_voices)
+            elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+    def test_refetch_after_ttl_expires(self, mock_elevenlabs_client: MagicMock) -> None:
+        """After TTL expires, the next call re-fetches from the API."""
+        import punt_vox.providers.elevenlabs as elevenlabs
+
+        saved_voices = dict(elevenlabs.VOICES)
+        saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+        elevenlabs.VOICES.clear()
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+
+        try:
+            provider = ElevenLabsProvider(client=mock_elevenlabs_client)
+            # First call fetches.
+            provider.list_voices()
+            assert mock_elevenlabs_client.voices.get_all.call_count == 1
+
+            # Simulate TTL expiry by pushing the timestamp into the past.
+            elevenlabs._voices_loaded_at = time.monotonic() - _VOICE_CACHE_TTL_S - 1  # pyright: ignore[reportPrivateUsage]
+
+            # Next call re-fetches.
+            provider.list_voices()
+            assert mock_elevenlabs_client.voices.get_all.call_count == 2
+        finally:
+            elevenlabs.VOICES.clear()
+            elevenlabs.VOICES.update(saved_voices)
+            elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+    def test_new_voice_found_after_ttl_expiry(
+        self, mock_elevenlabs_client: MagicMock
+    ) -> None:
+        """A voice added after initial fetch is found after TTL expiry."""
+        import punt_vox.providers.elevenlabs as elevenlabs
+
+        saved_voices = dict(elevenlabs.VOICES)
+        saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+        elevenlabs.VOICES.clear()
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+
+        try:
+            provider = ElevenLabsProvider(client=mock_elevenlabs_client)
+            # First fetch: only matilda and drew.
+            provider.list_voices()
+
+            # The new voice "aria" does not exist yet.
+            with pytest.raises(VoiceNotFoundError):
+                provider.resolve_voice("aria")
+
+            # Simulate: user adds "aria" to their ElevenLabs account.
+            voice_aria = MagicMock()
+            voice_aria.name = "Aria - Expressive, warm"
+            voice_aria.voice_id = "9BWtsMINqrJLrRacOk9x"
+
+            old_voices = mock_elevenlabs_client.voices.get_all.return_value.voices
+            updated_response = MagicMock()
+            updated_response.voices = [*list(old_voices), voice_aria]
+            mock_elevenlabs_client.voices.get_all.return_value = updated_response
+
+            # Expire the cache.
+            elevenlabs._voices_loaded_at = time.monotonic() - _VOICE_CACHE_TTL_S - 1  # pyright: ignore[reportPrivateUsage]
+
+            # Now "aria" resolves after TTL-triggered re-fetch.
+            result = provider.resolve_voice("aria")
+            assert result == "aria"
+        finally:
+            elevenlabs.VOICES.clear()
+            elevenlabs.VOICES.update(saved_voices)
+            elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+    def test_deleted_voice_removed_after_ttl_expiry(
+        self, mock_elevenlabs_client: MagicMock
+    ) -> None:
+        """A voice removed from the account disappears after TTL expiry."""
+        import punt_vox.providers.elevenlabs as elevenlabs
+
+        saved_voices = dict(elevenlabs.VOICES)
+        saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+        elevenlabs.VOICES.clear()
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+
+        try:
+            provider = ElevenLabsProvider(client=mock_elevenlabs_client)
+            # First fetch: matilda and drew both present.
+            voices = provider.list_voices()
+            assert "drew" in voices
+
+            # Simulate: user removes "drew" from their account.
+            voice_matilda = MagicMock()
+            voice_matilda.name = "Matilda - Knowledgable, Professional"
+            voice_matilda.voice_id = "XrExE9yKIg1WjnnlVkGX"
+            updated_response = MagicMock()
+            updated_response.voices = [voice_matilda]
+            mock_elevenlabs_client.voices.get_all.return_value = updated_response
+
+            # Expire the cache.
+            elevenlabs._voices_loaded_at = time.monotonic() - _VOICE_CACHE_TTL_S - 1  # pyright: ignore[reportPrivateUsage]
+
+            # After re-fetch, "drew" is gone.
+            voices_after = provider.list_voices()
+            assert "drew" not in voices_after
+        finally:
+            elevenlabs.VOICES.clear()
+            elevenlabs.VOICES.update(saved_voices)
+            elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
Voice cache never refreshed — voices added to ElevenLabs account after daemon start were invisible until restart. Now clears and re-fetches after 30 minutes. 4 new tests. Mission m-2026-04-12-012. Closes vox-bjw.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to ElevenLabs voice-cache refresh behavior and associated tests, with minimal impact beyond potentially additional periodic API calls.
> 
> **Overview**
> **ElevenLabs voice caching now expires and refreshes.** The provider replaces the one-time `_voices_loaded` flag with a monotonic timestamp plus a 30-minute TTL so newly added/removed voices become visible without restarting.
> 
> The voice fetch path now builds a fresh map and atomically swaps `VOICES` only after a successful API call (avoiding an empty-cache window on errors). Tests/fixtures were updated and extended to cover TTL no-refetch, refetch-after-expiry, and add/remove voice scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2c3b35cbdc2267193e49d4de9a117f1c676399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->