### PR TITLE
docs: CHANGELOG entries for security dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bump authlib 1.6.9 → 1.6.11: CSRF fix in Starlette OAuth client, unvalidated `redirect_uri` on UnsupportedResponseTypeError (#236)
+- Bump python-multipart 0.0.22 → 0.0.27: multipart header limits (DoS hardening), `chunk_size` validation (#233)
+- Bump python-dotenv 1.2.1 → 1.2.2: symlink following fix in `set_key`/`unset_key` (#234)
+- Bump pytest 9.0.2 → 9.0.3: insecure temporary directory CVE-2025-71176 (#235)
+
+### Removed
+
+- Dead `assets` symlink at repo root (pointed to `src/punt_vox/assets/`, unused since v3.0.0) (#241)
+
 ## [4.7.5] - 2026-05-11
 
 ### Changed


### PR DESCRIPTION
## Summary

- Add CHANGELOG entries under [Unreleased]/Security for the 4 dependabot PRs merged in #233, #234, #235, #236
- Add [Unreleased]/Removed entry for dead assets symlink (#241)

## Test plan

- [x] CHANGELOG-only change, no code affected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: `CHANGELOG.md`-only documentation updates with no runtime or dependency changes in this PR.
> 
> **Overview**
> Adds new **`[Unreleased]`** changelog entries documenting recent security-related dependency bumps (`authlib`, `python-multipart`, `python-dotenv`, `pytest`).
> 
> Also notes removal of a dead repo-root `assets` symlink under **Removed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7533e411ed1af9b8f43fbbf8c0a73f6cbe320a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->