### PR TITLE
chore: canonical .envrc with inline beads + platform secrets

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,9 +1,33 @@
-# Inherit shared punt-labs environment (BEADS_DOLT_*, git identity, etc.) from the meta-repo .envrc.
-source_up
+# Git identity (user-specific — name, email, signing key vary per contributor)
+if [ -f "${HOME}/.punt-labs/git-identity.env" ]; then
+  source "${HOME}/.punt-labs/git-identity.env"
+fi
 
-# Shared punt-labs environment
-source "${HOME}/.punt-labs/git-identity.env"
-source_env_if_exists .envrc.local
+# Beads — Hosted DoltDB connection
+export BEADS_DOLT_SERVER_HOST="punt-labs-beads-1.dbs.hosted.doltdb.com"
+export BEADS_DOLT_SERVER_PORT=3306
+export BEADS_DOLT_SERVER_USER="tacvb9o46xu04pa5"
+export BEADS_DOLT_SERVER_TLS=1
+
+# Secrets from platform-native secret store (service-name lookup only)
+case "$(uname -s)" in
+  Darwin)
+    export BEADS_DOLT_PASSWORD="$(security find-generic-password -s 'BEADS_DOLT_PASSWORD' -w 2>/dev/null)"
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s 'github-pat' -w 2>/dev/null)"
+    export ANTHROPIC_API_KEY="$(security find-generic-password -s 'ANTHROPIC_API_KEY' -w 2>/dev/null)"
+    export OPENAI_API_KEY="$(security find-generic-password -s 'OPENAI_API_KEY' -w 2>/dev/null)"
+    export ELEVENLABS_API_KEY="$(security find-generic-password -s 'elevenlabs-api-key' -w 2>/dev/null)"
+    export RESEND_API_KEY="$(security find-generic-password -s 'RESEND_API_KEY' -w 2>/dev/null)"
+    ;;
+  Linux)
+    export BEADS_DOLT_PASSWORD="$(pass show beads/dolt-password 2>/dev/null)"
+    export GITHUB_PERSONAL_ACCESS_TOKEN="$(pass show github/personal-access-token 2>/dev/null)"
+    export ANTHROPIC_API_KEY="$(pass show anthropic/api-key 2>/dev/null)"
+    export OPENAI_API_KEY="$(pass show openai/api-key 2>/dev/null)"
+    export ELEVENLABS_API_KEY="$(pass show elevenlabs/api-key 2>/dev/null)"
+    export RESEND_API_KEY="$(pass show resend/api-key 2>/dev/null)"
+    ;;
+esac
 
 export DISABLE_TELEMETRY=1
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
@@ -12,3 +36,6 @@ unset  CLAUDE_CODE_ENABLE_TELEMETRY
 
 export TMPDIR="$PWD/.tmp"
 mkdir -p "$TMPDIR"
+
+# Local overrides (last — wins over everything above)
+source_env_if_exists .envrc.local


### PR DESCRIPTION
Org-wide .envrc standardization. Self-contained: git identity, beads Hosted DoltDB connection, all secrets from platform secret store (Keychain/pass), telemetry flags, TMPDIR. .envrc.local sourced last for local overrides. No source_up, no cross-directory inheritance. Clone, direnv allow, done.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how developer secrets and DB credentials are sourced, which can break local setups or inadvertently load empty/incorrect values if the expected Keychain/pass entries are missing.
> 
> **Overview**
> Makes `.envrc` self-contained by removing `source_up`/meta-repo inheritance and explicitly setting Beads Hosted DoltDB connection vars.
> 
> Secrets are now loaded per-OS from the native secret store (macOS Keychain via `security`, Linux via `pass`) for Dolt, GitHub PAT, and several API keys, and `.envrc.local` is sourced last to allow overrides. Telemetry flags and a repo-local `TMPDIR` setup remain/are enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd330a073d64dc96cd8c8a451e07df50a917097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->