### PR TITLE
chore: release v4.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.7.0",
   "author": {

--- a/.vox/config.md
+++ b/.vox/config.md
@@ -1,9 +1,0 @@
----
-notify: "c"
-speak: "n"
-voice: "roger"
-vibe_signals: ""
-vibe_tags: "[warm]"
-vibe: "sad"
-vibe_mode: "manual"
----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.0] - 2026-04-12
+
 ## [4.6.0] - 2026-04-12
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.6.0"
+VERSION="4.7.0"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.6.0"
+version = "4.7.0"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.6.0"
+__version__ = "4.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.6.0"
+version = "4.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and metadata changes with no runtime logic modifications. Main risk is packaging/install mismatches if any downstream tooling expects the old plugin name or version string.
> 
> **Overview**
> Bumps the project to **v4.7.0** across packaging/install surfaces (`pyproject.toml`, `uv.lock`, `src/punt_vox/__init__.py`, `install.sh`, and `.claude-plugin/plugin.json`) and adds a `4.7.0` entry to `CHANGELOG.md`.
> 
> Renames the Claude plugin identifier from `vox-dev` to `vox` and removes the legacy `.vox/config.md` file from the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c74a0573353331ae3f4df787b8f140100ec7456f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->