### PR TITLE
chore: release v4.7.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.7.3",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.3] - 2026-04-14
+
 ### Fixed
 
 - **CLI double-normalization defeated vibe tag stripping**: `vox unmute` and `vox record` called `normalize_for_speech` before sending text to voxd. This stripped brackets from vibe tags (e.g. `[alert]` → `alert`) before voxd's `_apply_vibe_for_synthesis` could match and remove them. Result: bare words "alert serious" survived into ElevenLabs. Fix: removed pre-normalization from both CLI commands — voxd already normalizes via `_apply_vibe_for_synthesis`. Closes vox-6kv.

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.7.2"
+VERSION="4.7.3"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.7.2"
+version = "4.7.3"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.7.2"
+__version__ = "4.7.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.7.2"
+version = "4.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version/name metadata and lockfile updates plus changelog entry; no functional code changes in this diff.
> 
> **Overview**
> Bumps the project to **v4.7.3** across packaging and distribution metadata (`pyproject.toml`, `__init__.__version__`, `uv.lock`, `install.sh`) and updates the Claude plugin metadata (renames plugin from `vox-dev` to `vox`).
> 
> Adds a `CHANGELOG.md` entry for `4.7.3` documenting the fix for CLI double-normalization interfering with vibe tag stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0048036b905fec7550881ebf6e4c22c427be0439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->