### PR TITLE
feat(elevenlabs): re-enable eleven_v3 expressive tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ElevenLabs**: re-enabled `eleven_v3` in expressive models set — bracket-style tags like `[alert]` and `[serious]` are now preserved and interpreted as expressive cues instead of being stripped. The v4.7.1 removal was based on a misdiagnosis; the CLI was pre-normalizing brackets before the model saw them.
+
 ## [4.7.3] - 2026-04-14
 
 ### Fixed

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -169,10 +169,13 @@ class ElevenLabsProvider:
         return "matilda"
 
     # Models that interpret bracket-style expressive tags natively.
-    # No current ElevenLabs model does this; the infrastructure remains
-    # so a future model can be added without changing the conditional
-    # logic in synthesize().
-    _EXPRESSIVE_MODELS: frozenset[str] = frozenset()
+    # eleven_v3 treats bracket tags like [alert] and [serious] as
+    # expressive cues — it does not speak them as literal words.
+    # Note: the ElevenLabs Model API's `can_use_style` refers to the
+    # style voice-settings slider (a float 0-1), not bracket tags.
+    # eleven_v3 reports can_use_style=False yet interprets bracket
+    # tags. No API property exists for bracket-tag support.
+    _EXPRESSIVE_MODELS: frozenset[str] = frozenset({"eleven_v3"})
 
     @property
     def supports_expressive_tags(self) -> bool:
@@ -184,9 +187,8 @@ class ElevenLabsProvider:
 
         Resolves the model the same way ``__init__`` does (explicit param,
         ``TTS_MODEL`` env var, then ``_DEFAULT_MODEL``) and checks
-        membership in the expressive set. Currently returns False for all
-        models — no ElevenLabs model interprets bracket-style tags. The
-        infrastructure remains for future models that may.
+        membership in the expressive set. Returns True for ``eleven_v3``,
+        which treats bracket tags like ``[alert]`` as expressive cues.
 
         Pure: does not construct the provider or touch the ElevenLabs SDK.
         """

--- a/src/punt_vox/providers/elevenlabs.py
+++ b/src/punt_vox/providers/elevenlabs.py
@@ -28,10 +28,11 @@ logger = logging.getLogger(__name__)
 __all__ = ["ElevenLabsProvider"]
 
 # Default model — eleven_v3 is the latest model with the best voice
-# quality and multilingual support. No current ElevenLabs model
-# interprets bracket-style expressive tags natively, so vibe tags are
-# always stripped before synthesis. Users who want lower cost or lower
-# latency can override via TTS_MODEL=eleven_flash_v2_5.
+# quality and multilingual support. eleven_v3 interprets bracket-style
+# expressive tags natively (e.g. [whisper], [serious]), so vibe tags
+# are preserved for that model. Other models strip tags before
+# synthesis. Users who want lower cost or lower latency can override
+# via TTS_MODEL=eleven_flash_v2_5.
 _DEFAULT_MODEL = "eleven_v3"
 
 # Character limits per model (from ElevenLabs docs).
@@ -140,10 +141,11 @@ class ElevenLabsProvider:
     """ElevenLabs TTS provider.
 
     Implements the TTSProvider protocol using the ElevenLabs SDK.
-    Defaults to eleven_v3 for best voice quality. No current model
-    interprets bracket-style expressive tags natively, so vibe tags
-    are always stripped before synthesis. Override with ``TTS_MODEL``
-    env var for lower cost or latency (e.g. ``eleven_flash_v2_5``).
+    Defaults to eleven_v3 for best voice quality. eleven_v3 interprets
+    bracket-style expressive tags natively, so tags are preserved for
+    that model. Other models strip tags before synthesis. Override with
+    ``TTS_MODEL`` env var for lower cost or latency (e.g.
+    ``eleven_flash_v2_5``).
     """
 
     def __init__(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -404,12 +404,12 @@ class TestVibeTagStripping:
         assert "[Figure 1]" in call_kwargs["Text"]
         assert result.text == "See [Figure 1] for details"
 
-    def test_elevenlabs_v3_strips_tags(
+    def test_elevenlabs_v3_preserves_tags(
         self,
         mock_elevenlabs_client: MagicMock,
         tmp_output_dir: Path,
     ) -> None:
-        """ElevenLabs eleven_v3 strips tags — no current model interprets them."""
+        """ElevenLabs eleven_v3 preserves tags — the model interprets them."""
         provider = ElevenLabsProvider(model="eleven_v3", client=mock_elevenlabs_client)
         client = TTSClient(provider)
         request = SynthesisRequest(text="[serious] Hello world", voice="matilda")
@@ -418,8 +418,8 @@ class TestVibeTagStripping:
         result = client.synthesize(request, out)
 
         call_kwargs = mock_elevenlabs_client.text_to_speech.stream.call_args.kwargs
-        assert "[serious]" not in call_kwargs["text"]
-        assert result.text == "Hello world"
+        assert "[serious]" in call_kwargs["text"]
+        assert "Hello world" in result.text
 
     def test_elevenlabs_flash_strips_tags(
         self,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -418,8 +418,8 @@ class TestVibeTagStripping:
         result = client.synthesize(request, out)
 
         call_kwargs = mock_elevenlabs_client.text_to_speech.stream.call_args.kwargs
-        assert "[serious]" in call_kwargs["text"]
-        assert "Hello world" in result.text
+        assert call_kwargs["text"] == "[serious] Hello world"
+        assert result.text == "[serious] Hello world"
 
     def test_elevenlabs_flash_strips_tags(
         self,

--- a/tests/test_elevenlabs_provider.py
+++ b/tests/test_elevenlabs_provider.py
@@ -287,13 +287,10 @@ class TestElevenLabsProviderDefaultModel:
         provider = ElevenLabsProvider(client=MagicMock())
         assert provider._model == "eleven_v3"  # pyright: ignore[reportPrivateUsage]
 
-    def test_default_does_not_support_expressive_tags(
+    def test_default_supports_expressive_tags(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """No current model interprets bracket-style tags natively.
-
-        The default model is eleven_v3 which supports expressive tags.
-        """
+        """The default model (eleven_v3) interprets bracket-style tags natively."""
         # Clear TTS_MODEL to validate the code default, not an env override.
         monkeypatch.delenv("TTS_MODEL", raising=False)
         provider = ElevenLabsProvider(client=MagicMock())

--- a/tests/test_elevenlabs_provider.py
+++ b/tests/test_elevenlabs_provider.py
@@ -292,13 +292,12 @@ class TestElevenLabsProviderDefaultModel:
     ) -> None:
         """No current model interprets bracket-style tags natively.
 
-        Vibe tags are always stripped before synthesis so the TTS engine
-        never speaks "[serious]" as literal text.
+        The default model is eleven_v3 which supports expressive tags.
         """
         # Clear TTS_MODEL to validate the code default, not an env override.
         monkeypatch.delenv("TTS_MODEL", raising=False)
         provider = ElevenLabsProvider(client=MagicMock())
-        assert provider.supports_expressive_tags is False
+        assert provider.supports_expressive_tags is True
 
     def test_explicit_model(self) -> None:
         provider = ElevenLabsProvider(model="eleven_turbo_v2_5", client=MagicMock())
@@ -314,9 +313,9 @@ class TestElevenLabsProviderDefaultModel:
         provider = ElevenLabsProvider(model="eleven_v3", client=MagicMock())
         assert provider._model == "eleven_v3"  # pyright: ignore[reportPrivateUsage]
 
-    def test_expressive_tags_not_supported_on_v3(self) -> None:
+    def test_expressive_tags_supported_on_v3(self) -> None:
         provider = ElevenLabsProvider(model="eleven_v3", client=MagicMock())
-        assert provider.supports_expressive_tags is False
+        assert provider.supports_expressive_tags is True
 
     def test_expressive_tags_not_supported_on_flash(self) -> None:
         provider = ElevenLabsProvider(model="eleven_flash_v2_5", client=MagicMock())
@@ -329,9 +328,9 @@ class TestElevenLabsProviderDefaultModel:
     def test_model_supports_expressive_tags_classmethod_v3(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Static lookup returns False for eleven_v3 — no native tag support."""
+        """Static lookup returns True for eleven_v3 — native tag support."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
-        assert ElevenLabsProvider.model_supports_expressive_tags("eleven_v3") is False
+        assert ElevenLabsProvider.model_supports_expressive_tags("eleven_v3") is True
 
     def test_model_supports_expressive_tags_classmethod_flash(
         self, monkeypatch: pytest.MonkeyPatch
@@ -346,9 +345,9 @@ class TestElevenLabsProviderDefaultModel:
     def test_model_supports_expressive_tags_classmethod_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """None argument resolves to the code default (eleven_v3 → False)."""
+        """None argument resolves to the code default (eleven_v3 → True)."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
-        assert ElevenLabsProvider.model_supports_expressive_tags(None) is False
+        assert ElevenLabsProvider.model_supports_expressive_tags(None) is True
 
     def test_model_supports_expressive_tags_classmethod_env_override(
         self, monkeypatch: pytest.MonkeyPatch
@@ -360,9 +359,9 @@ class TestElevenLabsProviderDefaultModel:
     def test_model_supports_expressive_tags_classmethod_explicit_beats_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Explicit model arg wins over the TTS_MODEL env var — both False."""
+        """Explicit model arg wins over the TTS_MODEL env var."""
         monkeypatch.setenv("TTS_MODEL", "eleven_flash_v2_5")
-        assert ElevenLabsProvider.model_supports_expressive_tags("eleven_v3") is False
+        assert ElevenLabsProvider.model_supports_expressive_tags("eleven_v3") is True
 
 
 class TestElevenLabsProviderCharLimits:

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -1760,8 +1760,7 @@ class TestApplyVibeForSynthesis:
         result = _apply_vibe_for_synthesis(
             "[whisper] Quiet message", None, "elevenlabs", "eleven_v3"
         )
-        assert "[whisper]" in result
-        assert "Quiet message" in result
+        assert result == "[whisper] Quiet message"
 
     def test_non_expressive_model_drops_vibe_tags(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1848,7 +1847,7 @@ class TestApplyVibeForSynthesis:
         """Tags-only input on eleven_v3 preserves the tag as an expressive cue."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
         result = _apply_vibe_for_synthesis("[sighs]", None, "elevenlabs", "eleven_v3")
-        assert "[sighs]" in result
+        assert result == "[sighs]"
 
     def test_normalizes_body_through_production_call_path(
         self,
@@ -1885,9 +1884,7 @@ class TestApplyVibeForSynthesis:
         result = _apply_vibe_for_synthesis(
             "[whisper] my_function works", None, "elevenlabs", "eleven_v3"
         )
-        assert "[whisper]" in result
-        assert "my function works" in result
-        assert "_" not in result
+        assert result == "[whisper] my function works"
 
     # -- vox-6ls: trailing / inline vibe tags at any position ---------------
 

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -1681,9 +1681,9 @@ class TestModelSupportsExpressiveTags:
     env-mutation lock that the real synthesize path needs).
     """
 
-    def test_elevenlabs_v3_unsupported(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_elevenlabs_v3_supported(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("TTS_MODEL", raising=False)
-        assert _model_supports_expressive_tags("elevenlabs", "eleven_v3") is False
+        assert _model_supports_expressive_tags("elevenlabs", "eleven_v3") is True
 
     def test_elevenlabs_flash_does_not_support(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1693,12 +1693,12 @@ class TestModelSupportsExpressiveTags:
             _model_supports_expressive_tags("elevenlabs", "eleven_flash_v2_5") is False
         )
 
-    def test_elevenlabs_default_unsupported(
+    def test_elevenlabs_default_supported(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """None model resolves to eleven_v3 — no native tag support."""
+        """None model resolves to eleven_v3 — supports expressive tags."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
-        assert _model_supports_expressive_tags("elevenlabs", None) is False
+        assert _model_supports_expressive_tags("elevenlabs", None) is True
 
     def test_polly_never_supports(self) -> None:
         assert _model_supports_expressive_tags("polly", None) is False
@@ -1735,14 +1735,13 @@ class TestApplyVibeForSynthesis:
     both are dropped entirely.
     """
 
-    def test_v3_drops_vibe_tags(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """eleven_v3 does not interpret tags — vibe_tags are dropped."""
+    def test_v3_preserves_vibe_tags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """eleven_v3 interprets tags natively — vibe_tags are prepended."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
         result = _apply_vibe_for_synthesis(
             "Hello world", "[excited]", "elevenlabs", "eleven_v3"
         )
-        assert result == "Hello world"
-        assert "excited" not in result
+        assert result == "[excited] Hello world"
 
     def test_expressive_model_passthrough_when_no_vibe_tags(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1753,14 +1752,16 @@ class TestApplyVibeForSynthesis:
         )
         assert result == "Hello world"
 
-    def test_v3_strips_user_tags_in_text(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """eleven_v3 strips user-supplied tags — no native tag support."""
+    def test_v3_preserves_user_tags_in_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """eleven_v3 interprets tags natively — user tags are preserved."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
         result = _apply_vibe_for_synthesis(
             "[whisper] Quiet message", None, "elevenlabs", "eleven_v3"
         )
-        assert result == "Quiet message"
-        assert "whisper" not in result
+        assert "[whisper]" in result
+        assert "Quiet message" in result
 
     def test_non_expressive_model_drops_vibe_tags(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1840,18 +1841,14 @@ class TestApplyVibeForSynthesis:
         )
         assert result == ""
 
-    def test_degenerate_text_only_tags_v3_returns_empty(
+    def test_degenerate_text_only_tags_v3_preserves(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Tags-only input on eleven_v3 returns empty — tags are stripped.
-
-        No current model interprets bracket tags natively, so the tag
-        is split off and dropped, leaving an empty body.
-        """
+        """Tags-only input on eleven_v3 preserves the tag as an expressive cue."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
         result = _apply_vibe_for_synthesis("[sighs]", None, "elevenlabs", "eleven_v3")
-        assert result == ""
+        assert "[sighs]" in result
 
     def test_normalizes_body_through_production_call_path(
         self,
@@ -1879,17 +1876,18 @@ class TestApplyVibeForSynthesis:
         assert "[" not in result
         assert "_" not in result
 
-    def test_v3_normalizes_body_and_strips_tags(
+    def test_v3_normalizes_body_and_preserves_tags(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """eleven_v3 normalizes the body and strips leading tags."""
+        """eleven_v3 normalizes the body and preserves leading tags."""
         monkeypatch.delenv("TTS_MODEL", raising=False)
         result = _apply_vibe_for_synthesis(
             "[whisper] my_function works", None, "elevenlabs", "eleven_v3"
         )
-        assert result == "my function works"
-        assert "whisper" not in result
+        assert "[whisper]" in result
+        assert "my function works" in result
+        assert "_" not in result
 
     # -- vox-6ls: trailing / inline vibe tags at any position ---------------
 


### PR DESCRIPTION
## Summary

- Re-enabled `eleven_v3` in `_EXPRESSIVE_MODELS` — bracket-style tags like `[alert]` and `[serious]` are now preserved and interpreted as expressive cues by ElevenLabs
- The v4.7.1 removal was a misdiagnosis: the CLI was pre-normalizing brackets before the model saw them (fixed in v4.7.3)
- Documented that the ElevenLabs API's `can_use_style` refers to the style voice-settings slider, not bracket tags — no API property exists for bracket-tag support

## Evidence

Manual test with `eleven_v3`: synthesized identical text with and without `[alert] [serious]` tags. The tagged version had different delivery energy. Neither version spoke "alert" or "serious" as literal words. The model interprets bracket tags as expressive cues.

ElevenLabs Model API confirms `can_use_style` is unrelated:
- `eleven_v3`: `can_use_style=False` (yet interprets bracket tags)
- `eleven_multilingual_v2`: `can_use_style=True` (style slider, not bracket tags)

## Test plan

- [x] `make check` passes (1381 tests)
- [x] Tests updated: eleven_v3 asserts True for expressive support
- [x] Manual: `[alert] [serious]` tags not spoken aloud by eleven_v3
- [ ] End-to-end: `/wall` with vibe tags produces expressive delivery

Closes vox-npi.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how text is preprocessed for ElevenLabs `eleven_v3`, preserving bracket tags that were previously stripped; this can affect spoken output and any downstream assumptions about tag removal.
> 
> **Overview**
> Re-enables `eleven_v3` as an *expressive* ElevenLabs model so bracket-style tags (e.g. `[serious]`, `[whisper]`) are preserved in synthesis input instead of being stripped, while non-v3 models continue stripping tags.
> 
> Updates provider documentation/comments and adjusts unit tests (core, provider, and `voxd` vibe application) to assert `eleven_v3` supports expressive tags and that tag-only / vibe-tag cases are preserved for v3. Adds an Unreleased changelog entry documenting the revert and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af32959b3d8977a785b827f056b7ee19a3b5b672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->