### PR TITLE
chore: remove dead assets symlink from repo root

### DIFF
--- a/assets
+++ b/assets
@@ -1,1 +1,0 @@
-src/punt_vox/assets


### PR DESCRIPTION
## Summary

- Remove `assets → src/punt_vox/assets` symlink from repo root
- Added in v1.10.2 for hook compatibility, dead since v3.0.0 (all code uses `__file__`-relative resolution)
- No hook, command, or Python module references this path

## Test plan

- [x] `grep -rn` confirms no references to root `assets/` path
- [x] `make check` unaffected (symlink not used by any code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes an unused repo-root `assets` symlink; no code references were found, so functional impact should be minimal unless external tooling depended on the path.
> 
> **Overview**
> Removes the repo-root `assets` entry (previously a symlink to `src/punt_vox/assets`).
> 
> This cleans up a dead path with no in-repo references, reducing confusion and avoiding stale filesystem links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e196e6e2c8c92a0c1b8b1a9fa2aa69351116d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->