### PR TITLE
refactor(config): split into vox.md (tracked) + vox.local.md (ephemeral)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,9 @@ research/
 .entire/
 .vscode/
 
-# Per-repo vox session state (config, ephemeral audio)
-.punt-labs/vox/
+# Per-repo vox ephemeral state (session config, audio)
+.punt-labs/vox/vox.local.md
+.punt-labs/vox/ephemeral/
 
 # LaTeX auxiliary files (prfaq.pdf is tracked, build artifacts are not)
 *.aux

--- a/.punt-labs/vox/vox.md
+++ b/.punt-labs/vox/vox.md
@@ -1,0 +1,6 @@
+---
+notify: "c"
+speak: "n"
+vibe_mode: "manual"
+voice: "roger"
+---

--- a/.vox/config.md
+++ b/.vox/config.md
@@ -1,9 +1,0 @@
----
-vibe_tags: "[neutral]"
-vibe_signals: ""
-notify: "y"
-speak: "y"
-voice: "fin"
-vibe: "neutral"
-vibe_mode: "manual"
----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Config split into two files**: per-repo config moved from single `.vox/config.md` to two files under `.punt-labs/vox/`: `vox.md` (tracked in git, durable preferences: voice, provider, model, notify, speak, vibe_mode) and `vox.local.md` (gitignored, ephemeral session state: vibe, vibe_tags, vibe_signals). Removed legacy `.vox/` directory entirely. The `config_path` parameter is now `config_dir` throughout the API. Read/write helpers route fields by `DURABLE_KEYS`/`EPHEMERAL_KEYS` frozensets. `find_config()` renamed to `find_config_dir()` in new `dirs.py` module.
+
 ### Fixed
 
 - **`/music` triggered permission prompt on first use**: `hooks/session-start.sh` auto-allows `Skill()` rules for plugin commands, but `Skill(music)` was missing from the hardcoded list. Added it, and introduced `scripts/check-skill-permissions.sh` (wired into `make lint`) to flag any drift between `commands/*.md` and the hook's allowlist. Closes vox-zz2.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,12 @@ Module structure under `src/punt_vox/`:
 |--------|---------------|
 | `types.py` | Domain types: `TTSProvider` protocol, `AudioProviderId`, `AudioRequest`, `AudioResult`, `HealthCheck`, `MergeStrategy` |
 | `core.py` | `TTSClient` — provider-agnostic orchestration: batching, pair stitching, audio merge, `split_text()` |
-| `output.py` | Output path resolution: `VOX_OUTPUT_DIR` env var, `~/vox-output` fallback |
+| `output.py` | Output path resolution: delegates to `dirs.default_output_dir()` (`VOX_OUTPUT_DIR` env var, `~/Music/vox/` fallback) |
 | `logging_config.py` | Logging setup (used by CLI and hooks, not by voxd) |
 | `voxd.py` | **Audio daemon** (`voxd` binary). WebSocket server: synthesize, chime, record, voices, health. Playback queue, dedup, cache. System paths (Homebrew prefix on macOS, FHS on Linux). No MCP, no sessions, no project awareness. |
 | `client.py` | WebSocket client for `voxd`. `VoxClient` (async), `VoxClientSync` (sync wrapper). Lightweight — stdlib + websockets only. |
-| `config.py` | Read `.vox/config.md` YAML frontmatter: `read_field()`, `read_config()`, `write_field()`, `find_config()`. No ContextVar. |
+| `config.py` | Read/write two config files: `vox.md` (durable prefs) + `vox.local.md` (ephemeral state). Routes by `DURABLE_KEYS`/`EPHEMERAL_KEYS` frozensets. Public API: `read_field()`, `read_config()`, `write_field()`, `write_fields()`. No ContextVar. |
+| `dirs.py` | Cross-platform directory resolution: `DEFAULT_CONFIG_DIR` (`.punt-labs/vox/`), `find_config_dir()`, `default_output_dir()`, `music_output_dir()`, `ephemeral_dir()` |
 | `resolve.py` | Shared resolution helpers: `resolve_voice_and_language()`, `apply_vibe()` |
 | `normalize.py` | Text normalization for speech: `normalize_for_speech()` — snake_case, camelCase, abbreviation expansion |
 | `voices.py` | Voice metadata: `VOICE_BLURBS`, `voice_not_found_message()` |
@@ -88,7 +89,7 @@ Plugin structure (Claude Code hooks and commands):
 | `assets/chime_done.mp3` | Task-complete chime tone |
 | `assets/chime_prompt.mp3` | Needs-approval chime tone |
 
-Tests mirror source: `test_types.py`, `test_core.py`, `test_output.py`, `test_playback.py`, `test_cli.py`, `test_client.py`, `test_hooks.py`, `test_normalize.py`, `test_cache.py`, `test_keys.py`, `test_server.py`, `test_server_partition.py`, `test_service.py`, `test_applet.py`, `test_watcher.py`, `test_polly_provider.py`, `test_openai_provider.py`, `test_elevenlabs_provider.py`, `test_say_provider.py`, `test_espeak_provider.py` plus `conftest.py` for shared fixtures. See [TESTING.md](TESTING.md) for the full testing philosophy and architecture.
+Tests mirror source: `test_types.py`, `test_core.py`, `test_output.py`, `test_playback.py`, `test_cli.py`, `test_client.py`, `test_config.py`, `test_dirs.py`, `test_hooks.py`, `test_normalize.py`, `test_cache.py`, `test_keys.py`, `test_server.py`, `test_server_partition.py`, `test_service.py`, `test_applet.py`, `test_watcher.py`, `test_polly_provider.py`, `test_openai_provider.py`, `test_elevenlabs_provider.py`, `test_say_provider.py`, `test_espeak_provider.py` plus `conftest.py` for shared fixtures. See [TESTING.md](TESTING.md) for the full testing philosophy and architecture.
 
 ## Python Coding Standards
 

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -28,7 +28,7 @@ from punt_vox.config import (
     write_field,
     write_fields,
 )
-from punt_vox.dirs import DEFAULT_CONFIG_PATH, default_output_dir, find_config
+from punt_vox.dirs import DEFAULT_CONFIG_DIR, default_output_dir, find_config_dir
 from punt_vox.hooks import hook_app
 from punt_vox.paths import installed_version, log_dir
 from punt_vox.providers import auto_detect_provider
@@ -633,16 +633,16 @@ def vibe_cmd(  # pyright: ignore[reportUnusedFunction]
     mood: Annotated[str, typer.Argument(help="Mood description or 'auto'/'off'.")],
 ) -> None:
     """Set session mood for TTS voice."""
-    cp = find_config() or DEFAULT_CONFIG_PATH
+    cd = find_config_dir() or DEFAULT_CONFIG_DIR
     if mood == "auto":
-        write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "auto"}, config_path=cp)
+        write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "auto"}, config_dir=cd)
         _emit({"vibe_mode": "auto"}, "Vibe mode: auto")
     elif mood == "off":
-        write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "off"}, config_path=cp)
+        write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "off"}, config_dir=cd)
         _emit({"vibe_mode": "off"}, "Vibe mode: off")
     else:
         write_fields(
-            {"vibe": mood, "vibe_tags": "", "vibe_mode": "manual"}, config_path=cp
+            {"vibe": mood, "vibe_tags": "", "vibe_mode": "manual"}, config_dir=cd
         )
         _emit({"vibe": mood, "vibe_mode": "manual"}, f"Vibe: {mood}")
 
@@ -668,14 +668,16 @@ def notify_cmd(  # pyright: ignore[reportUnusedFunction]
         typer.echo("Error: mode must be y, n, or c.", err=True)
         raise typer.Exit(code=1)
 
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    first_init = not config_path.exists()
+    from punt_vox.config import read_field
+
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    first_init = read_field("notify", config_dir) is None
     updates: dict[str, str] = {"notify": mode}
     if mode == "c" or (first_init and mode == "y"):
         updates["speak"] = "y"
     if voice is not None:
         updates["voice"] = voice
-    write_fields(updates, config_path=config_path)
+    write_fields(updates, config_dir=config_dir)
 
     labels = {
         "y": "Notifications enabled.",
@@ -702,7 +704,7 @@ def speak_cmd(  # pyright: ignore[reportUnusedFunction]
         typer.echo("Error: mode must be y or n.", err=True)
         raise typer.Exit(code=1)
 
-    write_field("speak", mode, config_path=find_config() or DEFAULT_CONFIG_PATH)
+    write_field("speak", mode, config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
     label = "Voice on." if mode == "y" else "Muted — chimes only."
     _emit({"speak": mode}, label)
 
@@ -717,7 +719,7 @@ def voice_cmd(  # pyright: ignore[reportUnusedFunction]
     name: Annotated[str, typer.Argument(help="Voice name (e.g. matilda, roger).")],
 ) -> None:
     """Set the session voice."""
-    write_field("voice", name, config_path=find_config() or DEFAULT_CONFIG_PATH)
+    write_field("voice", name, config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
     _emit({"voice": name}, f"{name}'s here.")
 
 
@@ -740,7 +742,7 @@ def version_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @app.command("status")
 def status_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """Show current state (daemon, voice, vibe, notify)."""
-    cfg = read_config(config_path=find_config() or DEFAULT_CONFIG_PATH)
+    cfg = read_config(config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
 
     # Try to get provider from voxd health
     daemon_provider: str | None = None
@@ -1033,22 +1035,6 @@ def doctor() -> None:
             _FAIL,
             f"Daemon: reachable but unhealthy \u2014 {exc}",
         )
-
-    # Legacy .vox/ directory (vox-4jk migration)
-    legacy_vox = Path.cwd() / ".vox"
-    if legacy_vox.is_dir() and not legacy_vox.is_symlink():
-        if (legacy_vox / "config.md").exists():
-            _check(
-                _FAIL,
-                f"Legacy .vox/ directory: {legacy_vox} contains config.md"
-                " \u2014 run 'vox install' to migrate to .punt-labs/vox/",
-            )
-        else:
-            _check(
-                _WARN,
-                f"Legacy .vox/ directory: {legacy_vox} exists but has no"
-                " config.md \u2014 safe to remove manually",
-            )
 
     # Legacy ~/vox-output/ directory (vox-4jk migration)
     legacy_output = Path.home() / "vox-output"

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -200,8 +200,9 @@ def read_config(config_dir: Path | None = None) -> VoxConfig:
     # Base layer: durable prefs
     fields.update(_parse_frontmatter(d / "vox.md"))
 
-    # Overlay: ephemeral session state (wins on conflict)
-    fields.update(_parse_frontmatter(d / "vox.local.md"))
+    # Overlay: ephemeral session state — only EPHEMERAL_KEYS accepted
+    local = _parse_frontmatter(d / "vox.local.md")
+    fields.update({k: v for k, v in local.items() if k in EPHEMERAL_KEYS})
 
     return _fields_to_config(fields)
 

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -1,11 +1,10 @@
-"""Centralized read/write for ``.punt-labs/vox/config.md`` YAML frontmatter.
+"""Read/write for split vox config: ``vox.md`` (durable) + ``vox.local.md`` (ephemeral).
 
-Python components that need config (e.g. server, CLI, watcher) import
-from here.  Shell hooks (e.g. ``hooks/*.sh``) read the same file via
-their own bash-based reader.  The canonical path is
-``.punt-labs/vox/config.md`` in the repo root (legacy ``.vox/config.md``
-is discovered by ``find_config()`` for unmigrated repos).
-All fields return safe defaults when the file is missing.
+Python components that need config import from here.  Shell hooks read
+the same files via their own bash-based reader.  The canonical directory
+is ``.punt-labs/vox/`` in the repo root; ``find_config_dir()`` walks up
+from cwd to locate it.  All fields return safe defaults when files are
+missing.
 """
 
 from __future__ import annotations
@@ -15,16 +14,17 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from punt_vox.dirs import DEFAULT_CONFIG_PATH, find_config
+from punt_vox.dirs import DEFAULT_CONFIG_DIR, find_config_dir
 
 logger = logging.getLogger(__name__)
 
-# Re-export so existing callers that import from config.py keep working.
 __all__ = [
     "ALLOWED_CONFIG_KEYS",
-    "DEFAULT_CONFIG_PATH",
+    "DEFAULT_CONFIG_DIR",
+    "DURABLE_KEYS",
+    "EPHEMERAL_KEYS",
     "VoxConfig",
-    "find_config",
+    "find_config_dir",
     "read_config",
     "read_field",
     "write_field",
@@ -33,11 +33,35 @@ __all__ = [
 
 
 _FIELD_RE = re.compile(r'^([a-z_]+):\s*"?([^"\n]*)"?\s*$', re.MULTILINE)
+_CLOSING_FENCE_RE = re.compile(r"\n---\s*$", re.MULTILINE)
+
+# ── Field-to-file routing ────────────────────────────────────────────
+
+DURABLE_KEYS: frozenset[str] = frozenset(
+    {
+        "model",
+        "notify",
+        "provider",
+        "speak",
+        "vibe_mode",
+        "voice",
+    }
+)
+
+EPHEMERAL_KEYS: frozenset[str] = frozenset(
+    {
+        "vibe",
+        "vibe_tags",
+        "vibe_signals",
+    }
+)
+
+ALLOWED_CONFIG_KEYS: frozenset[str] = DURABLE_KEYS | EPHEMERAL_KEYS
 
 
 @dataclass(frozen=True)
 class VoxConfig:
-    """Snapshot of all config fields from .punt-labs/vox/config.md."""
+    """Snapshot of all config fields from vox.md + vox.local.md."""
 
     notify: str  # "y" | "c" | "n"
     speak: str  # "y" | "n"
@@ -50,31 +74,24 @@ class VoxConfig:
     vibe_signals: str | None
 
 
-def read_field(field: str, config_path: Path | None = None) -> str | None:
-    """Read a single YAML frontmatter field.  Returns None if absent."""
-    path = config_path or DEFAULT_CONFIG_PATH
+# ── Internal helpers ─────────────────────────────────────────────────
+
+
+def _parse_frontmatter(path: Path) -> dict[str, str]:
+    """Parse YAML frontmatter fields from *path*.  Returns empty dict if missing."""
     if not path.exists():
-        return None
+        return {}
     text = path.read_text(encoding="utf-8")
-    pattern = re.compile(rf"^{re.escape(field)}:\s*\"?([^\"\n]*)\"?\s*$", re.MULTILINE)
-    match = pattern.search(text)
-    if match and match.group(1).strip():
-        return match.group(1).strip()
-    return None
-
-
-def read_config(config_path: Path | None = None) -> VoxConfig:
-    """Read all config fields.  Returns defaults when file is missing."""
-    path = config_path or DEFAULT_CONFIG_PATH
     fields: dict[str, str] = {}
-    if path.exists():
-        text = path.read_text(encoding="utf-8")
-        for match in _FIELD_RE.finditer(text):
-            key = match.group(1)
-            val = match.group(2).strip()
-            if val:
-                fields[key] = val
+    for match in _FIELD_RE.finditer(text):
+        val = match.group(2).strip()
+        if val:
+            fields[match.group(1)] = val
+    return fields
 
+
+def _fields_to_config(fields: dict[str, str]) -> VoxConfig:
+    """Build a VoxConfig from raw field dict, applying validation and defaults."""
     notify = fields.get("notify", "n")
     if notify not in ("y", "c", "n"):
         notify = "n"
@@ -100,42 +117,21 @@ def read_config(config_path: Path | None = None) -> VoxConfig:
     )
 
 
-# ---------------------------------------------------------------------------
-# Write helpers
-# ---------------------------------------------------------------------------
-
-ALLOWED_CONFIG_KEYS: frozenset[str] = frozenset(
-    {
-        "model",
-        "notify",
-        "provider",
-        "speak",
-        "voice",
-        "vibe",
-        "vibe_tags",
-        "vibe_mode",
-        "vibe_signals",
-    }
-)
-
-_CLOSING_FENCE_RE = re.compile(r"\n---\s*$", re.MULTILINE)
+def _read_single_field(path: Path, field: str) -> str | None:
+    """Read a single YAML frontmatter field from *path*.  Returns None if absent."""
+    if not path.exists():
+        return None
+    text = path.read_text(encoding="utf-8")
+    pattern = re.compile(rf"^{re.escape(field)}:\s*\"?([^\"\n]*)\"?\s*$", re.MULTILINE)
+    match = pattern.search(text)
+    if match and match.group(1).strip():
+        return match.group(1).strip()
+    return None
 
 
-def write_field(key: str, value: str, config_path: Path | None = None) -> None:
-    """Write a single YAML frontmatter field to .punt-labs/vox/config.md.
-
-    Updates the field in-place if present, or inserts it before the
-    closing ``---`` if absent. Creates the file with minimal frontmatter
-    if it does not exist.
-    """
-    if key not in ALLOWED_CONFIG_KEYS:
-        allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
-        msg = f"Unknown config key '{key}'. Allowed: {allowed}"
-        raise ValueError(msg)
-
-    path = config_path or DEFAULT_CONFIG_PATH
+def _write_single(path: Path, key: str, value: str) -> None:
+    """Write a single key-value pair to the YAML frontmatter in *path*."""
     path.parent.mkdir(parents=True, exist_ok=True)
-
     replacement = f'{key}: "{value}"'
 
     if not path.exists():
@@ -157,20 +153,8 @@ def write_field(key: str, value: str, config_path: Path | None = None) -> None:
     logger.info("Config: set %s = %r in %s", key, value, path)
 
 
-def write_fields(updates: dict[str, str], config_path: Path | None = None) -> None:
-    """Write multiple YAML frontmatter fields in a single read-write cycle.
-
-    Reads the file once, applies all regex substitutions, writes once.
-    All keys are validated before any I/O so a single bad key aborts
-    the entire batch.
-    """
-    for key in updates:
-        if key not in ALLOWED_CONFIG_KEYS:
-            allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
-            msg = f"Unknown config key '{key}'. Allowed: {allowed}"
-            raise ValueError(msg)
-
-    path = config_path or DEFAULT_CONFIG_PATH
+def _write_batch(path: Path, updates: dict[str, str]) -> None:
+    """Write multiple key-value pairs in a single read-write cycle."""
     path.parent.mkdir(parents=True, exist_ok=True)
 
     if not path.exists():
@@ -195,3 +179,59 @@ def write_fields(updates: dict[str, str], config_path: Path | None = None) -> No
     path.write_text(text)
     for key, value in updates.items():
         logger.info("Config: set %s = %r in %s", key, value, path)
+
+
+# ── Public API ───────────────────────────────────────────────────────
+
+
+def read_field(field: str, config_dir: Path | None = None) -> str | None:
+    """Read a single config field from the correct file."""
+    d = config_dir or DEFAULT_CONFIG_DIR
+    if field in EPHEMERAL_KEYS:
+        return _read_single_field(d / "vox.local.md", field)
+    return _read_single_field(d / "vox.md", field)
+
+
+def read_config(config_dir: Path | None = None) -> VoxConfig:
+    """Read all config fields, merging vox.md and vox.local.md."""
+    d = config_dir or DEFAULT_CONFIG_DIR
+    fields: dict[str, str] = {}
+
+    # Base layer: durable prefs
+    fields.update(_parse_frontmatter(d / "vox.md"))
+
+    # Overlay: ephemeral session state (wins on conflict)
+    fields.update(_parse_frontmatter(d / "vox.local.md"))
+
+    return _fields_to_config(fields)
+
+
+def write_field(key: str, value: str, config_dir: Path | None = None) -> None:
+    """Write a single config field to the correct file."""
+    if key not in ALLOWED_CONFIG_KEYS:
+        allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
+        msg = f"Unknown config key '{key}'. Allowed: {allowed}"
+        raise ValueError(msg)
+
+    d = config_dir or DEFAULT_CONFIG_DIR
+    if key in EPHEMERAL_KEYS:
+        _write_single(d / "vox.local.md", key, value)
+    else:
+        _write_single(d / "vox.md", key, value)
+
+
+def write_fields(updates: dict[str, str], config_dir: Path | None = None) -> None:
+    """Write multiple config fields, routing each to the correct file."""
+    for key in updates:
+        if key not in ALLOWED_CONFIG_KEYS:
+            allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
+            msg = f"Unknown config key '{key}'. Allowed: {allowed}"
+            raise ValueError(msg)
+
+    d = config_dir or DEFAULT_CONFIG_DIR
+    durable_updates = {k: v for k, v in updates.items() if k in DURABLE_KEYS}
+    ephemeral_updates = {k: v for k, v in updates.items() if k in EPHEMERAL_KEYS}
+    if durable_updates:
+        _write_batch(d / "vox.md", durable_updates)
+    if ephemeral_updates:
+        _write_batch(d / "vox.local.md", ephemeral_updates)

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -206,12 +206,20 @@ def read_config(config_dir: Path | None = None) -> VoxConfig:
     return _fields_to_config(fields)
 
 
+def _validate_value(value: str) -> None:
+    """Reject values that would corrupt YAML frontmatter."""
+    if "\n" in value or "\r" in value:
+        msg = f"Config values must not contain newlines, got: {value!r}"
+        raise ValueError(msg)
+
+
 def write_field(key: str, value: str, config_dir: Path | None = None) -> None:
     """Write a single config field to the correct file."""
     if key not in ALLOWED_CONFIG_KEYS:
         allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
         msg = f"Unknown config key '{key}'. Allowed: {allowed}"
         raise ValueError(msg)
+    _validate_value(value)
 
     d = config_dir or DEFAULT_CONFIG_DIR
     if key in EPHEMERAL_KEYS:
@@ -222,11 +230,12 @@ def write_field(key: str, value: str, config_dir: Path | None = None) -> None:
 
 def write_fields(updates: dict[str, str], config_dir: Path | None = None) -> None:
     """Write multiple config fields, routing each to the correct file."""
-    for key in updates:
+    for key, value in updates.items():
         if key not in ALLOWED_CONFIG_KEYS:
             allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
             msg = f"Unknown config key '{key}'. Allowed: {allowed}"
             raise ValueError(msg)
+        _validate_value(value)
 
     d = config_dir or DEFAULT_CONFIG_DIR
     durable_updates = {k: v for k, v in updates.items() if k in DURABLE_KEYS}

--- a/src/punt_vox/dirs.py
+++ b/src/punt_vox/dirs.py
@@ -10,26 +10,20 @@ from pathlib import Path
 # Per-repo subdirectory under .punt-labs/
 _REPO_SUBDIR = Path(".punt-labs") / "vox"
 
-# Legacy per-repo directory
-_LEGACY_REPO_DIR = Path(".vox")
-
-DEFAULT_CONFIG_PATH = _REPO_SUBDIR / "config.md"
+DEFAULT_CONFIG_DIR = _REPO_SUBDIR  # Path(".punt-labs/vox")
 
 
-def find_config(start: Path | None = None) -> Path | None:
-    """Walk up from start (default: cwd) to find per-repo config.
+def find_config_dir(start: Path | None = None) -> Path | None:
+    """Walk up from *start* (default: cwd) to find ``.punt-labs/vox/``.
 
-    Checks ``.punt-labs/vox/config.md`` first, then falls back to the
-    legacy ``.vox/config.md`` for unmigrated repos.
+    Returns the directory if either ``vox.md`` or ``vox.local.md``
+    exists inside it.  No legacy fallback.
     """
     path = (start or Path.cwd()).resolve()
     for parent in (path, *path.parents):
-        new = parent / _REPO_SUBDIR / "config.md"
-        if new.exists():
-            return new
-        legacy = parent / _LEGACY_REPO_DIR / "config.md"
-        if legacy.exists():
-            return legacy
+        d = parent / _REPO_SUBDIR
+        if (d / "vox.md").exists() or (d / "vox.local.md").exists():
+            return d
     return None
 
 

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -37,7 +37,7 @@ from punt_vox.config import (
     write_field,
     write_fields,
 )
-from punt_vox.dirs import DEFAULT_CONFIG_PATH, find_config
+from punt_vox.dirs import DEFAULT_CONFIG_DIR, find_config_dir
 from punt_vox.quips import (
     ACKNOWLEDGE_PHRASES,
     FAREWELL_PHRASES,
@@ -265,8 +265,8 @@ def handle_stop(data: dict[str, object], config: VoxConfig) -> dict[str, object]
         pass  # Manual mode with existing tags — already set
     else:
         tags = resolve_tags_from_signals(config.vibe_signals)
-        config_path = find_config() or DEFAULT_CONFIG_PATH
-        write_fields({"vibe_tags": tags, "vibe_signals": ""}, config_path)
+        config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+        write_fields({"vibe_tags": tags, "vibe_signals": ""}, config_dir)
     return {"decision": "block", "reason": phrase}
 
 
@@ -311,10 +311,10 @@ def classify_signal(exit_code: int | None, stdout: str) -> str | None:
     return None
 
 
-def handle_post_bash(data: dict[str, object], config_path: Path) -> None:
+def handle_post_bash(data: dict[str, object], config_dir: Path) -> None:
     """Accumulate vibe signals from Bash tool execution.
 
-    Appends a signal token to ``vibe_signals`` in ``.vox/config.md``.
+    Appends a signal token to ``vibe_signals`` in ``vox.local.md``.
 
     .. todo:: Signal accumulation should move to the MCP server so hooks
        don't write to config. Kept here as the one exception to preserve
@@ -345,14 +345,14 @@ def handle_post_bash(data: dict[str, object], config_path: Path) -> None:
     timestamp = datetime.now().strftime("%H:%M")
     token = f"{signal}@{timestamp}"
 
-    current = read_config(config_path).vibe_signals or ""
+    current = read_config(config_dir).vibe_signals or ""
     new_signals = f"{current},{token}" if current else token
 
     parts = new_signals.split(",")
     if len(parts) > MAX_VIBE_SIGNALS:
         new_signals = ",".join(parts[-MAX_VIBE_SIGNALS:])
 
-    write_field("vibe_signals", new_signals, config_path)
+    write_field("vibe_signals", new_signals, config_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -508,7 +508,7 @@ def handle_subagent_stop(config: VoxConfig) -> None:
 # ---------------------------------------------------------------------------
 
 
-def handle_session_end(config: VoxConfig, config_path: Path) -> None:
+def handle_session_end(config: VoxConfig, config_dir: Path) -> None:
     """Speak a farewell and clean up session state.
 
     Fires when notify != 'n' (both on-demand and continuous).
@@ -524,7 +524,7 @@ def handle_session_end(config: VoxConfig, config_path: Path) -> None:
 
     # Clean slate for next session
     if config.vibe_signals:
-        write_field("vibe_signals", "", config_path)
+        write_field("vibe_signals", "", config_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -535,11 +535,8 @@ def handle_session_end(config: VoxConfig, config_path: Path) -> None:
 @hook_app.command("stop")
 def stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """Stop hook: task-completion notification."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
     data = _read_hook_input()
     result = handle_stop(data, config)
     if result is not None:
@@ -549,22 +546,16 @@ def stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("post-bash")
 def post_bash_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """PostToolUse hook: accumulate vibe signals from Bash."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
     data = _read_hook_input()
-    handle_post_bash(data, config_path)
+    handle_post_bash(data, config_dir)
 
 
 @hook_app.command("notification")
 def notification_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """Notification hook: permission/idle prompt audio alerts."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
     data = _read_hook_input()
     handle_notification(data, config)
 
@@ -572,56 +563,41 @@ def notification_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("pre-compact")
 def pre_compact_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """PreCompact hook: playful 'be right back' message."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
     handle_pre_compact(config)
 
 
 @hook_app.command("user-prompt-submit")
 def user_prompt_submit_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """UserPromptSubmit hook: acknowledgment in continuous mode."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
     handle_user_prompt_submit(config)
 
 
 @hook_app.command("subagent-start")
 def subagent_start_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """SubagentStart hook: announce subagent spawn."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
     handle_subagent_start(config)
 
 
 @hook_app.command("subagent-stop")
 def subagent_stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """SubagentStop hook: announce subagent completion."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
     handle_subagent_stop(config)
 
 
 @hook_app.command("session-end")
 def session_end_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """SessionEnd hook: farewell speech."""
-    config_path = find_config() or DEFAULT_CONFIG_PATH
-    if not config_path.exists():
-        return
-
-    config = read_config(config_path)
-    handle_session_end(config, config_path)
+    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config = read_config(config_dir)
+    handle_session_end(config, config_dir)
 
 
 @hook_app.command("_chime", hidden=True)

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -535,7 +535,9 @@ def handle_session_end(config: VoxConfig, config_dir: Path) -> None:
 @hook_app.command("stop")
 def stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """Stop hook: task-completion notification."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     data = _read_hook_input()
     result = handle_stop(data, config)
@@ -546,7 +548,9 @@ def stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("post-bash")
 def post_bash_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """PostToolUse hook: accumulate vibe signals from Bash."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     data = _read_hook_input()
     handle_post_bash(data, config_dir)
 
@@ -554,7 +558,9 @@ def post_bash_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("notification")
 def notification_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """Notification hook: permission/idle prompt audio alerts."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     data = _read_hook_input()
     handle_notification(data, config)
@@ -563,7 +569,9 @@ def notification_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("pre-compact")
 def pre_compact_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """PreCompact hook: playful 'be right back' message."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     handle_pre_compact(config)
 
@@ -571,7 +579,9 @@ def pre_compact_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("user-prompt-submit")
 def user_prompt_submit_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """UserPromptSubmit hook: acknowledgment in continuous mode."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     handle_user_prompt_submit(config)
 
@@ -579,7 +589,9 @@ def user_prompt_submit_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("subagent-start")
 def subagent_start_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """SubagentStart hook: announce subagent spawn."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     handle_subagent_start(config)
 
@@ -587,7 +599,9 @@ def subagent_start_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("subagent-stop")
 def subagent_stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """SubagentStop hook: announce subagent completion."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     handle_subagent_stop(config)
 
@@ -595,7 +609,9 @@ def subagent_stop_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
 @hook_app.command("session-end")
 def session_end_cmd() -> None:  # pyright: ignore[reportUnusedFunction]
     """SessionEnd hook: farewell speech."""
-    config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+    config_dir = find_config_dir()
+    if config_dir is None:
+        return
     config = read_config(config_dir)
     handle_session_end(config, config_dir)
 

--- a/src/punt_vox/providers/__init__.py
+++ b/src/punt_vox/providers/__init__.py
@@ -144,27 +144,27 @@ def auto_detect_provider() -> str:
 
 def get_provider(
     name: str | None = None,
-    config_path: Path | None = None,
+    config_dir: Path | None = None,
     **kwargs: str | None,
 ) -> TTSProvider:
     """Look up a provider by name, or auto-detect.
 
     Resolution priority for provider name:
       1. Explicit ``name`` argument
-      2. Session config (``.punt-labs/vox/config.md`` provider field)
+      2. Session config (``.punt-labs/vox/`` provider field)
       3. ``TTS_PROVIDER`` env var / API key auto-detection
 
     Resolution priority for model (passed via kwargs):
       1. Explicit ``model`` kwarg
-      2. Session config (``.punt-labs/vox/config.md`` model field)
+      2. Session config (``.punt-labs/vox/`` model field)
       3. ``TTS_MODEL`` env var / provider default
 
     Args:
         name: Provider name (e.g. 'polly', 'openai'). If None, checks
             session config then auto-detects.
-        config_path: Path to session config file. Use
-            ``find_config()`` to locate the nearest config.
-            Defaults to ``.punt-labs/vox/config.md`` in the current directory.
+        config_dir: Path to session config directory. Use
+            ``find_config_dir()`` to locate the nearest config.
+            Defaults to ``.punt-labs/vox/`` in the current directory.
         **kwargs: Provider-specific options (e.g. model='tts-1-hd').
 
     Returns:
@@ -176,7 +176,7 @@ def get_provider(
     # Read session config for fallback values.
     from punt_vox.config import read_config
 
-    config = read_config(config_path=config_path)
+    config = read_config(config_dir=config_dir)
 
     if name is not None:
         resolved = name.lower()

--- a/src/punt_vox/resolve.py
+++ b/src/punt_vox/resolve.py
@@ -63,7 +63,7 @@ def resolve_voice_and_language(
     voice: str | None,
     language: str | None,
     *,
-    config_path: Path | None = None,
+    config_dir: Path | None = None,
 ) -> tuple[str, str | None]:
     """Resolve voice and language from user input.
 
@@ -73,8 +73,8 @@ def resolve_voice_and_language(
     If only voice is provided, infers language from the voice (best-effort).
     If both, validates compatibility.
 
-    When *config_path* is provided (or defaults to
-    ``.punt-labs/vox/config.md``), reads the ``voice`` field as session
+    When *config_dir* is provided (or defaults to
+    ``.punt-labs/vox/``), reads the ``voice`` field as session
     default.
     """
     if language is not None:
@@ -82,7 +82,7 @@ def resolve_voice_and_language(
 
     voice_from_config = False
     if voice is None:
-        voice = _config.read_field("voice", config_path or _config.DEFAULT_CONFIG_PATH)
+        voice = _config.read_field("voice", config_dir or _config.DEFAULT_CONFIG_DIR)
         voice_from_config = voice is not None
 
     if voice is None and language is not None:
@@ -120,7 +120,7 @@ def apply_vibe(
     *,
     expressive_tags: bool,
     override_tags: str | None = None,
-    config_path: Path | None = None,
+    config_dir: Path | None = None,
 ) -> str:
     """Prepend vibe tags to text if the provider supports them.
 
@@ -137,7 +137,7 @@ def apply_vibe(
     if not expressive_tags:
         return strip_expressive_tags(text)
     tags = override_tags or _config.read_field(
-        "vibe_tags", config_path or _config.DEFAULT_CONFIG_PATH
+        "vibe_tags", config_dir or _config.DEFAULT_CONFIG_DIR
     )
     if tags and not _LEADING_TAG_RE.match(text):
         return f"{tags} {text}"

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -50,7 +50,7 @@ mcp._mcp_server.version = __version__  # pyright: ignore[reportPrivateUsage]
 
 @dataclass
 class SessionState:
-    """In-memory session state. Seeded from .punt-labs/vox/ config on startup."""
+    """In-memory session state. Seeded from vox.md + vox.local.md."""
 
     session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     notify: str = "n"

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -35,7 +35,8 @@ mcp = FastMCP(
         "ephemeral=true. Mood tags are pre-resolved in config \u2014 do not "
         "pass vibe_tags. No other output.\n\n"
         "Do NOT use Read, Write, or Bash tools to access "
-        ".punt-labs/vox/config.md. All config state is available through "
+        ".punt-labs/vox/vox.md or .punt-labs/vox/vox.local.md. "
+        "All config state is available through "
         "MCP tools or hook context."
     ),
 )
@@ -49,7 +50,7 @@ mcp._mcp_server.version = __version__  # pyright: ignore[reportPrivateUsage]
 
 @dataclass
 class SessionState:
-    """In-memory session state. Seeded from .punt-labs/vox/config.md on startup."""
+    """In-memory session state. Seeded from .punt-labs/vox/ config on startup."""
 
     session_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     notify: str = "n"
@@ -73,21 +74,21 @@ _state: SessionState = SessionState()
 # ---------------------------------------------------------------------------
 
 
-def _find_config() -> Path | None:
-    """Walk up from cwd to find per-repo config.md."""
-    from punt_vox.dirs import find_config
+def _find_config_dir() -> Path | None:
+    """Walk up from cwd to find per-repo .punt-labs/vox/ directory."""
+    from punt_vox.dirs import find_config_dir
 
-    return find_config()
+    return find_config_dir()
 
 
-def _seed_state_from_config(config_path: Path | None) -> SessionState:
-    """Read per-repo config.md once and return a SessionState."""
-    if config_path is None or not config_path.exists():
+def _seed_state_from_config(config_dir: Path | None) -> SessionState:
+    """Read per-repo config once and return a SessionState."""
+    if config_dir is None:
         return SessionState()
 
     from punt_vox.config import read_config
 
-    cfg = read_config(config_path=config_path)
+    cfg = read_config(config_dir=config_dir)
     return SessionState(
         notify=cfg.notify,
         speak=cfg.speak,
@@ -471,7 +472,7 @@ def vibe(
     # Persist to disk so hooks (which read config independently) see the change
     from punt_vox.config import write_fields
 
-    write_fields(updates, _find_config())
+    write_fields(updates, _find_config_dir())
 
     # Propagate vibe change to music loop if this session owns music.
     if _state.music_mode == "on":
@@ -748,7 +749,7 @@ def notify(
     # Persist to disk so hooks (which read config independently) see the change
     from punt_vox.config import write_fields
 
-    write_fields(updates, _find_config())
+    write_fields(updates, _find_config_dir())
 
     return json.dumps({"notify": updates})
 
@@ -792,7 +793,7 @@ def speak(
     # Persist to disk so hooks (which read config independently) see the change
     from punt_vox.config import write_fields
 
-    write_fields(updates, _find_config())
+    write_fields(updates, _find_config_dir())
 
     return json.dumps(updates)
 
@@ -869,15 +870,15 @@ def run_server() -> None:
     configure_logging(stderr_level="INFO")
     logger.info("Starting vox MCP server (mic)")
 
-    # Seed session state from per-repo config.md if it exists.
-    config_path = _find_config()
-    _state = _seed_state_from_config(config_path)
+    # Seed session state from per-repo config if it exists.
+    config_dir = _find_config_dir()
+    _state = _seed_state_from_config(config_dir)
 
     # Mark speak as explicitly set if the config file had it.
-    if config_path is not None and config_path.exists():
+    if config_dir is not None:
         from punt_vox.config import read_field
 
-        if read_field("speak", config_path) is not None:
+        if read_field("speak", config_dir) is not None:
             _speak_explicit = True
 
     logger.info(

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -25,7 +25,6 @@ entire install ran as root inside ``$HOME``. See DES-029 in
 
 from __future__ import annotations
 
-import contextlib
 import getpass
 import html
 import logging
@@ -34,7 +33,6 @@ import platform
 import pwd
 import re
 import shlex
-import shutil
 import signal
 import subprocess
 import sys
@@ -486,91 +484,6 @@ def _voxd_exec_args() -> list[str]:
 # ---------------------------------------------------------------------------
 # Legacy repo config migration (.vox/ -> .punt-labs/vox/)
 # ---------------------------------------------------------------------------
-
-
-def _migrate_legacy_repo_config(repo_root: Path) -> bool:
-    """Migrate .vox/config.md to .punt-labs/vox/config.md.
-
-    Called by ``vox install`` and ``vox daemon install`` with the project
-    root as argument. Returns True if migration occurred.
-
-    Idempotent: safe to call repeatedly. Skips when:
-    - .vox/config.md does not exist
-    - .punt-labs/vox/config.md already exists (don't overwrite)
-    - .vox is a symlink (not ours to touch)
-    - .vox/config.md is a symlink (don't follow indirections)
-    - .punt-labs exists but is not a directory (bail, don't corrupt)
-    """
-    legacy_dir = repo_root / ".vox"
-    legacy_config = legacy_dir / "config.md"
-
-    if not legacy_config.exists():
-        return False
-
-    if legacy_dir.is_symlink():
-        logger.warning(".vox/ is a symlink, skipping migration")
-        return False
-
-    if legacy_config.is_symlink():
-        logger.warning(".vox/config.md is a symlink, skipping migration")
-        return False
-
-    punt_labs_dir = repo_root / ".punt-labs"
-    if punt_labs_dir.exists() and not punt_labs_dir.is_dir():
-        logger.warning(
-            ".punt-labs exists but is not a directory (%s), skipping migration",
-            punt_labs_dir,
-        )
-        return False
-
-    new_dir = repo_root / ".punt-labs" / "vox"
-    new_config = new_dir / "config.md"
-
-    if new_config.exists():
-        # New config already exists — still clean up the legacy file
-        # so doctor stops flagging it.
-        logger.info("Config already at .punt-labs/vox/config.md")
-        with contextlib.suppress(OSError):
-            legacy_config.unlink()
-        # Clean up ephemeral MP3s and remove .vox/ if empty
-        for f in legacy_dir.glob("*.mp3"):
-            with contextlib.suppress(OSError):
-                f.unlink()
-        with contextlib.suppress(OSError):
-            legacy_dir.rmdir()
-        return False
-
-    try:
-        new_dir.mkdir(parents=True, exist_ok=True)
-    except PermissionError:
-        logger.warning("Could not create %s, skipping migration", new_dir)
-        return False
-
-    try:
-        shutil.move(str(legacy_config), str(new_config))
-    except PermissionError:
-        logger.warning("Could not move config.md, skipping migration")
-        return False
-    except OSError as exc:
-        logger.warning("Could not move config.md: %s, skipping migration", exc)
-        return False
-
-    logger.info("Migrated .vox/config.md -> .punt-labs/vox/config.md")
-
-    # Clean up ephemeral MP3s in .vox/
-    for f in legacy_dir.glob("*.mp3"):
-        f.unlink(missing_ok=True)
-
-    # Remove .vox/ if empty
-    try:
-        legacy_dir.rmdir()
-    except OSError:
-        logger.warning(
-            ".vox/ not empty after migration (user files detected): %s",
-            legacy_dir,
-        )
-
-    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1143,16 +1056,6 @@ def install() -> str:
 
     # Create per-user state directories as the invoking user.
     state_root = _ensure_user_dirs()
-
-    # Migrate legacy .vox/config.md -> .punt-labs/vox/config.md
-    # Best-effort on $PWD. The authoritative migration is find_config()
-    # walk-up discovery; this catches the common case where install runs
-    # from a project root.
-    cwd = Path.cwd()
-    if (cwd / ".vox" / "config.md").exists():
-        migrated = _migrate_legacy_repo_config(cwd)
-        if migrated:
-            logger.info("Migrated legacy config in %s", cwd)
 
     # Write provider keys into the user's state dir. Normal user
     # permissions — no chown, no fd tricks.

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -1174,7 +1174,7 @@ async def _synthesize_to_file(
                 os.environ[env_key_name] = api_key
 
         try:
-            provider = get_provider(provider_name, config_path=None, model=model)
+            provider = get_provider(provider_name, config_dir=None, model=model)
             request = _build_audio_request(
                 normalized,
                 voice,
@@ -1333,7 +1333,7 @@ async def _try_direct_play(
     )
 
     def _factory() -> TTSProvider:
-        return get_provider(provider_name, config_path=None, model=model)
+        return get_provider(provider_name, config_dir=None, model=model)
 
     start = _monotonic()
     try:
@@ -1670,7 +1670,7 @@ async def _handle_voices(
     provider_name = _parse_optional_str(msg, "provider") or auto_detect_provider()
 
     try:
-        provider = get_provider(provider_name, config_path=None)
+        provider = get_provider(provider_name, config_dir=None)
         voice_list = await asyncio.to_thread(provider.list_voices)
     except Exception as exc:
         logger.exception("Voice listing failed for provider=%s", provider_name)

--- a/src/punt_vox/watcher.py
+++ b/src/punt_vox/watcher.py
@@ -169,7 +169,7 @@ _SIGNAL_PHRASES: dict[str, str] = {
 
 
 def make_notification_consumer(
-    config_path: Path | None = None,
+    config_dir: Path | None = None,
     throttle_seconds: float = 15.0,
 ) -> SessionEventConsumer:
     """Create a consumer that announces events via speech or chime.
@@ -180,7 +180,7 @@ def make_notification_consumer(
     last_fired: dict[str, float] = {}
 
     def _consumer(event: SessionEvent) -> None:
-        config = read_config(config_path)
+        config = read_config(config_dir)
         if config.notify != "c":
             return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -933,8 +933,7 @@ class TestVibeCommand:
     def test_vibe_mood(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["vibe", "excited"])
@@ -944,8 +943,7 @@ class TestVibeCommand:
     def test_vibe_auto(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["vibe", "auto"])
@@ -955,8 +953,7 @@ class TestVibeCommand:
     def test_vibe_off(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["vibe", "off"])
@@ -973,9 +970,8 @@ class TestNotifyCommand:
     def test_notify_y(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["notify", "y"])
@@ -985,9 +981,8 @@ class TestNotifyCommand:
     def test_notify_n(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["notify", "n"])
@@ -997,9 +992,8 @@ class TestNotifyCommand:
     def test_notify_c(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["notify", "c"])
@@ -1012,36 +1006,35 @@ class TestNotifyCommand:
         """Continuous mode always sets speak=y, even if file exists."""
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        config.write_text('---\nspeak: "n"\nnotify: "n"\n---\n')
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nspeak: "n"\nnotify: "n"\n---\n')
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["notify", "c"])
         assert result.exit_code == 0
-        text = config.read_text()
+        text = vox_md.read_text()
         assert 'speak: "y"' in text
         assert 'notify: "c"' in text
 
     def test_notify_c_with_voice(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["notify", "c", "--voice", "matilda"])
         assert result.exit_code == 0
-        text = config.read_text()
+        vox_md = tmp_path / "vox.md"
+        text = vox_md.read_text()
         assert 'voice: "matilda"' in text
         assert 'notify: "c"' in text
         assert 'speak: "y"' in text
 
     def test_notify_invalid(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
-        config = tmp_path / "config.md"
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["notify", "x"])
@@ -1052,9 +1045,8 @@ class TestSpeakCommand:
     def test_speak_y(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["speak", "y"])
@@ -1064,9 +1056,8 @@ class TestSpeakCommand:
     def test_speak_n(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["speak", "n"])
@@ -1078,9 +1069,8 @@ class TestVoiceCommand:
     def test_voice(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-        monkeypatch.setattr("punt_vox.__main__.find_config", lambda: config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["voice", "matilda"])
@@ -1113,8 +1103,7 @@ class TestStatusCommand:
     ) -> None:
         import punt_vox.config as cfg
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
 
         mock_instance = mock_client_cls.return_value
         mock_instance.health.return_value = {"provider": "elevenlabs"}
@@ -1133,8 +1122,7 @@ class TestStatusCommand:
         import punt_vox.config as cfg
         from punt_vox.client import VoxdConnectionError
 
-        config = tmp_path / "config.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
 
         mock_instance = mock_client_cls.return_value
         mock_instance.health.side_effect = VoxdConnectionError("not running")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,12 +105,17 @@ class TestReadConfig:
         assert cfg.vibe == "happy"
         assert cfg.vibe_tags == "[joyful]"
 
-    def test_read_config_ephemeral_wins_on_conflict(self, tmp_path: Path) -> None:
-        """Test 5: same key in both files, ephemeral value wins."""
-        _write_frontmatter(tmp_path / "vox.md", {"voice": "stale"})
-        _write_frontmatter(tmp_path / "vox.local.md", {"voice": "fresh"})
+    def test_local_durable_keys_ignored(self, tmp_path: Path) -> None:
+        """Durable keys in vox.local.md must not override vox.md."""
+        _write_frontmatter(tmp_path / "vox.md", {"notify": "n", "provider": "polly"})
+        _write_frontmatter(
+            tmp_path / "vox.local.md",
+            {"notify": "c", "provider": "elevenlabs", "vibe": "calm"},
+        )
         cfg = read_config(config_dir=tmp_path)
-        assert cfg.voice == "fresh"
+        assert cfg.notify == "n"
+        assert cfg.provider == "polly"
+        assert cfg.vibe == "calm"
 
     def test_read_config_missing_files(self, tmp_path: Path) -> None:
         """Test 6: neither file exists, safe defaults."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,47 +1,238 @@
-"""Tests for punt_vox.config — centralized .vox/config.md reader."""
+"""Tests for punt_vox.config -- split config routing."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from punt_vox.config import VoxConfig, read_config, read_field
+import pytest
+
+from punt_vox.config import (
+    ALLOWED_CONFIG_KEYS,
+    DURABLE_KEYS,
+    EPHEMERAL_KEYS,
+    VoxConfig,
+    read_config,
+    read_field,
+    write_field,
+    write_fields,
+)
+from punt_vox.dirs import find_config_dir
+
+# -- Helpers ---------------------------------------------------------------
 
 
-class TestReadField:
-    def test_returns_value_for_existing_field(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nnotify: "y"\n---\n')
-        assert read_field("notify", cfg) == "y"
+def _write_frontmatter(path: Path, fields: dict[str, str]) -> None:
+    """Write a minimal YAML frontmatter file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f'{k}: "{v}"' for k, v in fields.items()]
+    path.write_text("---\n" + "\n".join(lines) + "\n---\n")
 
-    def test_returns_none_for_missing_field(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text("---\nspeak: y\n---\n")
-        assert read_field("voice", cfg) is None
 
-    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "nonexistent.md"
-        assert read_field("notify", cfg) is None
+# -- Design tests 1-12: config.py -----------------------------------------
 
-    def test_handles_unquoted_values(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text("---\nspeak: y\n---\n")
-        assert read_field("speak", cfg) == "y"
 
-    def test_handles_quoted_values(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nvibe_tags: "[happy] [calm]"\n---\n')
-        assert read_field("vibe_tags", cfg) == "[happy] [calm]"
+class TestWriteFieldRouting:
+    """Design tests 1, 2, 11, 12."""
 
-    def test_returns_none_for_empty_value(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nvibe_signals: ""\n---\n')
-        assert read_field("vibe_signals", cfg) is None
+    def test_write_field_routes_durable_to_vox_md(self, tmp_path: Path) -> None:
+        """Test 1: write 'voice' lands in vox.md only."""
+        write_field("voice", "charlie", config_dir=tmp_path)
+        assert (tmp_path / "vox.md").exists()
+        assert not (tmp_path / "vox.local.md").exists()
+        assert read_field("voice", config_dir=tmp_path) == "charlie"
+
+    def test_write_field_routes_ephemeral_to_vox_local_md(self, tmp_path: Path) -> None:
+        """Test 2: write 'vibe_signals' lands in vox.local.md only."""
+        write_field("vibe_signals", "tests-pass@14:00", config_dir=tmp_path)
+        assert (tmp_path / "vox.local.md").exists()
+        assert not (tmp_path / "vox.md").exists()
+        assert read_field("vibe_signals", config_dir=tmp_path) == "tests-pass@14:00"
+
+    def test_write_field_creates_dir(self, tmp_path: Path) -> None:
+        """Test 11: write to nonexistent dir creates it."""
+        deep = tmp_path / "a" / "b" / "c"
+        write_field("voice", "fin", config_dir=deep)
+        assert (deep / "vox.md").exists()
+        assert read_field("voice", config_dir=deep) == "fin"
+
+    def test_write_field_rejects_unknown_key(self, tmp_path: Path) -> None:
+        """Test 12: ValueError for unknown key."""
+        with pytest.raises(ValueError, match="Unknown config key 'bogus'"):
+            write_field("bogus", "val", config_dir=tmp_path)
+
+
+class TestWriteFieldsRouting:
+    """Design test 3."""
+
+    def test_write_fields_mixed_keys_routes_correctly(self, tmp_path: Path) -> None:
+        """Test 3: mixed durable + ephemeral routes correctly."""
+        write_fields({"notify": "y", "vibe_tags": "[calm]"}, config_dir=tmp_path)
+
+        # notify (durable) in vox.md
+        assert read_field("notify", config_dir=tmp_path) == "y"
+        vox_text = (tmp_path / "vox.md").read_text()
+        assert "notify" in vox_text
+        assert "vibe_tags" not in vox_text
+
+        # vibe_tags (ephemeral) in vox.local.md
+        assert read_field("vibe_tags", config_dir=tmp_path) == "[calm]"
+        local_text = (tmp_path / "vox.local.md").read_text()
+        assert "vibe_tags" in local_text
+        assert "notify" not in local_text
 
 
 class TestReadConfig:
-    def test_defaults_when_file_missing(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "nonexistent.md"
-        result = read_config(cfg)
+    """Design tests 4-8."""
+
+    def test_read_config_merges_both_files(self, tmp_path: Path) -> None:
+        """Test 4: durable + ephemeral merged into single VoxConfig."""
+        _write_frontmatter(tmp_path / "vox.md", {"notify": "c", "voice": "charlie"})
+        _write_frontmatter(
+            tmp_path / "vox.local.md",
+            {"vibe": "happy", "vibe_tags": "[joyful]"},
+        )
+        cfg = read_config(config_dir=tmp_path)
+        assert cfg.notify == "c"
+        assert cfg.voice == "charlie"
+        assert cfg.vibe == "happy"
+        assert cfg.vibe_tags == "[joyful]"
+
+    def test_read_config_ephemeral_wins_on_conflict(self, tmp_path: Path) -> None:
+        """Test 5: same key in both files, ephemeral value wins."""
+        _write_frontmatter(tmp_path / "vox.md", {"voice": "stale"})
+        _write_frontmatter(tmp_path / "vox.local.md", {"voice": "fresh"})
+        cfg = read_config(config_dir=tmp_path)
+        assert cfg.voice == "fresh"
+
+    def test_read_config_missing_files(self, tmp_path: Path) -> None:
+        """Test 6: neither file exists, safe defaults."""
+        cfg = read_config(config_dir=tmp_path)
+        assert cfg == VoxConfig(
+            notify="n",
+            speak="y",
+            vibe_mode="auto",
+            voice=None,
+            provider=None,
+            model=None,
+            vibe=None,
+            vibe_tags=None,
+            vibe_signals=None,
+        )
+
+    def test_read_config_only_durable(self, tmp_path: Path) -> None:
+        """Test 7: only vox.md exists, ephemeral fields default."""
+        _write_frontmatter(tmp_path / "vox.md", {"notify": "y", "voice": "matilda"})
+        cfg = read_config(config_dir=tmp_path)
+        assert cfg.notify == "y"
+        assert cfg.voice == "matilda"
+        assert cfg.vibe is None
+        assert cfg.vibe_tags is None
+
+    def test_read_config_only_ephemeral(self, tmp_path: Path) -> None:
+        """Test 8: only vox.local.md exists, durable fields default."""
+        _write_frontmatter(
+            tmp_path / "vox.local.md",
+            {"vibe": "chill", "vibe_signals": "test@12"},
+        )
+        cfg = read_config(config_dir=tmp_path)
+        assert cfg.notify == "n"  # default
+        assert cfg.speak == "y"  # default
+        assert cfg.vibe == "chill"
+        assert cfg.vibe_signals == "test@12"
+
+
+class TestReadField:
+    """Design tests 9-10."""
+
+    def test_read_field_durable_key(self, tmp_path: Path) -> None:
+        """Test 9: read_field('voice') reads from vox.md."""
+        _write_frontmatter(tmp_path / "vox.md", {"voice": "fin"})
+        _write_frontmatter(tmp_path / "vox.local.md", {"vibe": "happy"})
+        assert read_field("voice", config_dir=tmp_path) == "fin"
+
+    def test_read_field_ephemeral_key(self, tmp_path: Path) -> None:
+        """Test 10: read_field('vibe_signals') reads from vox.local.md."""
+        _write_frontmatter(tmp_path / "vox.md", {"voice": "fin"})
+        _write_frontmatter(
+            tmp_path / "vox.local.md",
+            {"vibe_signals": "deploy@15:30"},
+        )
+        assert read_field("vibe_signals", config_dir=tmp_path) == "deploy@15:30"
+
+
+# -- Design tests 13-15: dirs.py ------------------------------------------
+
+
+class TestFindConfigDir:
+    """Design tests 13-15."""
+
+    def test_find_config_dir_walks_up(self, tmp_path: Path) -> None:
+        """Test 13: finds .punt-labs/vox/ from a child directory."""
+        config_d = tmp_path / ".punt-labs" / "vox"
+        _write_frontmatter(config_d / "vox.md", {"notify": "y"})
+        child = tmp_path / "a" / "b" / "c"
+        child.mkdir(parents=True)
+        result = find_config_dir(start=child)
+        assert result == config_d
+
+    def test_find_config_dir_finds_ephemeral_only(self, tmp_path: Path) -> None:
+        """Test 14: directory with only vox.local.md is found."""
+        config_d = tmp_path / ".punt-labs" / "vox"
+        _write_frontmatter(config_d / "vox.local.md", {"vibe": "happy"})
+        result = find_config_dir(start=tmp_path)
+        assert result == config_d
+
+    def test_find_config_dir_no_legacy(self, tmp_path: Path) -> None:
+        """Test 15: .vox/config.md is NOT found."""
+        legacy = tmp_path / ".vox"
+        legacy.mkdir()
+        (legacy / "config.md").write_text('---\nnotify: "y"\n---\n')
+        result = find_config_dir(start=tmp_path)
+        assert result is None
+
+
+# -- Existing test coverage (updated for config_dir API) -------------------
+
+
+class TestReadFieldLegacy:
+    """Existing read_field coverage, adapted for split config."""
+
+    def test_returns_value_for_existing_field(self, tmp_path: Path) -> None:
+        _write_frontmatter(tmp_path / "vox.md", {"notify": "y"})
+        assert read_field("notify", config_dir=tmp_path) == "y"
+
+    def test_returns_none_for_missing_field(self, tmp_path: Path) -> None:
+        _write_frontmatter(tmp_path / "vox.md", {"speak": "y"})
+        assert read_field("voice", config_dir=tmp_path) is None
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        assert read_field("notify", config_dir=tmp_path) is None
+
+    def test_handles_unquoted_values(self, tmp_path: Path) -> None:
+        vox = tmp_path / "vox.md"
+        vox.parent.mkdir(parents=True, exist_ok=True)
+        vox.write_text("---\nspeak: y\n---\n")
+        assert read_field("speak", config_dir=tmp_path) == "y"
+
+    def test_handles_quoted_values(self, tmp_path: Path) -> None:
+        _write_frontmatter(
+            tmp_path / "vox.local.md",
+            {"vibe_tags": "[happy] [calm]"},
+        )
+        assert read_field("vibe_tags", config_dir=tmp_path) == "[happy] [calm]"
+
+    def test_returns_none_for_empty_value(self, tmp_path: Path) -> None:
+        vox_local = tmp_path / "vox.local.md"
+        vox_local.parent.mkdir(parents=True, exist_ok=True)
+        vox_local.write_text('---\nvibe_signals: ""\n---\n')
+        assert read_field("vibe_signals", config_dir=tmp_path) is None
+
+
+class TestReadConfigLegacy:
+    """Existing read_config coverage, adapted for split config."""
+
+    def test_defaults_when_files_missing(self, tmp_path: Path) -> None:
+        result = read_config(config_dir=tmp_path)
         assert result == VoxConfig(
             notify="n",
             speak="y",
@@ -55,19 +246,24 @@ class TestReadConfig:
         )
 
     def test_reads_all_fields(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text(
-            "---\n"
-            'notify: "c"\n'
-            'speak: "y"\n'
-            'vibe_tags: "[happy] [calm]"\n'
-            'vibe_signals: "tests-pass@14:00"\n'
-            'vibe: "happy"\n'
-            'vibe_mode: "manual"\n'
-            'voice: "charlie"\n'
-            "---\n"
+        _write_frontmatter(
+            tmp_path / "vox.md",
+            {
+                "notify": "c",
+                "speak": "y",
+                "vibe_mode": "manual",
+                "voice": "charlie",
+            },
         )
-        result = read_config(cfg)
+        _write_frontmatter(
+            tmp_path / "vox.local.md",
+            {
+                "vibe_tags": "[happy] [calm]",
+                "vibe_signals": "tests-pass@14:00",
+                "vibe": "happy",
+            },
+        )
+        result = read_config(config_dir=tmp_path)
         assert result.notify == "c"
         assert result.speak == "y"
         assert result.vibe_mode == "manual"
@@ -77,30 +273,48 @@ class TestReadConfig:
         assert result.vibe_signals == "tests-pass@14:00"
 
     def test_invalid_notify_defaults_to_n(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nnotify: "invalid"\n---\n')
-        assert read_config(cfg).notify == "n"
+        _write_frontmatter(tmp_path / "vox.md", {"notify": "invalid"})
+        assert read_config(config_dir=tmp_path).notify == "n"
 
     def test_invalid_speak_defaults_to_y(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nspeak: "invalid"\n---\n')
-        assert read_config(cfg).speak == "y"
+        _write_frontmatter(tmp_path / "vox.md", {"speak": "invalid"})
+        assert read_config(config_dir=tmp_path).speak == "y"
 
     def test_invalid_vibe_mode_defaults_to_auto(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nvibe_mode: "invalid"\n---\n')
-        assert read_config(cfg).vibe_mode == "auto"
+        _write_frontmatter(tmp_path / "vox.md", {"vibe_mode": "invalid"})
+        assert read_config(config_dir=tmp_path).vibe_mode == "auto"
 
     def test_empty_signals_returns_none(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nvibe_signals: ""\n---\n')
-        assert read_config(cfg).vibe_signals is None
+        vox_local = tmp_path / "vox.local.md"
+        vox_local.parent.mkdir(parents=True, exist_ok=True)
+        vox_local.write_text('---\nvibe_signals: ""\n---\n')
+        assert read_config(config_dir=tmp_path).vibe_signals is None
 
     def test_partial_config_fills_defaults(self, tmp_path: Path) -> None:
-        cfg = tmp_path / "config.md"
-        cfg.write_text('---\nnotify: "y"\nvoice: "matilda"\n---\n')
-        result = read_config(cfg)
+        _write_frontmatter(tmp_path / "vox.md", {"notify": "y", "voice": "matilda"})
+        result = read_config(config_dir=tmp_path)
         assert result.notify == "y"
         assert result.voice == "matilda"
         assert result.speak == "y"
         assert result.vibe_mode == "auto"
+
+
+class TestWriteFieldsValidation:
+    """write_fields rejects unknown keys before any I/O."""
+
+    def test_rejects_unknown_key_in_batch(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown config key 'bad_key'"):
+            write_fields({"notify": "y", "bad_key": "val"}, config_dir=tmp_path)
+        # No files created
+        assert not (tmp_path / "vox.md").exists()
+        assert not (tmp_path / "vox.local.md").exists()
+
+
+class TestKeySetConsistency:
+    """DURABLE_KEYS and EPHEMERAL_KEYS are disjoint and cover ALLOWED."""
+
+    def test_disjoint(self) -> None:
+        assert not (DURABLE_KEYS & EPHEMERAL_KEYS)
+
+    def test_union_is_allowed(self) -> None:
+        assert DURABLE_KEYS | EPHEMERAL_KEYS == ALLOWED_CONFIG_KEYS

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,12 +183,13 @@ class TestFindConfigDir:
         assert result == config_d
 
     def test_find_config_dir_no_legacy(self, tmp_path: Path) -> None:
-        """Test 15: .vox/config.md is NOT found."""
+        """Test 15: .vox/config.md is NOT found by find_config_dir."""
         legacy = tmp_path / ".vox"
         legacy.mkdir()
         (legacy / "config.md").write_text('---\nnotify: "y"\n---\n')
         result = find_config_dir(start=tmp_path)
-        assert result is None
+        if result is not None:
+            assert not result.is_relative_to(tmp_path / ".vox")
 
 
 # -- Existing test coverage (updated for config_dir API) -------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,14 @@ class TestWriteFieldRouting:
         with pytest.raises(ValueError, match="Unknown config key 'bogus'"):
             write_field("bogus", "val", config_dir=tmp_path)
 
+    def test_write_field_rejects_newline_in_value(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="must not contain newlines"):
+            write_field("voice", "fin\nevil: injection", config_dir=tmp_path)
+
+    def test_write_fields_rejects_newline_in_value(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="must not contain newlines"):
+            write_fields({"voice": "ok", "vibe": "calm\nbad"}, config_dir=tmp_path)
+
 
 class TestWriteFieldsRouting:
     """Design test 3."""

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -6,80 +6,69 @@ from pathlib import Path
 from unittest.mock import patch
 
 from punt_vox.dirs import (
-    DEFAULT_CONFIG_PATH,
+    DEFAULT_CONFIG_DIR,
     _parse_xdg_user_dir,  # pyright: ignore[reportPrivateUsage]
     _resolve_music_dir,  # pyright: ignore[reportPrivateUsage]
     default_output_dir,
     ephemeral_dir,
-    find_config,
+    find_config_dir,
     music_output_dir,
 )
 
 # ---------------------------------------------------------------------------
-# DEFAULT_CONFIG_PATH
+# DEFAULT_CONFIG_DIR
 # ---------------------------------------------------------------------------
 
 
-class TestDefaultConfigPath:
+class TestDefaultConfigDir:
     def test_uses_punt_labs_subdir(self) -> None:
-        assert Path(".punt-labs/vox/config.md") == DEFAULT_CONFIG_PATH
+        assert Path(".punt-labs/vox") == DEFAULT_CONFIG_DIR
 
 
 # ---------------------------------------------------------------------------
-# find_config
+# find_config_dir
 # ---------------------------------------------------------------------------
 
 
-class TestFindConfig:
-    def test_finds_new_path(self, tmp_path: Path) -> None:
-        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
-        new_config.parent.mkdir(parents=True)
-        new_config.write_text("---\nnotify: y\n---\n")
-        result = find_config(tmp_path)
-        assert result == new_config
+class TestFindConfigDir:
+    def test_finds_dir_with_vox_md(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".punt-labs" / "vox"
+        config_dir.mkdir(parents=True)
+        (config_dir / "vox.md").write_text("---\nnotify: y\n---\n")
+        result = find_config_dir(tmp_path)
+        assert result == config_dir
 
-    def test_falls_back_to_legacy(self, tmp_path: Path) -> None:
+    def test_finds_dir_with_vox_local_md(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".punt-labs" / "vox"
+        config_dir.mkdir(parents=True)
+        (config_dir / "vox.local.md").write_text("---\nvibe: calm\n---\n")
+        result = find_config_dir(tmp_path)
+        assert result == config_dir
+
+    def test_no_legacy_fallback(self, tmp_path: Path) -> None:
         legacy = tmp_path / ".vox" / "config.md"
         legacy.parent.mkdir(parents=True)
         legacy.write_text("---\nnotify: y\n---\n")
-        result = find_config(tmp_path)
-        assert result == legacy
-
-    def test_prefers_new_over_legacy(self, tmp_path: Path) -> None:
-        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
-        new_config.parent.mkdir(parents=True)
-        new_config.write_text("---\nnotify: y\n---\n")
-        legacy = tmp_path / ".vox" / "config.md"
-        legacy.parent.mkdir(parents=True)
-        legacy.write_text("---\nnotify: n\n---\n")
-        result = find_config(tmp_path)
-        assert result == new_config
+        result = find_config_dir(tmp_path)
+        if result is not None:
+            assert not result.is_relative_to(tmp_path / ".vox")
 
     def test_returns_none_when_absent(self, tmp_path: Path) -> None:
-        # Create an isolated directory tree with no config anywhere
-        # above it by starting from a fresh root with no parents to walk.
         isolated = tmp_path / "isolated"
         isolated.mkdir()
         with patch("punt_vox.dirs.Path.cwd", return_value=isolated):
-            # Walk up from isolated; tmp_path has no config files
-            # but walk-up may reach the real repo root. Pass the
-            # isolated dir explicitly so the walk stays bounded.
-            result = find_config(isolated)
-        # May find a parent config if tmp_path is inside a repo
-        # with .punt-labs/vox/config.md. The contract is that
-        # find_config returns None when no config exists in the
-        # walk-up chain. Test only with an isolated subtree.
+            result = find_config_dir(isolated)
         if result is not None:
             assert not result.is_relative_to(isolated)
 
     def test_walks_up_to_parent(self, tmp_path: Path) -> None:
-        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
-        new_config.parent.mkdir(parents=True)
-        new_config.write_text("---\n---\n")
+        config_dir = tmp_path / ".punt-labs" / "vox"
+        config_dir.mkdir(parents=True)
+        (config_dir / "vox.md").write_text("---\n---\n")
         child = tmp_path / "sub" / "dir"
         child.mkdir(parents=True)
-        result = find_config(child)
-        assert result == new_config
+        result = find_config_dir(child)
+        assert result == config_dir
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -143,7 +143,7 @@ class TestHandleStop:
         assert result is None
 
     @patch("punt_vox.hooks.write_fields")
-    @patch("punt_vox.hooks.find_config")
+    @patch("punt_vox.hooks.find_config_dir")
     def test_voice_mode_blocks_clean_reason(
         self, _mock_path: MagicMock, _mock_write: MagicMock
     ) -> None:
@@ -159,7 +159,7 @@ class TestHandleStop:
         assert "vibe_signals" not in reason
 
     @patch("punt_vox.hooks.write_fields")
-    @patch("punt_vox.hooks.find_config")
+    @patch("punt_vox.hooks.find_config_dir")
     def test_auto_mode_writes_tags_and_clears_signals(
         self, mock_path: MagicMock, mock_write: MagicMock
     ) -> None:
@@ -172,7 +172,7 @@ class TestHandleStop:
         )
 
     @patch("punt_vox.hooks.write_fields")
-    @patch("punt_vox.hooks.find_config")
+    @patch("punt_vox.hooks.find_config_dir")
     def test_continuous_mode_blocks(
         self, _mock_path: MagicMock, _mock_write: MagicMock
     ) -> None:
@@ -307,80 +307,86 @@ class TestHandlePostBash:
     def test_appends_signal(self, tmp_path: Path) -> None:
         from punt_vox.hooks import handle_post_bash
 
-        config_path = tmp_path / ".vox" / "config.md"
-        config_path.parent.mkdir(parents=True)
-        config_path.write_text('---\nnotify: "y"\n---\n')
+        config_dir = tmp_path
+        vox_md = config_dir / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
 
         data: dict[str, object] = {
             "tool_response": {"exit_code": 0, "stdout": "5 passed in 1.2s"}
         }
-        handle_post_bash(data, config_path)
+        handle_post_bash(data, config_dir)
 
-        text = config_path.read_text()
+        # vibe_signals is ephemeral — written to vox.local.md
+        local_md = config_dir / "vox.local.md"
+        assert local_md.exists()
+        text = local_md.read_text()
         assert "vibe_signals" in text
         assert "tests-pass" in text
 
     def test_no_signal_no_write(self, tmp_path: Path) -> None:
         from punt_vox.hooks import handle_post_bash
 
-        config_path = tmp_path / ".vox" / "config.md"
-        config_path.parent.mkdir(parents=True)
-        config_path.write_text('---\nnotify: "y"\n---\n')
+        config_dir = tmp_path
+        vox_md = config_dir / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
 
         data: dict[str, object] = {
             "tool_response": {"exit_code": 0, "stdout": "hello world"}
         }
-        handle_post_bash(data, config_path)
+        handle_post_bash(data, config_dir)
 
-        text = config_path.read_text()
-        assert "vibe_signals" not in text
+        # No signal matched — vox.local.md should not be created
+        local_md = config_dir / "vox.local.md"
+        assert not local_md.exists()
 
     def test_accumulates_signals(self, tmp_path: Path) -> None:
         from punt_vox.hooks import handle_post_bash
 
-        config_path = tmp_path / ".vox" / "config.md"
-        config_path.parent.mkdir(parents=True)
-        config_path.write_text(
-            '---\nnotify: "y"\nvibe_signals: "lint-pass@11:00"\n---\n'
-        )
+        config_dir = tmp_path
+        vox_md = config_dir / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
+        local_md = config_dir / "vox.local.md"
+        local_md.write_text('---\nvibe_signals: "lint-pass@11:00"\n---\n')
 
         data: dict[str, object] = {
             "tool_response": {"exit_code": 0, "stdout": "5 passed in 1.2s"}
         }
-        handle_post_bash(data, config_path)
+        handle_post_bash(data, config_dir)
 
-        text = config_path.read_text()
+        text = local_md.read_text()
         assert "lint-pass@11:00" in text
         assert "tests-pass" in text
 
     def test_invalid_tool_response(self, tmp_path: Path) -> None:
         from punt_vox.hooks import handle_post_bash
 
-        config_path = tmp_path / ".vox" / "config.md"
-        config_path.parent.mkdir(parents=True)
-        config_path.write_text('---\nnotify: "y"\n---\n')
+        config_dir = tmp_path
+        vox_md = config_dir / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
 
         data: dict[str, object] = {"tool_response": "not a dict"}
-        handle_post_bash(data, config_path)
+        handle_post_bash(data, config_dir)
 
-        text = config_path.read_text()
-        assert "vibe_signals" not in text
+        local_md = config_dir / "vox.local.md"
+        assert not local_md.exists()
 
     def test_prunes_signals_at_max(self, tmp_path: Path) -> None:
         from punt_vox.hooks import MAX_VIBE_SIGNALS, handle_post_bash
 
-        config_path = tmp_path / ".vox" / "config.md"
-        config_path.parent.mkdir(parents=True)
+        config_dir = tmp_path
+        vox_md = config_dir / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
+        local_md = config_dir / "vox.local.md"
         # Seed with exactly MAX signals already present
         existing = ",".join(f"old-{i}@00:00" for i in range(MAX_VIBE_SIGNALS))
-        config_path.write_text(f'---\nnotify: "y"\nvibe_signals: "{existing}"\n---\n')
+        local_md.write_text(f'---\nvibe_signals: "{existing}"\n---\n')
 
         data: dict[str, object] = {
             "tool_response": {"exit_code": 0, "stdout": "5 passed in 1.2s"}
         }
-        handle_post_bash(data, config_path)
+        handle_post_bash(data, config_dir)
 
-        text = config_path.read_text()
+        text = local_md.read_text()
         # Extract the vibe_signals value
         for line in text.splitlines():
             if "vibe_signals" in line:
@@ -619,7 +625,7 @@ class TestHandleSessionEnd:
         self, mock_run: MagicMock, mock_enqueue: MagicMock
     ) -> None:
         config = _make_config(notify="n")
-        handle_session_end(config, Path("/fake/.vox/config.md"))
+        handle_session_end(config, Path("/fake/.punt-labs/vox"))
         mock_run.assert_not_called()
         mock_enqueue.assert_not_called()
 
@@ -627,13 +633,13 @@ class TestHandleSessionEnd:
     def test_chime_mode(self, mock_enqueue: MagicMock) -> None:
         """Fires for notify=y (not just continuous)."""
         config = _make_config(notify="y", speak="n", vibe_signals=None)
-        handle_session_end(config, Path("/fake/.vox/config.md"))
+        handle_session_end(config, Path("/fake/.punt-labs/vox"))
         mock_enqueue.assert_called_once()
 
     @patch("punt_vox.hooks._speak_via_voxd")
     def test_voice_mode_speaks(self, mock_speak: MagicMock) -> None:
         config = _make_config(notify="y", speak="y", vibe_signals=None)
-        handle_session_end(config, Path("/fake/.vox/config.md"))
+        handle_session_end(config, Path("/fake/.punt-labs/vox"))
         mock_speak.assert_called_once()
         text = mock_speak.call_args[0][0]
         assert text in FAREWELL_PHRASES
@@ -641,7 +647,7 @@ class TestHandleSessionEnd:
     @patch("punt_vox.hooks._speak_via_voxd")
     def test_continuous_mode_speaks(self, mock_speak: MagicMock) -> None:
         config = _make_config(notify="c", speak="y", vibe_signals=None)
-        handle_session_end(config, Path("/fake/.vox/config.md"))
+        handle_session_end(config, Path("/fake/.punt-labs/vox"))
         mock_speak.assert_called_once()
 
     @patch("punt_vox.hooks.write_field")
@@ -651,9 +657,9 @@ class TestHandleSessionEnd:
     ) -> None:
         """SessionEnd clears vibe_signals to prevent stale leakage."""
         config = _make_config(notify="y", speak="y", vibe_signals="tests-pass@12:00")
-        config_path = Path("/fake/.vox/config.md")
-        handle_session_end(config, config_path)
-        mock_write.assert_called_once_with("vibe_signals", "", config_path)
+        config_dir = Path("/fake/.punt-labs/vox")
+        handle_session_end(config, config_dir)
+        mock_write.assert_called_once_with("vibe_signals", "", config_dir)
 
     @patch("punt_vox.hooks.write_field")
     @patch("punt_vox.hooks._speak_via_voxd")
@@ -662,7 +668,7 @@ class TestHandleSessionEnd:
     ) -> None:
         """Does not write config if vibe_signals is already empty."""
         config = _make_config(notify="y", speak="y", vibe_signals=None)
-        handle_session_end(config, Path("/fake/.vox/config.md"))
+        handle_session_end(config, Path("/fake/.punt-labs/vox"))
         mock_write.assert_not_called()
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -39,14 +39,21 @@ from punt_vox.voices import voice_not_found_message
 def _patch_config(  # pyright: ignore[reportUnusedFunction]
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Path:
-    """Return a writable config path and patch config module default."""
+    """Return a writable config directory and patch config module default.
+
+    Returns tmp_path as the config directory. Callers that write
+    ``vox.md`` or ``vox.local.md`` should place them inside tmp_path.
+    For backwards-compat, tests that write to the returned path directly
+    (e.g. ``_patch_config.write_text(...)``) will create a file whose
+    name is the last component of tmp_path — migrate such tests to write
+    to ``tmp_path / "vox.md"`` or ``tmp_path / "vox.local.md"``.
+    """
     import punt_vox.config as cfg
     import punt_vox.dirs as dirs
 
-    config = tmp_path / "config.md"
-    monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", config)
-    monkeypatch.setattr(dirs, "DEFAULT_CONFIG_PATH", config)
-    return config
+    monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(dirs, "DEFAULT_CONFIG_DIR", tmp_path)
+    return tmp_path
 
 
 @pytest.fixture(autouse=True)
@@ -67,43 +74,47 @@ class TestApplyVibe:
     """Tests for apply_vibe text injection."""
 
     def test_prepends_tags(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[excited]"\n---\n')
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text('---\nvibe_tags: "[excited]"\n---\n')
         result = apply_vibe("Hello world", expressive_tags=True)
         assert result == "[excited] Hello world"
 
     def test_multiple_tags(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[frustrated] [sighs]"\n---\n')
+        (_patch_config / "vox.local.md").write_text(
+            '---\nvibe_tags: "[frustrated] [sighs]"\n---\n'
+        )
         result = apply_vibe("Hello world", expressive_tags=True)
         assert result == "[frustrated] [sighs] Hello world"
 
     def test_skips_prepend_when_text_starts_with_tag(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
+        (_patch_config / "vox.local.md").write_text('---\nvibe_tags: "[calm]"\n---\n')
         result = apply_vibe("[calm] Already tagged", expressive_tags=True)
         assert result == "[calm] Already tagged"
 
     def test_skips_prepend_when_text_starts_with_different_tag(
         self, _patch_config: Path
     ) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
+        (_patch_config / "vox.local.md").write_text('---\nvibe_tags: "[calm]"\n---\n')
         result = apply_vibe("[excited] Different tag", expressive_tags=True)
         assert result == "[excited] Different tag"
 
     def test_skips_prepend_when_tag_contains_punctuation(
         self, _patch_config: Path
     ) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
+        (_patch_config / "vox.local.md").write_text('---\nvibe_tags: "[calm]"\n---\n')
         result = apply_vibe("[dramatic tone] Something important", expressive_tags=True)
         assert result == "[dramatic tone] Something important"
 
     def test_passthrough_when_no_tags(self, tmp_path: Path, monkeypatch: Any) -> None:
         import punt_vox.config as cfg
 
-        missing = tmp_path / "missing.md"
-        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_PATH", missing)
+        missing = tmp_path / "missing_dir"
+        monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", missing)
         assert apply_vibe("Hello world", expressive_tags=True) == "Hello world"
 
     def test_skips_tags_when_not_supported(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[excited]"\n---\n')
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text('---\nvibe_tags: "[excited]"\n---\n')
         result = apply_vibe("Hello world", expressive_tags=False)
         assert result == "Hello world"
 
@@ -122,7 +133,7 @@ class TestApplyVibe:
         assert result == "[serious]"
 
     def test_override_tags_win_over_config(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
+        (_patch_config / "vox.local.md").write_text('---\nvibe_tags: "[calm]"\n---\n')
         result = apply_vibe(
             "Hello world",
             expressive_tags=True,
@@ -133,7 +144,7 @@ class TestApplyVibe:
     def test_override_tags_empty_falls_through_to_config(
         self, _patch_config: Path
     ) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[calm]"\n---\n')
+        (_patch_config / "vox.local.md").write_text('---\nvibe_tags: "[calm]"\n---\n')
         result = apply_vibe("Hello world", expressive_tags=True, override_tags="")
         assert result == "[calm] Hello world"
 
@@ -230,69 +241,78 @@ class TestWriteConfigField:
 
     def test_creates_file_when_missing(self, _patch_config: Path) -> None:
         write_field("vibe_tags", "[excited]")
-        assert _patch_config.exists()
-        text = _patch_config.read_text()
+        local_md = _patch_config / "vox.local.md"
+        assert local_md.exists()
+        text = local_md.read_text()
         assert 'vibe_tags: "[excited]"' in text
         assert text.startswith("---\n")
         assert text.rstrip().endswith("---")
 
     def test_updates_existing_field(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[tired]"\n---\n')
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text('---\nvibe_tags: "[tired]"\n---\n')
         write_field("vibe_tags", "[excited]")
-        text = _patch_config.read_text()
+        text = local_md.read_text()
         assert 'vibe_tags: "[excited]"' in text
         assert "[tired]" not in text
 
     def test_updates_unquoted_field(self, _patch_config: Path) -> None:
-        _patch_config.write_text("---\nvibe_tags: [whispers]\n---\n")
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text("---\nvibe_tags: [whispers]\n---\n")
         write_field("vibe_tags", "[excited]")
-        text = _patch_config.read_text()
+        text = local_md.read_text()
         assert 'vibe_tags: "[excited]"' in text
         assert "[whispers]" not in text
 
     def test_inserts_new_field_before_closing_fence(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nnotify: "y"\n---\n')
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text('---\nvibe: "happy"\n---\n')
         write_field("vibe_tags", "[excited]")
-        text = _patch_config.read_text()
+        text = local_md.read_text()
         assert 'vibe_tags: "[excited]"' in text
-        assert 'notify: "y"' in text
+        assert 'vibe: "happy"' in text
 
     def test_preserves_other_fields(self, _patch_config: Path) -> None:
-        _patch_config.write_text(
-            '---\nnotify: "y"\nvibe_tags: "[tired]"\nspeak: "y"\n---\n'
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text(
+            '---\nvibe: "happy"\nvibe_tags: "[tired]"\nvibe_signals: "x"\n---\n'
         )
         write_field("vibe_tags", "[excited]")
-        text = _patch_config.read_text()
-        assert 'notify: "y"' in text
-        assert 'speak: "y"' in text
+        text = local_md.read_text()
+        assert 'vibe: "happy"' in text
+        assert 'vibe_signals: "x"' in text
         assert 'vibe_tags: "[excited]"' in text
 
     def test_clears_field_with_empty_string(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nvibe_tags: "[tired]"\n---\n')
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text('---\nvibe_tags: "[tired]"\n---\n')
         write_field("vibe_tags", "")
-        text = _patch_config.read_text()
+        text = local_md.read_text()
         assert 'vibe_tags: ""' in text
 
     def test_rejects_unknown_key(self, _patch_config: Path) -> None:
-        _patch_config.write_text("---\n---\n")
+        vox_md = _patch_config / "vox.md"
+        vox_md.write_text("---\n---\n")
         with pytest.raises(ValueError, match="Unknown config key"):
             write_field("bad_key", "value")
 
     def test_creates_parent_directory(self, tmp_path: Path) -> None:
-        nested = tmp_path / "deep" / "dir" / "config.md"
+        nested = tmp_path / "deep" / "dir"
         write_field("notify", "y", nested)
-        assert nested.exists()
-        assert 'notify: "y"' in nested.read_text()
+        vox_md = nested / "vox.md"
+        assert vox_md.exists()
+        assert 'notify: "y"' in vox_md.read_text()
 
     def test_malformed_file_warns_and_overwrites(
         self, _patch_config: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
-        _patch_config.write_text("no frontmatter at all\n")
+        vox_md = _patch_config / "vox.md"
+        vox_md.write_text("no frontmatter at all\n")
         import logging
 
         with caplog.at_level(logging.WARNING, logger="punt_vox.config"):
             write_field("notify", "y", _patch_config)
-        assert 'notify: "y"' in _patch_config.read_text()
+        assert 'notify: "y"' in vox_md.read_text()
         assert "Malformed config" in caplog.text
 
 
@@ -300,54 +320,67 @@ class TestWriteConfigFields:
     """Tests for write_fields batch helper."""
 
     def test_writes_multiple_fields(self, _patch_config: Path) -> None:
-        _patch_config.write_text('---\nnotify: "y"\n---\n')
+        vox_md = _patch_config / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
         updates = {
             "vibe": "happy",
             "vibe_tags": "[cheerful]",
             "vibe_mode": "manual",
         }
         write_fields(updates)
-        text = _patch_config.read_text()
-        assert 'vibe: "happy"' in text
-        assert 'vibe_tags: "[cheerful]"' in text
-        assert 'vibe_mode: "manual"' in text
-        assert 'notify: "y"' in text
+        # vibe_mode is durable -> vox.md
+        vox_text = vox_md.read_text()
+        assert 'vibe_mode: "manual"' in vox_text
+        assert 'notify: "y"' in vox_text
+        # vibe, vibe_tags are ephemeral -> vox.local.md
+        local_text = (_patch_config / "vox.local.md").read_text()
+        assert 'vibe: "happy"' in local_text
+        assert 'vibe_tags: "[cheerful]"' in local_text
 
     def test_updates_existing_fields(self, _patch_config: Path) -> None:
-        _patch_config.write_text(
-            '---\nvibe: "old"\nvibe_tags: "[old]"\nvibe_mode: "off"\n---\n'
-        )
+        vox_md = _patch_config / "vox.md"
+        vox_md.write_text('---\nvibe_mode: "off"\n---\n')
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text('---\nvibe: "old"\nvibe_tags: "[old]"\n---\n')
         updates = {
             "vibe": "new",
             "vibe_tags": "[new]",
             "vibe_mode": "manual",
         }
         write_fields(updates)
-        text = _patch_config.read_text()
-        assert 'vibe: "new"' in text
-        assert 'vibe_tags: "[new]"' in text
-        assert 'vibe_mode: "manual"' in text
-        assert "old" not in text
+        vox_text = vox_md.read_text()
+        assert 'vibe_mode: "manual"' in vox_text
+        assert "off" not in vox_text
+        local_text = local_md.read_text()
+        assert 'vibe: "new"' in local_text
+        assert 'vibe_tags: "[new]"' in local_text
+        assert "old" not in local_text
 
     def test_creates_file_when_missing(self, _patch_config: Path) -> None:
         write_fields({"vibe": "happy", "vibe_tags": "[cheerful]"})
-        text = _patch_config.read_text()
+        local_md = _patch_config / "vox.local.md"
+        text = local_md.read_text()
         assert text.startswith("---\n")
         assert 'vibe: "happy"' in text
         assert 'vibe_tags: "[cheerful]"' in text
         assert text.rstrip().endswith("---")
 
     def test_rejects_invalid_key(self, _patch_config: Path) -> None:
-        _patch_config.write_text("---\n---\n")
+        vox_md = _patch_config / "vox.md"
+        vox_md.write_text("---\n---\n")
         with pytest.raises(ValueError, match="Unknown config key"):
             write_fields({"vibe": "ok", "bad_key": "fail"})
-        assert _patch_config.read_text() == "---\n---\n"
+        # vox.md should be unchanged — validation fails before any write
+        assert vox_md.read_text() == "---\n---\n"
 
     def test_atomic_single_read_write(
         self, _patch_config: Path, monkeypatch: Any
     ) -> None:
-        """Verify batch performs one read and one write."""
-        _patch_config.write_text("---\n---\n")
+        """Verify batch performs one read and one write per file."""
+        local_md = _patch_config / "vox.local.md"
+        local_md.write_text("---\n---\n")
+        vox_md = _patch_config / "vox.md"
+        vox_md.write_text("---\n---\n")
         read_count = 0
         write_count = 0
         orig_read = Path.read_text
@@ -355,21 +388,20 @@ class TestWriteConfigFields:
 
         def counting_read(self: Path, *args: Any, **kwargs: Any) -> str:
             nonlocal read_count
-            if self == _patch_config:
+            if self == local_md:
                 read_count += 1
             return orig_read(self, *args, **kwargs)
 
         def counting_write(self: Path, *args: Any, **kwargs: Any) -> int:
             nonlocal write_count
-            if self == _patch_config:
+            if self == local_md:
                 write_count += 1
             return orig_write(self, *args, **kwargs)
 
         monkeypatch.setattr(Path, "read_text", counting_read)
         monkeypatch.setattr(Path, "write_text", counting_write)
-        write_fields(
-            {"vibe": "a", "vibe_tags": "[b]", "vibe_mode": "manual"}, _patch_config
-        )
+        # All ephemeral keys -> single file write to vox.local.md
+        write_fields({"vibe": "a", "vibe_tags": "[b]"}, _patch_config)
         assert read_count == 1
         assert write_count == 1
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,12 +41,8 @@ def _patch_config(  # pyright: ignore[reportUnusedFunction]
 ) -> Path:
     """Return a writable config directory and patch config module default.
 
-    Returns tmp_path as the config directory. Callers that write
-    ``vox.md`` or ``vox.local.md`` should place them inside tmp_path.
-    For backwards-compat, tests that write to the returned path directly
-    (e.g. ``_patch_config.write_text(...)``) will create a file whose
-    name is the last component of tmp_path — migrate such tests to write
-    to ``tmp_path / "vox.md"`` or ``tmp_path / "vox.local.md"``.
+    Returns tmp_path as the config directory. Callers write
+    ``vox.md`` or ``vox.local.md`` inside tmp_path.
     """
     import punt_vox.config as cfg
     import punt_vox.dirs as dirs

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24,7 +24,6 @@ from punt_vox.service import (
     _launchd_plist_content,  # pyright: ignore[reportPrivateUsage]
     _launchd_stop,  # pyright: ignore[reportPrivateUsage]
     _legacy_user_unit_path,  # pyright: ignore[reportPrivateUsage]
-    _migrate_legacy_repo_config,  # pyright: ignore[reportPrivateUsage]
     _remove_port_file,  # pyright: ignore[reportPrivateUsage]
     _safe_systemd_value,  # pyright: ignore[reportPrivateUsage]
     _systemd_audio_env_lines,  # pyright: ignore[reportPrivateUsage]
@@ -2084,93 +2083,3 @@ def test_install_cleans_stale_user_unit_before_systemd_stop(
         "systemd_stop",
         "ensure_port_free",
     ], f"unexpected install() ordering: {call_order}"
-
-
-# ---------------------------------------------------------------------------
-# _migrate_legacy_repo_config
-# ---------------------------------------------------------------------------
-
-
-class TestMigrateLegacyRepoConfig:
-    def test_happy_path(self, tmp_path: Path) -> None:
-        legacy_dir = tmp_path / ".vox"
-        legacy_dir.mkdir()
-        legacy_config = legacy_dir / "config.md"
-        legacy_config.write_text('---\nnotify: "y"\n---\n')
-        # Add an ephemeral MP3
-        (legacy_dir / "ephemeral.mp3").write_bytes(b"fake")
-
-        result = _migrate_legacy_repo_config(tmp_path)
-
-        assert result is True
-        new_config = tmp_path / ".punt-labs" / "vox" / "config.md"
-        assert new_config.exists()
-        assert new_config.read_text() == '---\nnotify: "y"\n---\n'
-        assert not legacy_config.exists()
-        assert not (legacy_dir / "ephemeral.mp3").exists()
-        # .vox/ should be removed since it's empty
-        assert not legacy_dir.exists()
-
-    def test_no_legacy_config(self, tmp_path: Path) -> None:
-        assert _migrate_legacy_repo_config(tmp_path) is False
-
-    def test_already_migrated(self, tmp_path: Path) -> None:
-        legacy_dir = tmp_path / ".vox"
-        legacy_dir.mkdir()
-        (legacy_dir / "config.md").write_text("old")
-        new_dir = tmp_path / ".punt-labs" / "vox"
-        new_dir.mkdir(parents=True)
-        (new_dir / "config.md").write_text("new")
-
-        result = _migrate_legacy_repo_config(tmp_path)
-
-        assert result is False
-        # New config not overwritten
-        assert (new_dir / "config.md").read_text() == "new"
-
-    def test_legacy_dir_is_symlink(self, tmp_path: Path) -> None:
-        real_dir = tmp_path / "real_vox"
-        real_dir.mkdir()
-        (real_dir / "config.md").write_text("data")
-        (tmp_path / ".vox").symlink_to(real_dir)
-
-        result = _migrate_legacy_repo_config(tmp_path)
-
-        assert result is False
-
-    def test_legacy_config_is_symlink(self, tmp_path: Path) -> None:
-        legacy_dir = tmp_path / ".vox"
-        legacy_dir.mkdir()
-        real_config = tmp_path / "real_config.md"
-        real_config.write_text("data")
-        (legacy_dir / "config.md").symlink_to(real_config)
-
-        result = _migrate_legacy_repo_config(tmp_path)
-
-        assert result is False
-
-    def test_punt_labs_not_a_directory(self, tmp_path: Path) -> None:
-        legacy_dir = tmp_path / ".vox"
-        legacy_dir.mkdir()
-        (legacy_dir / "config.md").write_text("data")
-        # Create .punt-labs as a file, not a directory
-        (tmp_path / ".punt-labs").write_text("not a dir")
-
-        result = _migrate_legacy_repo_config(tmp_path)
-
-        assert result is False
-
-    def test_non_empty_legacy_dir_left_behind(self, tmp_path: Path) -> None:
-        legacy_dir = tmp_path / ".vox"
-        legacy_dir.mkdir()
-        (legacy_dir / "config.md").write_text("data")
-        (legacy_dir / "user_notes.txt").write_text("keep me")
-
-        result = _migrate_legacy_repo_config(tmp_path)
-
-        assert result is True
-        # .vox/ stays because it has user files
-        assert legacy_dir.exists()
-        assert (legacy_dir / "user_notes.txt").exists()
-        # But config.md was moved
-        assert not (legacy_dir / "config.md").exists()

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -836,7 +836,7 @@ class TestApiKeyPassthroughIntegration:
         def fake_get_provider(
             name: str,
             *,
-            config_path: object = None,
+            config_dir: object = None,
             model: str | None = None,
         ) -> object:
             assert name == "elevenlabs"
@@ -1077,7 +1077,7 @@ class TestCacheApiKeyBypass:
         def fake_get_provider(
             name: str,
             *,
-            config_path: object = None,
+            config_dir: object = None,
             model: str | None = None,
         ) -> object:
             assert name == "elevenlabs"

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -195,9 +195,9 @@ class TestNotificationConsumer:
     """Notification consumer config gating and throttle behavior."""
 
     def test_skips_when_notify_not_c(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "y"\n---\n')
-        consumer = make_notification_consumer(config_path=config_path)
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "y"\n---\n')
+        consumer = make_notification_consumer(config_dir=tmp_path)
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
         )
@@ -207,11 +207,9 @@ class TestNotificationConsumer:
             mock_voice.assert_not_called()
 
     def test_fires_when_notify_c_speak_y(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
-        consumer = make_notification_consumer(
-            config_path=config_path, throttle_seconds=0.0
-        )
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
+        consumer = make_notification_consumer(config_dir=tmp_path, throttle_seconds=0.0)
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
         )
@@ -221,11 +219,9 @@ class TestNotificationConsumer:
             mock_voice.assert_called_once_with(event)
 
     def test_chime_mode_when_speak_n(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "c"\nspeak: "n"\n---\n')
-        consumer = make_notification_consumer(
-            config_path=config_path, throttle_seconds=0.0
-        )
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "c"\nspeak: "n"\n---\n')
+        consumer = make_notification_consumer(config_dir=tmp_path, throttle_seconds=0.0)
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
         )
@@ -235,11 +231,11 @@ class TestNotificationConsumer:
             mock_chime.assert_called_once_with("tests-pass", None)
 
     def test_chime_mode_passes_vibe(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "c"\nspeak: "n"\nvibe: "happy"\n---\n')
-        consumer = make_notification_consumer(
-            config_path=config_path, throttle_seconds=0.0
-        )
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "c"\nspeak: "n"\n---\n')
+        local_md = tmp_path / "vox.local.md"
+        local_md.write_text('---\nvibe: "happy"\n---\n')
+        consumer = make_notification_consumer(config_dir=tmp_path, throttle_seconds=0.0)
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
         )
@@ -249,10 +245,10 @@ class TestNotificationConsumer:
             mock_chime.assert_called_once_with("tests-pass", "happy")
 
     def test_throttles_same_signal(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
         consumer = make_notification_consumer(
-            config_path=config_path, throttle_seconds=100.0
+            config_dir=tmp_path, throttle_seconds=100.0
         )
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
@@ -264,10 +260,10 @@ class TestNotificationConsumer:
             assert mock_voice.call_count == 1
 
     def test_different_signals_not_throttled(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
         consumer = make_notification_consumer(
-            config_path=config_path, throttle_seconds=100.0
+            config_dir=tmp_path, throttle_seconds=100.0
         )
         e1 = SessionEvent(signal="tests-pass", timestamp=time.time(), source_text="ok")
         e2 = SessionEvent(signal="lint-pass", timestamp=time.time(), source_text="ok")
@@ -292,10 +288,10 @@ class TestNotificationConsumer:
         This test mocks time.monotonic to return a value smaller than the
         throttle window, simulating the CI runner condition.
         """
-        config_path = tmp_path / "config.md"
-        config_path.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
+        vox_md = tmp_path / "vox.md"
+        vox_md.write_text('---\nnotify: "c"\nspeak: "y"\n---\n')
         consumer = make_notification_consumer(
-            config_path=config_path, throttle_seconds=100.0
+            config_dir=tmp_path, throttle_seconds=100.0
         )
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
@@ -311,7 +307,7 @@ class TestNotificationConsumer:
             )
 
     def test_skips_when_no_config_file(self, tmp_path: Path) -> None:
-        consumer = make_notification_consumer(config_path=tmp_path / "missing.md")
+        consumer = make_notification_consumer(config_dir=tmp_path / "missing_dir")
         event = SessionEvent(
             signal="tests-pass", timestamp=time.time(), source_text="ok"
         )


### PR DESCRIPTION
## Summary

- Split single `.vox/config.md` into two files under `.punt-labs/vox/`: `vox.md` (tracked in git, durable preferences) and `vox.local.md` (gitignored, ephemeral session state)
- Durable fields (voice, provider, model, notify, speak, vibe_mode) route to `vox.md`; ephemeral fields (vibe, vibe_tags, vibe_signals) route to `vox.local.md`
- `DURABLE_KEYS`/`EPHEMERAL_KEYS` frozensets drive all routing — callers never specify which file
- API rename: `config_path: Path` → `config_dir: Path` throughout (clean break, no legacy support)
- Removed `.vox/` directory entirely
- Security: added newline rejection in config values to prevent YAML frontmatter corruption (djb review finding)

Closes vox-11t.

## Test plan

- [x] 1401 tests pass (`make check` clean)
- [x] 33 config-specific tests covering routing, merge semantics, edge cases, validation
- [x] Security review (m-2026-05-12-006): all 5 focus areas pass
- [x] Newline injection regression tests added

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches config discovery/read-write across CLI, hooks, MCP server, watcher, and provider resolution; mistakes could break session state persistence or hook behavior. Risk is mitigated by extensive new tests, but it’s a broad plumbing change.
> 
> **Overview**
> Refactors per-repo configuration from a single file to a **split config directory** under `.punt-labs/vox/`: tracked `vox.md` for durable preferences and gitignored `vox.local.md` for ephemeral session state (plus gitignored `.punt-labs/vox/ephemeral/` audio).
> 
> Renames the public API from `config_path` to `config_dir` and updates all call sites (CLI, hooks, MCP `server.py`, `watcher.py`, provider selection, and `resolve.py`) to discover config via `find_config_dir()` and route writes via `DURABLE_KEYS`/`EPHEMERAL_KEYS`.
> 
> Removes legacy `.vox/` support and related migration/doctor checks, and adds validation to reject newline-containing config values to prevent frontmatter corruption; test suite is updated with expanded coverage for routing, merge semantics, and directory discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf59843938eaa99fb803db52f19447f2c8a1822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->