### PR TITLE
chore: release v4.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.6.0",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.6.0] - 2026-04-12
+
 ### Added
 
 - **Directory migration from `.vox/` to `.punt-labs/vox/` (vox-4jk)**: per-repo config now lives at `.punt-labs/vox/config.md` (was `.vox/config.md`). Saved audio output defaults to `~/Music/vox/` (was `~/vox-output/`). Music tracks live at `~/Music/vox/tracks/` (was `~/vox-output/music/`). New `dirs.py` module centralizes all cross-platform path resolution. Auto-migration runs on `vox install` and `vox daemon install`; shell hooks check both paths during transition. `vox migrate-audio` command moves saved audio from `~/vox-output/` to `~/Music/vox/` with dry-run by default (`--execute` to move). `vox doctor` checks for legacy `.vox/` directory and `~/vox-output/` with remediation hints.

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.5.1"
+VERSION="4.6.0"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.5.1"
+version = "4.6.0"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.5.1"
+__version__ = "4.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.5.1"
+version = "4.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: updates version numbers and plugin identifier, with no functional code changes in the runtime package beyond metadata.
> 
> **Overview**
> Bumps the project to **v4.6.0** across packaging/install metadata (`pyproject.toml`, `uv.lock`, `src/punt_vox/__init__.py`, `install.sh`) and updates the Claude plugin manifest.
> 
> Renames the plugin `name` from `vox-dev` to `vox` and adds a `4.6.0` entry to `CHANGELOG.md` describing the release highlights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3e59a70d5bfb44abda9373d3fd71aa1fedd247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->