### PR TITLE
chore(envrc): inherit meta-repo env via source_up

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,6 @@
+# Inherit shared punt-labs environment (BEADS_DOLT_*, git identity, etc.) from the meta-repo .envrc.
+source_up
+
 # Shared punt-labs environment
 source "${HOME}/.punt-labs/git-identity.env"
 source_env_if_exists .envrc.local


### PR DESCRIPTION
Adds `source_up` to this repo's `.envrc` so direnv inherits the punt-labs meta-repo's exports (notably `BEADS_DOLT_*` for the central Hosted DoltDB connection).

Companion to the bd-detach-to-hosted migration. Generated by `.bin/envrc-source-up-rollout.sh`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates local `direnv` setup and environment variable sourcing, with no runtime code or production behavior changes.
> 
> **Overview**
> Adds `source_up` to `.envrc` so `direnv` inherits environment exports from the parent/meta-repo before applying this repo’s existing local env setup (git identity, optional `.envrc.local`, and telemetry/TMPDIR settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9b0b418b95c98452e8cc60526d4c52eea928380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->