### PR TITLE
fix(providers): strip vibe tags for non-v3 providers (vox-9bo)

### DIFF
--- a/src/punt_vox/normalize.py
+++ b/src/punt_vox/normalize.py
@@ -532,18 +532,31 @@ _VIBE_TAG_RE = re.compile(r"\[([a-z]+(?:\s[a-z]+)?)\]")
 def strip_vibe_tags(text: str) -> str:
     """Remove ElevenLabs-style expressive tags from *text*.
 
-    Strips bracketed tokens that contain one or two lowercase-alpha
-    words -- e.g. ``[serious]``, ``[slow breath]``, ``[sighs]``.
+    Strips bracketed tokens **at any position** that contain one or two
+    lowercase-alpha words -- e.g. ``[serious]``, ``[slow breath]``,
+    ``[sighs]``.
 
     Preserves brackets that don't match this narrow pattern:
     ``[Figure 1]`` (uppercase), ``[1]`` (digits), ``[citation needed]``
     (three words), ``[IMPORTANT]`` (all caps).
 
     Collapses any extra whitespace left behind after removal.
+
+    .. note::
+
+       ``resolve.strip_expressive_tags`` strips only *leading* tags and
+       is used during vibe application (before synthesis).  This function
+       strips tags at *any* position and is used by providers that do not
+       support expressive tags at all (say, espeak) to sanitise the full
+       text before passing it to a subprocess.
     """
     result = _VIBE_TAG_RE.sub("", text)
     # Collapse runs of whitespace left behind by removal.
     result = re.sub(r"  +", " ", result).strip()
+    # Guard: if stripping removed all content, return original text
+    # unchanged so providers don't receive an empty string.
+    if not result:
+        return text
     return result
 
 

--- a/src/punt_vox/normalize.py
+++ b/src/punt_vox/normalize.py
@@ -526,6 +526,27 @@ _FILE_PATH_RE = re.compile(r"^[~/.]?/")
 # ---------------------------------------------------------------------------
 
 
+_VIBE_TAG_RE = re.compile(r"\[([a-z]+(?:\s[a-z]+)?)\]")
+
+
+def strip_vibe_tags(text: str) -> str:
+    """Remove ElevenLabs-style expressive tags from *text*.
+
+    Strips bracketed tokens that contain one or two lowercase-alpha
+    words -- e.g. ``[serious]``, ``[slow breath]``, ``[sighs]``.
+
+    Preserves brackets that don't match this narrow pattern:
+    ``[Figure 1]`` (uppercase), ``[1]`` (digits), ``[citation needed]``
+    (three words), ``[IMPORTANT]`` (all caps).
+
+    Collapses any extra whitespace left behind after removal.
+    """
+    result = _VIBE_TAG_RE.sub("", text)
+    # Collapse runs of whitespace left behind by removal.
+    result = re.sub(r"  +", " ", result).strip()
+    return result
+
+
 def normalize_for_speech(text: str) -> str:
     """Normalize programmer strings in *text* to natural spoken English.
 

--- a/src/punt_vox/normalize.py
+++ b/src/punt_vox/normalize.py
@@ -526,19 +526,19 @@ _FILE_PATH_RE = re.compile(r"^[~/.]?/")
 # ---------------------------------------------------------------------------
 
 
-_VIBE_TAG_RE = re.compile(r"\[([a-z]+(?:\s[a-z]+)?)\]")
+_VIBE_TAG_RE = re.compile(r"\[([a-z]+)\]")
 
 
 def strip_vibe_tags(text: str) -> str:
     """Remove ElevenLabs-style expressive tags from *text*.
 
-    Strips bracketed tokens **at any position** that contain one or two
-    lowercase-alpha words -- e.g. ``[serious]``, ``[slow breath]``,
-    ``[sighs]``.
+    Strips bracketed tokens **at any position** that contain a single
+    lowercase-alpha word -- e.g. ``[serious]``, ``[warm]``, ``[sighs]``.
 
     Preserves brackets that don't match this narrow pattern:
-    ``[Figure 1]`` (uppercase), ``[1]`` (digits), ``[citation needed]``
-    (three words), ``[IMPORTANT]`` (all caps).
+    ``[Figure 1]`` (has space/uppercase), ``[1]`` (digits),
+    ``[citation needed]`` (two words), ``[slow breath]`` (two words),
+    ``[IMPORTANT]`` (all caps).
 
     Collapses any extra whitespace left behind after removal.
 

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from elevenlabs.core import ApiError  # pyright: ignore[reportMissingTypeStubs]
 
+from punt_vox.normalize import strip_vibe_tags
 from punt_vox.output import resolve_output_path
 from punt_vox.types import (
     AudioProviderId,
@@ -204,6 +205,12 @@ class ElevenLabsProvider:
         self, request: SynthesisRequest, output_path: Path
     ) -> SynthesisResult:
         """Synthesize text to an MP3 file using ElevenLabs."""
+        # Strip expressive tags for models that don't interpret them,
+        # so the TTS engine doesn't speak "[serious]" as a literal word.
+        text = request.text
+        if not self.supports_expressive_tags:
+            text = strip_vibe_tags(text)
+
         resolved_voice = request.voice or self.default_voice
         voice_id = self._resolve_voice_id(resolved_voice)
         rate = request.rate if request.rate is not None else 100
@@ -217,10 +224,13 @@ class ElevenLabsProvider:
 
         char_limit = _MODEL_CHAR_LIMITS.get(self._model, _DEFAULT_CHAR_LIMIT)
 
-        if len(request.text) > char_limit:
-            self._chunked_synthesize(request, output_path, voice_id, char_limit)
+        if len(text) > char_limit:
+            from dataclasses import replace as _replace
+
+            req = _replace(request, text=text)
+            self._chunked_synthesize(req, output_path, voice_id, char_limit)
         else:
-            self._single_synthesize(request.text, output_path, voice_id, request)
+            self._single_synthesize(text, output_path, voice_id, request)
 
         logger.info("Wrote %s", output_path)
         display_voice = (
@@ -230,7 +240,7 @@ class ElevenLabsProvider:
         )
         return SynthesisResult(
             path=output_path,
-            text=request.text,
+            text=text,
             provider=AudioProviderId.elevenlabs,
             voice=display_voice,
             language=request.language,

--- a/src/punt_vox/providers/espeak.py
+++ b/src/punt_vox/providers/espeak.py
@@ -230,19 +230,20 @@ class EspeakProvider:
         entirely: same syscall and same audio session as a user shell.
         """
         voice_cfg, wpm = self._resolve_voice_and_rate(request)
+        text = strip_vibe_tags(request.text)
         cmd = [
             self._binary,
             "-v",
             voice_cfg.name,
             "-s",
             str(wpm),
-            request.text,
+            text,
         ]
         logger.info(
             "espeak direct-play: voice=%s wpm=%d chars=%d",
             voice_cfg.name,
             wpm,
-            len(request.text),
+            len(text),
         )
         try:
             result = subprocess.run(

--- a/src/punt_vox/providers/espeak.py
+++ b/src/punt_vox/providers/espeak.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from punt_vox.normalize import strip_vibe_tags
 from punt_vox.output import resolve_output_path
 from punt_vox.types import (
     AudioProviderId,
@@ -269,6 +270,8 @@ class EspeakProvider:
 
         Produces WAV via espeak-ng, then converts to MP3 via ffmpeg.
         """
+        text = strip_vibe_tags(request.text)
+
         voice_cfg, wpm = self._resolve_voice_and_rate(request)
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -286,7 +289,7 @@ class EspeakProvider:
                     str(wpm),
                     "-w",
                     str(wav_path),
-                    request.text,
+                    text,
                 ],
                 check=True,
                 timeout=60,
@@ -295,7 +298,7 @@ class EspeakProvider:
                 "espeak-ng: voice=%s, wpm=%d, chars=%d",
                 voice_cfg.name,
                 wpm,
-                len(request.text),
+                len(text),
             )
 
             subprocess.run(
@@ -322,7 +325,7 @@ class EspeakProvider:
         language = request.language or voice_cfg.language
         return SynthesisResult(
             path=output_path,
-            text=request.text,
+            text=text,
             provider=AudioProviderId.espeak,
             voice=voice_cfg.name,
             language=language,

--- a/src/punt_vox/providers/openai.py
+++ b/src/punt_vox/providers/openai.py
@@ -12,6 +12,7 @@ from typing import Any
 import openai
 
 from punt_vox.core import split_text
+from punt_vox.normalize import strip_vibe_tags
 from punt_vox.output import resolve_output_path
 from punt_vox.types import (
     AudioProviderId,
@@ -83,20 +84,25 @@ class OpenAIProvider:
         self, request: SynthesisRequest, output_path: Path
     ) -> SynthesisResult:
         """Synthesize text to an MP3 file using OpenAI TTS."""
+        text = strip_vibe_tags(request.text)
+
         resolved_voice = request.voice or self.default_voice
         voice = self._resolve_voice_name(resolved_voice)
         rate = request.rate if request.rate is not None else 90
         speed = self._rate_to_speed(rate)
 
-        if len(request.text) > _MAX_CHARS:
-            self._chunked_synthesize(request, output_path, voice, speed)
+        if len(text) > _MAX_CHARS:
+            from dataclasses import replace as _replace
+
+            stripped_request = _replace(request, text=text)
+            self._chunked_synthesize(stripped_request, output_path, voice, speed)
         else:
-            self._single_synthesize(request.text, output_path, voice, speed)
+            self._single_synthesize(text, output_path, voice, speed)
 
         logger.info("Wrote %s", output_path)
         return SynthesisResult(
             path=output_path,
-            text=request.text,
+            text=text,
             provider=AudioProviderId.openai,
             voice=voice,
             language=request.language,

--- a/src/punt_vox/providers/polly.py
+++ b/src/punt_vox/providers/polly.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import boto3
 
+from punt_vox.normalize import strip_vibe_tags
 from punt_vox.output import resolve_output_path
 from punt_vox.types import (
     AudioProviderId,
@@ -227,10 +228,12 @@ class PollyProvider:
         Resolves the voice name to Polly parameters internally, wraps
         the text in SSML with prosody rate, and writes the MP3 output.
         """
+        text = strip_vibe_tags(request.text)
+
         resolved_voice = request.voice or self.default_voice
         voice_cfg = self._resolve_voice_config(resolved_voice)
         rate = request.rate if request.rate is not None else 100
-        ssml_text = f'<speak><prosody rate="{rate}%">{request.text}</prosody></speak>'
+        ssml_text = f'<speak><prosody rate="{rate}%">{text}</prosody></speak>'
         response = self._client.synthesize_speech(
             Text=ssml_text,
             TextType="ssml",
@@ -244,7 +247,7 @@ class PollyProvider:
         logger.info(
             "API call: provider=polly, voice=%s, chars=%d",
             voice_cfg.voice_id,
-            len(request.text),
+            len(text),
         )
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -254,7 +257,7 @@ class PollyProvider:
         language = request.language or _infer_iso_from_bcp47(voice_cfg.language_code)
         return SynthesisResult(
             path=output_path,
-            text=request.text,
+            text=text,
             provider=AudioProviderId.polly,
             voice=voice_cfg.voice_id,
             language=language,

--- a/src/punt_vox/providers/say.py
+++ b/src/punt_vox/providers/say.py
@@ -185,19 +185,20 @@ class SayProvider:
         Bypasses the AIFF -> ffmpeg -> MP3 -> ffplay pipeline.
         """
         voice_cfg, wpm = self._resolve_voice_and_rate(request)
+        text = strip_vibe_tags(request.text)
         cmd = [
             "say",
             "-v",
             voice_cfg.name,
             "-r",
             str(wpm),
-            request.text,
+            text,
         ]
         logger.info(
             "say direct-play: voice=%s wpm=%d chars=%d",
             voice_cfg.name,
             wpm,
-            len(request.text),
+            len(text),
         )
         try:
             result = subprocess.run(

--- a/src/punt_vox/providers/say.py
+++ b/src/punt_vox/providers/say.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from punt_vox.normalize import strip_vibe_tags
 from punt_vox.output import resolve_output_path
 from punt_vox.types import (
     AudioProviderId,
@@ -226,6 +227,8 @@ class SayProvider:
 
         Produces AIFF via say, then converts to MP3 via ffmpeg.
         """
+        text = strip_vibe_tags(request.text)
+
         voice_cfg, wpm = self._resolve_voice_and_rate(request)
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -243,7 +246,7 @@ class SayProvider:
                     str(wpm),
                     "-o",
                     str(aiff_path),
-                    request.text,
+                    text,
                 ],
                 check=True,
                 timeout=60,
@@ -254,7 +257,7 @@ class SayProvider:
                 "say: voice=%s, wpm=%d, chars=%d",
                 voice_cfg.name,
                 wpm,
-                len(request.text),
+                len(text),
             )
 
             subprocess.run(
@@ -282,7 +285,7 @@ class SayProvider:
         language = request.language or _locale_to_iso(voice_cfg.locale)
         return SynthesisResult(
             path=output_path,
-            text=request.text,
+            text=text,
             provider=AudioProviderId.say,
             voice=voice_cfg.name,
             language=language,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ import pytest
 from pydub import AudioSegment
 
 from punt_vox.core import TRAILING_SILENCE_MS, TTSClient, stitch_audio
+from punt_vox.providers.elevenlabs import ElevenLabsProvider
 from punt_vox.types import (
     MergeStrategy,
     SynthesisRequest,
@@ -365,3 +366,101 @@ class TestTrailingSilence:
         buf = io.BytesIO()
         silence.export(buf, format="mp3")  # pyright: ignore[reportUnknownMemberType]
         return buf.getvalue()
+
+
+class TestVibeTagStripping:
+    """Verify that providers strip vibe tags before synthesis."""
+
+    def test_polly_strips_vibe_tags(
+        self,
+        mock_boto_client: MagicMock,
+        tts_client: TTSClient,
+        tmp_output_dir: Path,
+    ) -> None:
+        """Polly should never see bracketed vibe tags in the SSML text."""
+        request = SynthesisRequest(text="[serious] Hello world", voice="joanna")
+        out = tmp_output_dir / "stripped.mp3"
+
+        result = tts_client.synthesize(request, out)
+
+        call_kwargs = mock_boto_client.synthesize_speech.call_args.kwargs
+        assert "[serious]" not in call_kwargs["Text"]
+        assert "Hello world" in call_kwargs["Text"]
+        assert result.text == "Hello world"
+
+    def test_polly_preserves_non_tag_brackets(
+        self,
+        mock_boto_client: MagicMock,
+        tts_client: TTSClient,
+        tmp_output_dir: Path,
+    ) -> None:
+        """Brackets with uppercase or numbers should survive stripping."""
+        request = SynthesisRequest(text="See [Figure 1] for details", voice="joanna")
+        out = tmp_output_dir / "preserved.mp3"
+
+        result = tts_client.synthesize(request, out)
+
+        call_kwargs = mock_boto_client.synthesize_speech.call_args.kwargs
+        assert "[Figure 1]" in call_kwargs["Text"]
+        assert result.text == "See [Figure 1] for details"
+
+    def test_elevenlabs_v3_keeps_tags(
+        self,
+        mock_elevenlabs_client: MagicMock,
+        tmp_output_dir: Path,
+    ) -> None:
+        """ElevenLabs eleven_v3 model should keep expressive tags intact."""
+        provider = ElevenLabsProvider(model="eleven_v3", client=mock_elevenlabs_client)
+        client = TTSClient(provider)
+        request = SynthesisRequest(text="[serious] Hello world", voice="matilda")
+        out = tmp_output_dir / "kept.mp3"
+
+        result = client.synthesize(request, out)
+
+        call_kwargs = mock_elevenlabs_client.text_to_speech.stream.call_args.kwargs
+        assert "[serious]" in call_kwargs["text"]
+        assert result.text == "[serious] Hello world"
+
+    def test_elevenlabs_flash_strips_tags(
+        self,
+        mock_elevenlabs_client: MagicMock,
+        tmp_output_dir: Path,
+    ) -> None:
+        """ElevenLabs non-v3 models should strip expressive tags."""
+        provider = ElevenLabsProvider(
+            model="eleven_flash_v2_5", client=mock_elevenlabs_client
+        )
+        client = TTSClient(provider)
+        request = SynthesisRequest(text="[warm] Hello world", voice="matilda")
+        out = tmp_output_dir / "stripped.mp3"
+
+        result = client.synthesize(request, out)
+
+        call_kwargs = mock_elevenlabs_client.text_to_speech.stream.call_args.kwargs
+        assert "[warm]" not in call_kwargs["text"]
+        assert "Hello world" in call_kwargs["text"]
+        assert result.text == "Hello world"
+
+    def test_polly_strips_multiple_tags(
+        self,
+        mock_boto_client: MagicMock,
+        tts_client: TTSClient,
+        tmp_output_dir: Path,
+    ) -> None:
+        """Multiple vibe tags at various positions should all be stripped."""
+        request = SynthesisRequest(
+            text="[warm] Start [excited] middle [calm] end",
+            voice="joanna",
+        )
+        out = tmp_output_dir / "multi.mp3"
+
+        result = tts_client.synthesize(request, out)
+
+        call_kwargs = mock_boto_client.synthesize_speech.call_args.kwargs
+        assert "[warm]" not in call_kwargs["Text"]
+        assert "[excited]" not in call_kwargs["Text"]
+        assert "[calm]" not in call_kwargs["Text"]
+        assert "Start" in call_kwargs["Text"]
+        assert "middle" in call_kwargs["Text"]
+        assert "end" in call_kwargs["Text"]
+        assert result.text == "Start middle end"

--- a/tests/test_espeak_provider.py
+++ b/tests/test_espeak_provider.py
@@ -384,6 +384,16 @@ class TestEspeakProviderPlayDirectly:
             )
         assert rc == 3
 
+    def test_strips_vibe_tags(self, espeak_provider: EspeakProvider) -> None:
+        mock = MagicMock(return_value=subprocess.CompletedProcess([], 0, b"", b""))
+        with patch("punt_vox.providers.espeak.subprocess.run", mock):
+            espeak_provider.play_directly(
+                SynthesisRequest(text="[serious] Hello world", voice="en")
+            )
+        args = mock.call_args[0][0]
+        assert "Hello world" in args
+        assert "[serious]" not in " ".join(args)
+
     def test_binary_missing_returns_error(
         self, espeak_provider: EspeakProvider
     ) -> None:

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from punt_vox.normalize import normalize_for_speech
+from punt_vox.normalize import normalize_for_speech, strip_vibe_tags
 
 # ---------------------------------------------------------------------------
 # snake_case splitting
@@ -334,3 +334,79 @@ class TestSymbolStripping:
 
     def test_punctuation_only_token_dropped(self) -> None:
         assert normalize_for_speech("hello () world") == "hello world"
+
+
+# ---------------------------------------------------------------------------
+# strip_vibe_tags
+# ---------------------------------------------------------------------------
+
+
+class TestStripVibeTags:
+    """Tests for strip_vibe_tags — removal of ElevenLabs expressive tags."""
+
+    def test_single_word_tag(self) -> None:
+        assert strip_vibe_tags("[serious] Hello world") == "Hello world"
+
+    def test_two_word_tag(self) -> None:
+        assert strip_vibe_tags("[slow breath] Hello world") == "Hello world"
+
+    def test_tag_at_end(self) -> None:
+        assert strip_vibe_tags("Hello world [warm]") == "Hello world"
+
+    def test_tag_in_middle(self) -> None:
+        assert strip_vibe_tags("Hello [excited] world") == "Hello world"
+
+    def test_multiple_tags(self) -> None:
+        assert strip_vibe_tags("[serious] [warm] Hello world") == "Hello world"
+
+    def test_no_tags_passthrough(self) -> None:
+        assert strip_vibe_tags("Hello world") == "Hello world"
+
+    def test_empty_string(self) -> None:
+        assert strip_vibe_tags("") == ""
+
+    def test_preserves_uppercase_brackets(self) -> None:
+        assert strip_vibe_tags("[IMPORTANT] Hello") == "[IMPORTANT] Hello"
+
+    def test_preserves_numbered_brackets(self) -> None:
+        assert strip_vibe_tags("[1] Hello") == "[1] Hello"
+
+    def test_preserves_figure_reference(self) -> None:
+        assert strip_vibe_tags("[Figure 1] Hello") == "[Figure 1] Hello"
+
+    def test_preserves_mixed_case_brackets(self) -> None:
+        assert strip_vibe_tags("[Figure A] Hello") == "[Figure A] Hello"
+
+    def test_preserves_three_word_brackets(self) -> None:
+        text = "[citation needed here] Hello"
+        assert strip_vibe_tags(text) == text
+
+    def test_tag_with_digits_not_stripped(self) -> None:
+        assert strip_vibe_tags("[excited2] Hello") == "[excited2] Hello"
+
+    def test_sighs_tag(self) -> None:
+        assert strip_vibe_tags("[sighs] Hello world") == "Hello world"
+
+    def test_multiple_positions(self) -> None:
+        result = strip_vibe_tags("[warm] Start [excited] middle [calm] end")
+        assert result == "Start middle end"
+
+    def test_whitespace_collapsed(self) -> None:
+        result = strip_vibe_tags("[warm]  Hello  [calm]  world")
+        assert result == "Hello world"
+
+    @pytest.mark.parametrize(
+        ("input_text", "expected"),
+        [
+            ("[serious] Hello", "Hello"),
+            ("Hello [warm]", "Hello"),
+            ("[slow breath] text", "text"),
+            ("[sighs] sigh", "sigh"),
+            ("no tags here", "no tags here"),
+            ("[Figure 1] caption", "[Figure 1] caption"),
+            ("[1] item", "[1] item"),
+            ("[LOUD] text", "[LOUD] text"),
+        ],
+    )
+    def test_parametrized(self, input_text: str, expected: str) -> None:
+        assert strip_vibe_tags(input_text) == expected

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -365,6 +365,13 @@ class TestStripVibeTags:
     def test_empty_string(self) -> None:
         assert strip_vibe_tags("") == ""
 
+    def test_all_tags_returns_original(self) -> None:
+        """When stripping removes all content, return the original text."""
+        assert strip_vibe_tags("[serious] [warm]") == "[serious] [warm]"
+
+    def test_single_tag_only_returns_original(self) -> None:
+        assert strip_vibe_tags("[calm]") == "[calm]"
+
     def test_preserves_uppercase_brackets(self) -> None:
         assert strip_vibe_tags("[IMPORTANT] Hello") == "[IMPORTANT] Hello"
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -347,8 +347,10 @@ class TestStripVibeTags:
     def test_single_word_tag(self) -> None:
         assert strip_vibe_tags("[serious] Hello world") == "Hello world"
 
-    def test_two_word_tag(self) -> None:
-        assert strip_vibe_tags("[slow breath] Hello world") == "Hello world"
+    def test_two_word_tag_preserved(self) -> None:
+        """Two-word bracketed tokens are NOT stripped."""
+        text = "[slow breath] Hello world"
+        assert strip_vibe_tags(text) == text
 
     def test_tag_at_end(self) -> None:
         assert strip_vibe_tags("Hello world [warm]") == "Hello world"
@@ -407,7 +409,7 @@ class TestStripVibeTags:
         [
             ("[serious] Hello", "Hello"),
             ("Hello [warm]", "Hello"),
-            ("[slow breath] text", "text"),
+            ("[slow breath] text", "[slow breath] text"),
             ("[sighs] sigh", "sigh"),
             ("no tags here", "no tags here"),
             ("[Figure 1] caption", "[Figure 1] caption"),

--- a/tests/test_say_provider.py
+++ b/tests/test_say_provider.py
@@ -338,6 +338,16 @@ class TestSayProviderPlayDirectly:
             )
         assert rc == 5
 
+    def test_strips_vibe_tags(self, say_provider: SayProvider) -> None:
+        mock = MagicMock(return_value=subprocess.CompletedProcess([], 0, b"", b""))
+        with patch("punt_vox.providers.say.subprocess.run", mock):
+            say_provider.play_directly(
+                SynthesisRequest(text="[serious] Hello world", voice="fred")
+            )
+        args = mock.call_args[0][0]
+        assert "Hello world" in args
+        assert "[serious]" not in " ".join(args)
+
 
 class TestSayProviderCheckHealth:
     def test_darwin_with_say(self) -> None:


### PR DESCRIPTION
ElevenLabs [serious]/[warm]/[excited] tags are v3 voice control instructions. Non-v3 models and other providers read them as words. Now stripped at the provider boundary. 23 new tests. Mission m-2026-04-12-015. Closes vox-9bo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the text sent to multiple TTS providers by removing bracketed vibe tags, which can alter spoken output, chunking decisions, and recorded `SynthesisResult.text`. Risk is moderate because it touches the synthesis boundary for several providers but is narrowly scoped and heavily tested.
> 
> **Overview**
> Adds `strip_vibe_tags()` to remove ElevenLabs-style expressive tags like `[serious]`/`[warm]` anywhere in the input while preserving non-matching bracketed content (e.g., `[Figure 1]`) and collapsing whitespace.
> 
> Applies this sanitization at the provider boundary for `openai`, `polly`, `espeak`, and `say`, and for `elevenlabs` only when the selected model does *not* support expressive tags; the stripped text is also what gets length-checked/chunked and returned in `SynthesisResult.text`. Adds comprehensive tests covering stripping behavior and ensuring providers either strip or preserve tags based on capability/model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6131173e032d8cd17bc7048ebb805b9cd4f9d511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->