### PR TITLE
chore: release v4.7.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.7.1",
   "author": {

--- a/.punt-labs/biff/.gitignore
+++ b/.punt-labs/biff/.gitignore
@@ -1,0 +1,1 @@
+config.local.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.1] - 2026-04-14
+
 ### Fixed
 
 - **Vibe tags spoken literally by ElevenLabs**: `[serious]`, `[alert]`, and other bracket-style expressive tags were passed through to ElevenLabs `eleven_v3` as literal text instead of being stripped. The model does not interpret them as expressive cues — it speaks "[serious]" aloud. Emptied `_EXPRESSIVE_MODELS` so `strip_vibe_tags` runs unconditionally for all ElevenLabs models.

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.7.0"
+VERSION="4.7.1"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.7.0"
+version = "4.7.1"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.7.0"
+__version__ = "4.7.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.7.0"
+version = "4.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release metadata/update only; no runtime code changes beyond version bumps and tooling ignores. Main risk is accidental packaging/version mismatch across installer, plugin manifest, and lockfile.
> 
> **Overview**
> Prepares the `4.7.1` release by bumping the version in `pyproject.toml`, `src/punt_vox/__init__.py`, `uv.lock`, and the `install.sh` pinned version.
> 
> Updates the Claude plugin manifest to use the production name `vox` (was `vox-dev`) and records the release note about stripping bracket-style vibe tags for ElevenLabs models. Adds `.punt-labs/biff/.gitignore` to exclude `config.local.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89e7daecca0b44f5953b6fd45dc7e7899ba8390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->