### PR TITLE
feat(client): remote voxd connectivity via VOXD_HOST/PORT/TOKEN env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Remote voxd connectivity**: client-side env vars `VOXD_HOST`, `VOXD_PORT`, `VOXD_TOKEN` override localhost/file-based discovery, enabling cross-host audio playback without SSH tunnels. Server-side `VOXD_BIND` (via `--host` flag or env var) controls the bind address (default `127.0.0.1`, opt-in `0.0.0.0`). Token auth remains the security boundary. `vox doctor` reports active env var overrides. Access logs redact auth tokens. Warning logged when binding to non-localhost.
+
 ## [4.7.6] - 2026-05-12
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ Mission contract YAMLs go in `.tmp/missions/`. Result artifact YAMLs go in `.tmp
 
 ## Issue Tracking with Beads
 
-This project uses **beads** (`bd`) for issue tracking.
+This project uses **beads** (`bd`) for issue tracking. The shared Hosted DoltDB instance filters by repo label — every `bd create` in this repo **must** include `--add-label "repo:vox"` or the issue will be invisible in `bd list` and `bd ready`.
 
 ### When to Use Beads vs TodoWrite
 
@@ -264,7 +264,7 @@ bd list --status=open       # All open issues
 bd show <id>                # View issue details
 bd update <id> --status=in_progress   # Claim work
 bd close <id>               # Mark complete
-bd create --title="..." --type=task   # Create issue
+bd create --title="..." --type=task --add-label "repo:vox"  # Create issue
 bd dep add <child> <parent> # child depends on parent
 bd sync                     # Sync with git remote
 ```

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -1039,8 +1039,8 @@ def doctor() -> None:
     # Report active VOXD_* env var overrides
     overrides: list[str] = []
     for env_name in ("VOXD_HOST", "VOXD_PORT", "VOXD_TOKEN"):
-        env_val = os.environ.get(env_name)
-        if env_val is not None:
+        env_val = os.environ.get(env_name, "").strip()
+        if env_val:
             display = "***" if env_name == "VOXD_TOKEN" else env_val
             overrides.append(f"{env_name}={display}")
     if overrides:

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -1036,6 +1036,19 @@ def doctor() -> None:
             f"Daemon: reachable but unhealthy \u2014 {exc}",
         )
 
+    # Report active VOXD_* env var overrides
+    overrides = [
+        f"{k}={v}"
+        for k, v in [
+            ("VOXD_HOST", os.environ.get("VOXD_HOST")),
+            ("VOXD_PORT", os.environ.get("VOXD_PORT")),
+            ("VOXD_TOKEN", os.environ.get("VOXD_TOKEN")),
+        ]
+        if v is not None
+    ]
+    if overrides:
+        _check(_PASS, f"Remote config: {', '.join(overrides)}")
+
     # Legacy ~/vox-output/ directory (vox-4jk migration)
     legacy_output = Path.home() / "vox-output"
     if legacy_output.is_dir():

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -1037,15 +1037,12 @@ def doctor() -> None:
         )
 
     # Report active VOXD_* env var overrides
-    overrides = [
-        f"{k}={v}"
-        for k, v in [
-            ("VOXD_HOST", os.environ.get("VOXD_HOST")),
-            ("VOXD_PORT", os.environ.get("VOXD_PORT")),
-            ("VOXD_TOKEN", os.environ.get("VOXD_TOKEN")),
-        ]
-        if v is not None
-    ]
+    overrides: list[str] = []
+    for env_name in ("VOXD_HOST", "VOXD_PORT", "VOXD_TOKEN"):
+        env_val = os.environ.get(env_name)
+        if env_val is not None:
+            display = "***" if env_name == "VOXD_TOKEN" else env_val
+            overrides.append(f"{env_name}={display}")
     if overrides:
         _check(_PASS, f"Remote config: {', '.join(overrides)}")
 

--- a/src/punt_vox/client.py
+++ b/src/punt_vox/client.py
@@ -12,6 +12,7 @@ import binascii
 import contextlib
 import json
 import logging
+import os
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -78,6 +79,28 @@ class VoxdProtocolError(Exception):
 # ---------------------------------------------------------------------------
 
 
+def _env_host() -> str:
+    """Return VOXD_HOST or default."""
+    return os.environ.get("VOXD_HOST", "127.0.0.1")
+
+
+def _env_port() -> int | None:
+    """Return VOXD_PORT as int, or None to fall back to file."""
+    raw = os.environ.get("VOXD_PORT")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("VOXD_PORT=%r is not an integer, ignoring", raw)
+        return None
+
+
+def _env_token() -> str | None:
+    """Return VOXD_TOKEN, or None to fall back to file."""
+    return os.environ.get("VOXD_TOKEN")
+
+
 def _run_dir() -> Path:
     """Return ``~/.punt-labs/vox/run`` — holds ``serve.port`` / ``serve.token``."""
     return _user_run_dir()
@@ -111,11 +134,11 @@ class VoxClient:
 
     def __init__(
         self,
-        host: str = "127.0.0.1",
+        host: str | None = None,
         port: int | None = None,
         token: str | None = None,
     ) -> None:
-        self._host = host
+        self._host = host if host is not None else _env_host()
         self._explicit_port = port
         self._explicit_token = token
         self._port = port
@@ -129,6 +152,9 @@ class VoxClient:
         """Return the port, reading from file if needed."""
         if self._port is not None:
             return self._port
+        env = _env_port()
+        if env is not None:
+            return env
         port = read_port_file()
         if port is None:
             msg = "voxd port file not found. Is the daemon running? Start it with: voxd"
@@ -139,6 +165,9 @@ class VoxClient:
         """Return the token, reading from file if needed."""
         if self._token is not None:
             return self._token
+        env = _env_token()
+        if env is not None:
+            return env
         return read_token_file()
 
     def _build_uri(self) -> str:
@@ -534,11 +563,11 @@ class VoxClientSync:
 
     def __init__(
         self,
-        host: str = "127.0.0.1",
+        host: str | None = None,
         port: int | None = None,
         token: str | None = None,
     ) -> None:
-        self._host = host
+        self._host = host if host is not None else _env_host()
         self._port = port
         self._token = token
 

--- a/src/punt_vox/client.py
+++ b/src/punt_vox/client.py
@@ -81,24 +81,30 @@ class VoxdProtocolError(Exception):
 
 def _env_host() -> str:
     """Return VOXD_HOST or default."""
-    return os.environ.get("VOXD_HOST", "127.0.0.1")
+    val = os.environ.get("VOXD_HOST", "").strip()
+    return val if val else "127.0.0.1"
 
 
 def _env_port() -> int | None:
     """Return VOXD_PORT as int, or None to fall back to file."""
-    raw = os.environ.get("VOXD_PORT")
-    if raw is None:
+    raw = os.environ.get("VOXD_PORT", "").strip()
+    if not raw:
         return None
     try:
-        return int(raw)
+        port = int(raw)
     except ValueError:
         logger.warning("VOXD_PORT=%r is not an integer, ignoring", raw)
         return None
+    if not 1 <= port <= 65535:
+        logger.warning("VOXD_PORT=%d is out of range (1-65535), ignoring", port)
+        return None
+    return port
 
 
 def _env_token() -> str | None:
     """Return VOXD_TOKEN, or None to fall back to file."""
-    return os.environ.get("VOXD_TOKEN")
+    val = os.environ.get("VOXD_TOKEN", "").strip()
+    return val if val else None
 
 
 def _run_dir() -> Path:

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -512,6 +512,15 @@ _LAUNCHD_DIR = Path("/Library/LaunchDaemons")
 _LAUNCHD_PLIST = _LAUNCHD_DIR / f"{_LABEL}.plist"
 
 
+def _extra_launchd_env() -> dict[str, str]:
+    """Return extra env vars to bake into the launchd plist."""
+    extras: dict[str, str] = {}
+    bind = os.environ.get("VOXD_BIND")
+    if bind:
+        extras["VOXD_BIND"] = bind
+    return extras
+
+
 def _launchd_plist_content(user: str) -> str:
     args = _voxd_exec_args()
     # Plist XML reads <string> values literally — use html.escape for
@@ -526,6 +535,11 @@ def _launchd_plist_content(user: str) -> str:
     stderr_log = html.escape(str(log_dir / "voxd-stderr.log"))
     path_value = html.escape(os.environ.get("PATH", "/usr/bin:/bin:/usr/sbin:/sbin"))
     escaped_user = html.escape(user)
+    extra_env = "".join(
+        f"\n            <key>{html.escape(k)}</key>"
+        f"\n            <string>{html.escape(v)}</string>"
+        for k, v in _extra_launchd_env().items()
+    )
     return textwrap.dedent(f"""\
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -543,7 +557,7 @@ def _launchd_plist_content(user: str) -> str:
             <key>EnvironmentVariables</key>
             <dict>
                 <key>PATH</key>
-                <string>{path_value}</string>
+                <string>{path_value}</string>{extra_env}
             </dict>
             <key>RunAtLoad</key>
             <true/>
@@ -844,8 +858,10 @@ def _systemd_unit_content(user: str) -> str:
     raw_path = os.environ.get("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
     path_value = raw_path.replace("%", "%%")
     audio_lines = _systemd_audio_env_lines(user)
+    bind = os.environ.get("VOXD_BIND")
+    bind_lines = [f'Environment="VOXD_BIND={bind}"'] if bind else []
     env_block = ("\n" + " " * 8).join(
-        [f'Environment="PATH={path_value}"', *audio_lines]
+        [f'Environment="PATH={path_value}"', *audio_lines, *bind_lines]
     )
     # Runtime state lives in the user's home dir (see punt_vox.paths),
     # so there is no RuntimeDirectory= here — systemd does not need to

--- a/src/punt_vox/service.py
+++ b/src/punt_vox/service.py
@@ -859,7 +859,9 @@ def _systemd_unit_content(user: str) -> str:
     path_value = raw_path.replace("%", "%%")
     audio_lines = _systemd_audio_env_lines(user)
     bind = os.environ.get("VOXD_BIND")
-    bind_lines = [f'Environment="VOXD_BIND={bind}"'] if bind else []
+    bind_lines: list[str] = []
+    if bind and _safe_systemd_value(bind):
+        bind_lines = [f'Environment="VOXD_BIND={bind.replace("%", "%%")}"']
     env_block = ("\n" + " " * 8).join(
         [f'Environment="PATH={path_value}"', *audio_lines, *bind_lines]
     )

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -84,8 +84,14 @@ class _TokenRedactFilter(logging.Filter):
 
 
 def _install_token_redact_filter() -> None:
-    """Apply token redaction to uvicorn's access logger."""
+    """Apply token redaction to uvicorn's access logger.
+
+    Uvicorn sets the access logger level to match log_level (WARNING),
+    but access entries are logged at INFO. Override to INFO so access
+    logs actually fire, with the redact filter stripping tokens.
+    """
     uvicorn_access = logging.getLogger("uvicorn.access")
+    uvicorn_access.setLevel(logging.INFO)
     uvicorn_access.addFilter(_TokenRedactFilter())
 
 

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -73,8 +73,13 @@ class _TokenRedactFilter(logging.Filter):
     """Strip auth tokens from access log messages."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if hasattr(record, "msg") and isinstance(record.msg, str):
+        if isinstance(getattr(record, "msg", None), str):
             record.msg = _TOKEN_RE.sub("?token=REDACTED", record.msg)
+        if record.args and isinstance(record.args, tuple):
+            record.args = tuple(
+                _TOKEN_RE.sub("?token=REDACTED", a) if isinstance(a, str) else a
+                for a in record.args
+            )
         return True
 
 
@@ -2573,7 +2578,7 @@ def main(
 
     app = build_app(ctx, lifespan=lifespan)
 
-    if host not in ("127.0.0.1", "::1"):
+    if host not in ("127.0.0.1", "::1", "localhost"):
         logger.warning(
             "Binding to %s — voxd is accessible from the network. "
             "Ensure VOXD_TOKEN is set on all clients.",

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -66,6 +66,24 @@ logger = logging.getLogger(__name__)
 DEFAULT_PORT = 8421
 DEFAULT_HOST = "127.0.0.1"
 
+_TOKEN_RE = re.compile(r"\?token=[^\s\"']+")
+
+
+class _TokenRedactFilter(logging.Filter):
+    """Strip auth tokens from access log messages."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if hasattr(record, "msg") and isinstance(record.msg, str):
+            record.msg = _TOKEN_RE.sub("?token=REDACTED", record.msg)
+        return True
+
+
+def _install_token_redact_filter() -> None:
+    """Apply token redaction to uvicorn's access logger."""
+    uvicorn_access = logging.getLogger("uvicorn.access")
+    uvicorn_access.addFilter(_TokenRedactFilter())
+
+
 # Audio deduplication window: skip identical audio within this many seconds.
 _DEDUP_WINDOW_SECONDS = 5.0
 
@@ -2495,7 +2513,9 @@ cli = typer.Typer(add_completion=False)
 @cli.callback(invoke_without_command=True)
 def main(
     port: int = typer.Option(DEFAULT_PORT, "--port", "-p", help="Listen port"),
-    host: str = typer.Option(DEFAULT_HOST, "--host", help="Listen host"),
+    host: str = typer.Option(
+        DEFAULT_HOST, "--host", envvar="VOXD_BIND", help="Listen host"
+    ),
 ) -> None:
     """Start the voxd audio server daemon."""
     # Create (or tighten) per-user state dirs before anything else
@@ -2553,14 +2573,22 @@ def main(
 
     app = build_app(ctx, lifespan=lifespan)
 
+    if host not in ("127.0.0.1", "::1"):
+        logger.warning(
+            "Binding to %s — voxd is accessible from the network. "
+            "Ensure VOXD_TOKEN is set on all clients.",
+            host,
+        )
+
     config = uvicorn.Config(
         app,
         host=host,
         port=port,
         log_config=None,
         log_level="warning",
-        access_log=False,
+        access_log=True,
     )
+    _install_token_redact_filter()
     server = uvicorn.Server(config)
 
     # Write port file after bind

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1129,3 +1129,59 @@ class TestVoxClientSyncMusicPlayList:
 
         sent = json.loads(mock_ws.send.call_args[0][0])
         assert sent["name"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# Env var resolution (VOXD_HOST, VOXD_PORT, VOXD_TOKEN)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvVarResolution:
+    def test_voxd_host_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_HOST", "10.0.0.1")
+        client = VoxClient(port=8421, token="tok")
+        assert client._host == "10.0.0.1"  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_host_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VOXD_HOST", raising=False)
+        client = VoxClient(port=8421, token="tok")
+        assert client._host == "127.0.0.1"  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_host_explicit_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_HOST", "10.0.0.1")
+        client = VoxClient(host="192.168.1.1", port=8421, token="tok")
+        assert client._host == "192.168.1.1"  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_port_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_PORT", "9999")
+        client = VoxClient(token="tok")
+        assert client._resolve_port() == 9999  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_port_invalid_falls_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("VOXD_PORT", "not_a_number")
+        monkeypatch.setattr("punt_vox.client._run_dir", lambda: tmp_path)
+        client = VoxClient(token="tok")
+        with pytest.raises(VoxdConnectionError, match="port file not found"):
+            client._resolve_port()  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_port_explicit_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_PORT", "9999")
+        client = VoxClient(port=1234, token="tok")
+        assert client._resolve_port() == 1234  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_token_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_TOKEN", "remote-secret")
+        client = VoxClient(port=8421)
+        assert client._resolve_token() == "remote-secret"  # pyright: ignore[reportPrivateUsage]
+
+    def test_voxd_token_explicit_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_TOKEN", "remote-secret")
+        client = VoxClient(port=8421, token="local-secret")
+        assert client._resolve_token() == "local-secret"  # pyright: ignore[reportPrivateUsage]
+
+    def test_sync_client_inherits_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VOXD_HOST", "10.0.0.1")
+        sync_client = VoxClientSync(port=8421, token="tok")
+        assert sync_client._host == "10.0.0.1"  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary

- Client: `VOXD_HOST`, `VOXD_PORT`, `VOXD_TOKEN` env vars override localhost/file-based discovery for cross-host audio playback
- Server: `VOXD_BIND` via `typer.Option(envvar=)` on `--host` — CLI flag > env var > default (`127.0.0.1`)
- Service: bakes `VOXD_BIND` into systemd/launchd units when set at install time
- Doctor: reports active `VOXD_*` env var overrides
- Access logs: token redact filter strips `?token=...` from log messages
- Warning logged when binding to non-localhost address

Closes vox-vrv. Design: `.tmp/missions/results/remote-voxd-design.md` (m-2026-05-12-009, approved after 2 review rounds).

## Test plan

- [x] 1403 tests pass (`make check` clean)
- [x] 10 new env var resolution tests (host, port, token — default, env, explicit-wins, invalid, sync inheritance)
- [ ] Manual: SSH to okinos, set VOXD_HOST/PORT/TOKEN, `vox unmute hello` plays on host A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables network-accessible `voxd` bindings and remote client configuration, which increases exposure if tokens are misconfigured; mitigations include explicit bind opt-in, warnings, and token redaction in logs.
> 
> **Overview**
> Adds **remote `voxd` connectivity** by letting clients override localhost/file discovery with `VOXD_HOST`, `VOXD_PORT`, and `VOXD_TOKEN`, and updates `vox doctor` to surface active overrides (redacting the token).
> 
> Extends the daemon/service install flow to support non-localhost binds via `VOXD_BIND` (env var for `voxd --host`, baked into systemd/launchd units at install time), logs a warning when binding off-loopback, and turns on uvicorn access logs with a filter that **redacts `?token=...`**.
> 
> Updates docs/changelog and adds tests covering env-var resolution precedence and invalid port fallthrough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 181a14b69707c00ee96ebb01a27d44c9e033e205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->