### PR TITLE
fix(service): clean up legacy .vox/ when new config already exists

### DIFF
--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -25,6 +25,7 @@ entire install ran as root inside ``$HOME``. See DES-029 in
 
 from __future__ import annotations
 
+import contextlib
 import getpass
 import html
 import logging
@@ -529,17 +530,13 @@ def _migrate_legacy_repo_config(repo_root: Path) -> bool:
         # New config already exists — still clean up the legacy file
         # so doctor stops flagging it.
         logger.info("Config already at .punt-labs/vox/config.md")
-        try:
+        with contextlib.suppress(OSError):
             legacy_config.unlink()
-        except OSError:
-            pass
         # Clean up ephemeral MP3s and remove .vox/ if empty
         for f in legacy_dir.glob("*.mp3"):
             f.unlink(missing_ok=True)
-        try:
+        with contextlib.suppress(OSError):
             legacy_dir.rmdir()
-        except OSError:
-            pass
         return False
 
     try:

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -534,7 +534,8 @@ def _migrate_legacy_repo_config(repo_root: Path) -> bool:
             legacy_config.unlink()
         # Clean up ephemeral MP3s and remove .vox/ if empty
         for f in legacy_dir.glob("*.mp3"):
-            f.unlink(missing_ok=True)
+            with contextlib.suppress(OSError):
+                f.unlink()
         with contextlib.suppress(OSError):
             legacy_dir.rmdir()
         return False

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -526,7 +526,20 @@ def _migrate_legacy_repo_config(repo_root: Path) -> bool:
     new_config = new_dir / "config.md"
 
     if new_config.exists():
-        logger.info("Config already at .punt-labs/vox/config.md, skipping migration")
+        # New config already exists — still clean up the legacy file
+        # so doctor stops flagging it.
+        logger.info("Config already at .punt-labs/vox/config.md")
+        try:
+            legacy_config.unlink()
+        except OSError:
+            pass
+        # Clean up ephemeral MP3s and remove .vox/ if empty
+        for f in legacy_dir.glob("*.mp3"):
+            f.unlink(missing_ok=True)
+        try:
+            legacy_dir.rmdir()
+        except OSError:
+            pass
         return False
 
     try:


### PR DESCRIPTION
The migration's 'already migrated' path returned early without deleting the legacy .vox/config.md. Doctor kept flagging it. Now deletes the legacy file + cleans up ephemeral MP3s + removes .vox/ if empty.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow, best-effort filesystem cleanup in an idempotent migration path, with errors suppressed to avoid breaking installs.
> 
> **Overview**
> Fixes the legacy config migration’s “already migrated” path so it no longer leaves behind `.vox/config.md`.
> 
> When `.punt-labs/vox/config.md` already exists, the install now **best-effort deletes** the legacy `.vox/config.md`, removes any leftover `.vox/*.mp3`, and attempts to remove the `.vox/` directory if it’s empty (using `contextlib.suppress(OSError)` to avoid failing on permission/race issues).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbbaab6de049e5f6a86d1adc519d18e3398ca79d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->