### PR TITLE
chore: release v4.7.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.7.4",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.4] - 2026-04-14
+
 ### Changed
 
 - **ElevenLabs**: re-enabled `eleven_v3` in expressive models set — bracket-style tags like `[alert]` and `[serious]` are now preserved and interpreted as expressive cues instead of being stripped. The v4.7.1 removal was based on a misdiagnosis; the CLI was pre-normalizing brackets before the model saw them.

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.7.3"
+VERSION="4.7.4"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.7.3"
+version = "4.7.4"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.7.3"
+__version__ = "4.7.4"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.7.3"
+version = "4.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and plugin metadata updates with no functional code changes in this diff.
> 
> **Overview**
> Bumps the package/plugin release to `4.7.4` across `pyproject.toml`, `__init__.__version__`, `uv.lock`, and the installer script.
> 
> Updates the Claude Code plugin metadata by renaming the plugin from `vox-dev` to `vox`, and adds the `4.7.4` changelog entry documenting the ElevenLabs expressive-models change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc57d0257e8300bcfe293c1ca4b55ef8afca703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->