### PR TITLE
fix(elevenlabs): force voice cache refresh on cache miss

### DIFF
--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -55,6 +55,10 @@ VOICES: dict[str, str] = {}
 # Monotonic timestamp of the last successful voice fetch (0.0 = never).
 _voices_loaded_at: float = 0.0
 
+# Minimum interval between forced refreshes (cache-miss path).
+# Prevents typos or unknown voice names from hammering the API.
+_VOICE_FORCE_COOLDOWN_S: int = 60
+
 # Voices are re-fetched after this many seconds so newly added voices
 # appear without a daemon restart.
 _VOICE_CACHE_TTL_S: int = 1800
@@ -64,16 +68,25 @@ def _load_voices_from_api(client: Any, *, force: bool = False) -> None:  # pyrig
     """Fetch all voices from the ElevenLabs API and populate the cache.
 
     Args:
-        force: Bypass TTL check and re-fetch immediately. Used on cache
-            miss so newly added voices are found without waiting for
-            the 30-minute TTL.
+        force: Bypass the TTL check on cache miss so newly added voices
+            are found without waiting 30 minutes. Rate-limited by
+            ``_VOICE_FORCE_COOLDOWN_S`` (60s) to prevent typos from
+            hammering the API.
     """
     global _voices_loaded_at
     now = time.monotonic()
     cache_fresh = (
         _voices_loaded_at > 0.0 and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S
     )
-    if not force and cache_fresh:
+    if force:
+        # Rate-limit forced refreshes — don't re-fetch if we just did.
+        recently_loaded = (
+            _voices_loaded_at > 0.0
+            and (now - _voices_loaded_at) < _VOICE_FORCE_COOLDOWN_S
+        )
+        if recently_loaded:
+            return
+    elif cache_fresh:
         return
 
     # Fetch into a new dict, then swap atomically on success. If the

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -71,8 +71,7 @@ def _load_voices_from_api(client: Any, *, force: bool = False) -> None:  # pyrig
     global _voices_loaded_at
     now = time.monotonic()
     cache_fresh = (
-        _voices_loaded_at > 0.0
-        and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S
+        _voices_loaded_at > 0.0 and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S
     )
     if not force and cache_fresh:
         return

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -60,11 +60,21 @@ _voices_loaded_at: float = 0.0
 _VOICE_CACHE_TTL_S: int = 1800
 
 
-def _load_voices_from_api(client: Any) -> None:  # pyright: ignore[reportExplicitAny]
-    """Fetch all voices from the ElevenLabs API and populate the cache."""
+def _load_voices_from_api(client: Any, *, force: bool = False) -> None:  # pyright: ignore[reportExplicitAny]
+    """Fetch all voices from the ElevenLabs API and populate the cache.
+
+    Args:
+        force: Bypass TTL check and re-fetch immediately. Used on cache
+            miss so newly added voices are found without waiting for
+            the 30-minute TTL.
+    """
     global _voices_loaded_at
     now = time.monotonic()
-    if _voices_loaded_at > 0.0 and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S:
+    cache_fresh = (
+        _voices_loaded_at > 0.0
+        and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S
+    )
+    if not force and cache_fresh:
         return
 
     # Fetch into a new dict, then swap atomically on success. If the
@@ -300,7 +310,9 @@ class ElevenLabsProvider:
         if key in VOICES:
             return VOICES[key]
 
-        _load_voices_from_api(self._client)
+        # Cache miss — force a re-fetch regardless of TTL. If the user
+        # just added a voice, waiting 30 minutes is unacceptable.
+        _load_voices_from_api(self._client, force=True)
 
         if key in VOICES:
             return VOICES[key]

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -55,6 +55,11 @@ VOICES: dict[str, str] = {}
 # Monotonic timestamp of the last successful voice fetch (0.0 = never).
 _voices_loaded_at: float = 0.0
 
+# Monotonic timestamp of the last *forced* refresh (0.0 = never).
+# Separate from _voices_loaded_at so a TTL-triggered load doesn't
+# block the first forced refresh on a cache miss.
+_voices_force_fetched_at: float = 0.0
+
 # Minimum interval between forced refreshes (cache-miss path).
 # Prevents typos or unknown voice names from hammering the API.
 _VOICE_FORCE_COOLDOWN_S: int = 60
@@ -73,16 +78,18 @@ def _load_voices_from_api(client: Any, *, force: bool = False) -> None:  # pyrig
             ``_VOICE_FORCE_COOLDOWN_S`` (60s) to prevent typos from
             hammering the API.
     """
-    global _voices_loaded_at
+    global _voices_loaded_at, _voices_force_fetched_at
     now = time.monotonic()
     cache_fresh = (
         _voices_loaded_at > 0.0 and (now - _voices_loaded_at) < _VOICE_CACHE_TTL_S
     )
     if force:
-        # Rate-limit forced refreshes — don't re-fetch if we just did.
+        # Rate-limit forced refreshes — don't re-fetch if we just
+        # did a forced fetch recently. Uses a separate timestamp so
+        # a normal TTL-triggered load doesn't block the first force.
         recently_loaded = (
-            _voices_loaded_at > 0.0
-            and (now - _voices_loaded_at) < _VOICE_FORCE_COOLDOWN_S
+            _voices_force_fetched_at > 0.0
+            and (now - _voices_force_fetched_at) < _VOICE_FORCE_COOLDOWN_S
         )
         if recently_loaded:
             return
@@ -113,6 +120,8 @@ def _load_voices_from_api(client: Any, *, force: bool = False) -> None:  # pyrig
     VOICES.clear()
     VOICES.update(fresh)
     _voices_loaded_at = now
+    if force:
+        _voices_force_fetched_at = now
     logger.debug("Loaded %d voice entries from ElevenLabs API", len(VOICES))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,7 @@ def _populate_elevenlabs_voice_cache() -> Iterator[None]:  # pyright: ignore[rep
 
     saved_voices = dict(elevenlabs.VOICES)
     saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+    saved_force_at = elevenlabs._voices_force_fetched_at  # pyright: ignore[reportPrivateUsage]
 
     elevenlabs.VOICES.update(
         {
@@ -197,6 +198,7 @@ def _populate_elevenlabs_voice_cache() -> Iterator[None]:  # pyright: ignore[rep
     elevenlabs.VOICES.clear()
     elevenlabs.VOICES.update(saved_voices)
     elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+    elevenlabs._voices_force_fetched_at = saved_force_at  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.fixture

--- a/tests/test_elevenlabs_provider.py
+++ b/tests/test_elevenlabs_provider.py
@@ -513,9 +513,11 @@ class TestElevenLabsVoiceCacheTTL:
 
         saved_voices = dict(elevenlabs.VOICES)
         saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+        saved_force_at = elevenlabs._voices_force_fetched_at  # pyright: ignore[reportPrivateUsage]
 
         elevenlabs.VOICES.clear()
         elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+        elevenlabs._voices_force_fetched_at = 0.0  # pyright: ignore[reportPrivateUsage]
 
         try:
             provider = ElevenLabsProvider(client=mock_elevenlabs_client)
@@ -595,9 +597,11 @@ class TestElevenLabsVoiceCacheTTL:
 
         saved_voices = dict(elevenlabs.VOICES)
         saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+        saved_force_at = elevenlabs._voices_force_fetched_at  # pyright: ignore[reportPrivateUsage]
 
         elevenlabs.VOICES.clear()
         elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+        elevenlabs._voices_force_fetched_at = 0.0  # pyright: ignore[reportPrivateUsage]
 
         try:
             provider = ElevenLabsProvider(client=mock_elevenlabs_client)
@@ -623,3 +627,4 @@ class TestElevenLabsVoiceCacheTTL:
             elevenlabs.VOICES.clear()
             elevenlabs.VOICES.update(saved_voices)
             elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+            elevenlabs._voices_force_fetched_at = saved_force_at  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_elevenlabs_provider.py
+++ b/tests/test_elevenlabs_provider.py
@@ -536,16 +536,19 @@ class TestElevenLabsVoiceCacheTTL:
             updated_response.voices = [*list(old_voices), voice_aria]
             mock_elevenlabs_client.voices.get_all.return_value = updated_response
 
-            # Expire the cache.
+            # Expire the cache and reset force cooldown so the next
+            # miss triggers a fresh fetch.
             elevenlabs._voices_loaded_at = time.monotonic() - _VOICE_CACHE_TTL_S - 1  # pyright: ignore[reportPrivateUsage]
+            elevenlabs._voices_force_fetched_at = 0.0  # pyright: ignore[reportPrivateUsage]
 
-            # Now "aria" resolves after TTL-triggered re-fetch.
+            # Now "aria" resolves after re-fetch.
             result = provider.resolve_voice("aria")
             assert result == "aria"
         finally:
             elevenlabs.VOICES.clear()
             elevenlabs.VOICES.update(saved_voices)
             elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+            elevenlabs._voices_force_fetched_at = 0.0  # pyright: ignore[reportPrivateUsage]
 
     def test_deleted_voice_removed_after_ttl_expiry(
         self, mock_elevenlabs_client: MagicMock
@@ -579,6 +582,43 @@ class TestElevenLabsVoiceCacheTTL:
             # After re-fetch, "drew" is gone.
             voices_after = provider.list_voices()
             assert "drew" not in voices_after
+        finally:
+            elevenlabs.VOICES.clear()
+            elevenlabs.VOICES.update(saved_voices)
+            elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+    def test_cache_miss_forces_single_refetch_then_cooldown(
+        self, mock_elevenlabs_client: MagicMock
+    ) -> None:
+        """Cache miss forces one re-fetch; repeated misses within cooldown don't."""
+        import punt_vox.providers.elevenlabs as elevenlabs
+
+        saved_voices = dict(elevenlabs.VOICES)
+        saved_loaded_at = elevenlabs._voices_loaded_at  # pyright: ignore[reportPrivateUsage]
+
+        elevenlabs.VOICES.clear()
+        elevenlabs._voices_loaded_at = 0.0  # pyright: ignore[reportPrivateUsage]
+
+        try:
+            provider = ElevenLabsProvider(client=mock_elevenlabs_client)
+            # Initial fetch populates the cache.
+            provider.list_voices()
+            assert mock_elevenlabs_client.voices.get_all.call_count == 1
+
+            # "zzz_unknown" is not in the cache — triggers a forced re-fetch.
+            with pytest.raises(VoiceNotFoundError):
+                provider.resolve_voice("zzz_unknown")
+            assert mock_elevenlabs_client.voices.get_all.call_count == 2
+
+            # Same unknown voice again within cooldown — no additional fetch.
+            with pytest.raises(VoiceNotFoundError):
+                provider.resolve_voice("zzz_unknown")
+            assert mock_elevenlabs_client.voices.get_all.call_count == 2
+
+            # A different unknown voice within cooldown — still no fetch.
+            with pytest.raises(VoiceNotFoundError):
+                provider.resolve_voice("yyy_also_unknown")
+            assert mock_elevenlabs_client.voices.get_all.call_count == 2
         finally:
             elevenlabs.VOICES.clear()
             elevenlabs.VOICES.update(saved_voices)

--- a/tests/test_elevenlabs_provider.py
+++ b/tests/test_elevenlabs_provider.py
@@ -550,7 +550,7 @@ class TestElevenLabsVoiceCacheTTL:
             elevenlabs.VOICES.clear()
             elevenlabs.VOICES.update(saved_voices)
             elevenlabs._voices_loaded_at = saved_loaded_at  # pyright: ignore[reportPrivateUsage]
-            elevenlabs._voices_force_fetched_at = 0.0  # pyright: ignore[reportPrivateUsage]
+            elevenlabs._voices_force_fetched_at = saved_force_at  # pyright: ignore[reportPrivateUsage]
 
     def test_deleted_voice_removed_after_ttl_expiry(
         self, mock_elevenlabs_client: MagicMock


### PR DESCRIPTION
When a voice isn't in the cache, force a re-fetch regardless of TTL. A user who just added a voice shouldn't have to wait 30 minutes. The TTL still prevents re-fetching on every call for voices that *are* in the cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ElevenLabs voice resolution to trigger a forced API refresh on cache misses, which could increase API traffic or mask caching assumptions if cooldown logic is wrong. Added cooldown and expanded tests reduce the likelihood but behavior changes in a live API integration remain moderately risky.
> 
> **Overview**
> **ElevenLabs voice resolution now forces a cache refresh on voice-name cache misses** so newly added voices can be resolved immediately instead of waiting for the 30-minute TTL.
> 
> Adds a separate forced-refresh timestamp plus a 60s cooldown to prevent repeated unknown/typo lookups from hammering `voices.get_all`, updates test fixtures to track the new timestamp, and introduces a new test covering the forced-refresh + cooldown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb39c3b336fd6e04f6cd14cb1a846c4d53a4a9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->