### PR TITLE
feat: repo name in quips + markdownlint in make check

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,3 +1,3 @@
 {
-  "ignores": [".beads/", ".claude/", ".entire/", ".venv/"]
+  "ignores": [".beads/", ".claude/", ".entire/", ".tmp/", ".venv/"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Remote voxd connectivity**: client-side env vars `VOXD_HOST`, `VOXD_PORT`, `VOXD_TOKEN` override localhost/file-based discovery, enabling cross-host audio playback without SSH tunnels. Server-side `VOXD_BIND` (via `--host` flag or env var) controls the bind address (default `127.0.0.1`, opt-in `0.0.0.0`). Token auth remains the security boundary. `vox doctor` reports active env var overrides. Access logs redact auth tokens. Warning logged when binding to non-localhost.
+- **Remote voxd connectivity**: client-side env vars `VOXD_HOST`, `VOXD_PORT`, `VOXD_TOKEN` override localhost/file-based discovery, enabling cross-host audio playback without SSH tunnels. Server-side `VOXD_BIND` (via `--host` flag or env var) controls the bind address (default `127.0.0.1`, opt-in `0.0.0.0`). Token auth remains the security boundary. `vox doctor` reports active env var overrides. Access logs redact auth tokens. Warning logged when binding to non-localhost. See `docs/remote-setup.md` for setup guide.
+- **Repo name in spoken notifications**: hook quips now prefix the repo name (e.g. "vox. Needs your approval.") so users with multiple simultaneous sessions can identify which project needs attention. Derived from the config directory path. Degrades gracefully when config_dir is unavailable.
+
+### Fixed
+
+- **`make check` missing markdownlint**: added `docs` target running `npx markdownlint-cli2` to match the CI docs job. PRs that pass `make check` locally will no longer fail the docs CI check.
 
 ## [4.7.6] - 2026-05-12
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ type: ## Type check with mypy and pyright
 	uv run pyright src/ tests/
 
 docs: ## Lint markdown files (matches CI docs job)
-	npx markdownlint-cli2 "**/*.md"
+	npx --yes markdownlint-cli2@0.22.1 "**/*.md"
 
 check: lint type docs test ## Run all quality gates
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test lint type check format build clean depot prfaq clean-tex zspec zspec-test
+.PHONY: help test lint type docs check format build clean depot prfaq clean-tex zspec zspec-test
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
@@ -16,7 +16,10 @@ type: ## Type check with mypy and pyright
 	uv run mypy src/ tests/
 	uv run pyright src/ tests/
 
-check: lint type test ## Run all quality gates
+docs: ## Lint markdown files (matches CI docs job)
+	npx markdownlint-cli2 "**/*.md"
+
+check: lint type docs test ## Run all quality gates
 
 format: ## Auto-format code
 	uv run ruff format src/ tests/

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -72,6 +72,7 @@ class VoxConfig:
     vibe: str | None
     vibe_tags: str | None
     vibe_signals: str | None
+    repo_name: str | None = None
 
 
 # ── Internal helpers ─────────────────────────────────────────────────
@@ -90,7 +91,11 @@ def _parse_frontmatter(path: Path) -> dict[str, str]:
     return fields
 
 
-def _fields_to_config(fields: dict[str, str]) -> VoxConfig:
+def _fields_to_config(
+    fields: dict[str, str],
+    *,
+    repo_name: str | None = None,
+) -> VoxConfig:
     """Build a VoxConfig from raw field dict, applying validation and defaults."""
     notify = fields.get("notify", "n")
     if notify not in ("y", "c", "n"):
@@ -114,6 +119,7 @@ def _fields_to_config(fields: dict[str, str]) -> VoxConfig:
         vibe=fields.get("vibe"),
         vibe_tags=fields.get("vibe_tags"),
         vibe_signals=fields.get("vibe_signals"),
+        repo_name=repo_name,
     )
 
 
@@ -192,6 +198,21 @@ def read_field(field: str, config_dir: Path | None = None) -> str | None:
     return _read_single_field(d / "vox.md", field)
 
 
+def _derive_repo_name(config_dir: Path | None) -> str | None:
+    """Derive the repo name from config_dir.
+
+    config_dir is ``<repo>/.punt-labs/vox/``, so the repo root is two
+    parents up and its ``.name`` gives the repo directory name.  Returns
+    None when config_dir is None or when the path is too shallow.
+    """
+    if config_dir is None:
+        return None
+    repo_root = config_dir.parent.parent
+    # Guard against degenerate paths like "/" where .name is ""
+    name = repo_root.name
+    return name if name else None
+
+
 def read_config(config_dir: Path | None = None) -> VoxConfig:
     """Read all config fields, merging vox.md and vox.local.md."""
     d = config_dir or DEFAULT_CONFIG_DIR
@@ -204,7 +225,7 @@ def read_config(config_dir: Path | None = None) -> VoxConfig:
     local = _parse_frontmatter(d / "vox.local.md")
     fields.update({k: v for k, v in local.items() if k in EPHEMERAL_KEYS})
 
-    return _fields_to_config(fields)
+    return _fields_to_config(fields, repo_name=_derive_repo_name(config_dir))
 
 
 def _validate_value(value: str) -> None:

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -253,7 +253,7 @@ def handle_stop(data: dict[str, object], config: VoxConfig) -> dict[str, object]
 
     # Voice mode: block the stop, ask Claude to summarize and speak.
     # Resolve tags and write to config so apply_vibe picks them up
-    # automatically — no data in the user-visible reason string.
+    # automatically — no vibe tags or signals in the reason string.
     phrase = random.choice(STOP_PHRASES)
     if config.repo_name:
         phrase = f"{config.repo_name}. {phrase}"

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -255,6 +255,8 @@ def handle_stop(data: dict[str, object], config: VoxConfig) -> dict[str, object]
     # Resolve tags and write to config so apply_vibe picks them up
     # automatically — no data in the user-visible reason string.
     phrase = random.choice(STOP_PHRASES)
+    if config.repo_name:
+        phrase = f"{config.repo_name}. {phrase}"
     logger.info(
         "Stop hook: blocking for voice summary (signals=%s)",
         config.vibe_signals,
@@ -360,13 +362,26 @@ def handle_post_bash(data: dict[str, object], config_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _pick_notification_phrase(notification_type: str, message: str) -> str:
-    """Pick a phrase for a notification type."""
+def _pick_notification_phrase(
+    notification_type: str,
+    message: str,
+    *,
+    repo_name: str | None = None,
+) -> str:
+    """Pick a phrase for a notification type.
+
+    When *repo_name* is set, prepends it with a period separator so
+    the TTS engine inserts a natural pause.
+    """
     if notification_type == "permission_prompt":
-        return random.choice(PERMISSION_PHRASES)
-    if notification_type == "idle_prompt":
-        return random.choice(IDLE_PHRASES)
-    return f"Notification: {message[:80]}"
+        text = random.choice(PERMISSION_PHRASES)
+    elif notification_type == "idle_prompt":
+        text = random.choice(IDLE_PHRASES)
+    else:
+        text = f"Notification: {message[:80]}"
+    if repo_name:
+        text = f"{repo_name}. {text}"
+    return text
 
 
 def handle_notification(data: dict[str, object], config: VoxConfig) -> None:
@@ -397,7 +412,9 @@ def handle_notification(data: dict[str, object], config: VoxConfig) -> None:
         return
 
     # Voice mode: synthesize via voxd
-    text = _pick_notification_phrase(notification_type, message)
+    text = _pick_notification_phrase(
+        notification_type, message, repo_name=config.repo_name
+    )
     _speak_via_voxd(text, config)
 
 
@@ -415,13 +432,17 @@ def _speak_phrase(
     """Pick a random phrase and speak or chime it via voxd.
 
     Common pattern for async continuous-mode hooks: check speak mode,
-    play a chime or synthesize speech.
+    play a chime or synthesize speech.  When ``config.repo_name`` is
+    set, prepends it with a period separator so the TTS engine inserts
+    a natural pause between the repo name and the phrase.
     """
     if config.speak == "n":
         _chime_via_voxd(chime_signal)
         return
 
     text = random.choice(phrases)
+    if config.repo_name:
+        text = f"{config.repo_name}. {text}"
     _speak_via_voxd(text, config)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,6 @@ from punt_vox.config import (
     ALLOWED_CONFIG_KEYS,
     DURABLE_KEYS,
     EPHEMERAL_KEYS,
-    VoxConfig,
     read_config,
     read_field,
     write_field,
@@ -105,6 +104,19 @@ class TestReadConfig:
         assert cfg.vibe == "happy"
         assert cfg.vibe_tags == "[joyful]"
 
+    def test_repo_name_derived_from_config_dir(self, tmp_path: Path) -> None:
+        """repo_name is the directory two levels above config_dir."""
+        repo = tmp_path / "my-repo"
+        config_dir = repo / ".punt-labs" / "vox"
+        config_dir.mkdir(parents=True)
+        cfg = read_config(config_dir=config_dir)
+        assert cfg.repo_name == "my-repo"
+
+    def test_repo_name_none_when_config_dir_none(self) -> None:
+        """repo_name is None when no config_dir is provided."""
+        cfg = read_config(config_dir=None)
+        assert cfg.repo_name is None
+
     def test_local_durable_keys_ignored(self, tmp_path: Path) -> None:
         """Durable keys in vox.local.md must not override vox.md."""
         _write_frontmatter(tmp_path / "vox.md", {"notify": "n", "provider": "polly"})
@@ -120,17 +132,15 @@ class TestReadConfig:
     def test_read_config_missing_files(self, tmp_path: Path) -> None:
         """Test 6: neither file exists, safe defaults."""
         cfg = read_config(config_dir=tmp_path)
-        assert cfg == VoxConfig(
-            notify="n",
-            speak="y",
-            vibe_mode="auto",
-            voice=None,
-            provider=None,
-            model=None,
-            vibe=None,
-            vibe_tags=None,
-            vibe_signals=None,
-        )
+        assert cfg.notify == "n"
+        assert cfg.speak == "y"
+        assert cfg.vibe_mode == "auto"
+        assert cfg.voice is None
+        assert cfg.provider is None
+        assert cfg.model is None
+        assert cfg.vibe is None
+        assert cfg.vibe_tags is None
+        assert cfg.vibe_signals is None
 
     def test_read_config_only_durable(self, tmp_path: Path) -> None:
         """Test 7: only vox.md exists, ephemeral fields default."""
@@ -247,17 +257,15 @@ class TestReadConfigLegacy:
 
     def test_defaults_when_files_missing(self, tmp_path: Path) -> None:
         result = read_config(config_dir=tmp_path)
-        assert result == VoxConfig(
-            notify="n",
-            speak="y",
-            vibe_mode="auto",
-            voice=None,
-            provider=None,
-            model=None,
-            vibe=None,
-            vibe_tags=None,
-            vibe_signals=None,
-        )
+        assert result.notify == "n"
+        assert result.speak == "y"
+        assert result.vibe_mode == "auto"
+        assert result.voice is None
+        assert result.provider is None
+        assert result.model is None
+        assert result.vibe is None
+        assert result.vibe_tags is None
+        assert result.vibe_signals is None
 
     def test_reads_all_fields(self, tmp_path: Path) -> None:
         _write_frontmatter(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, call, patch
 
 from punt_vox.config import VoxConfig
 from punt_vox.hooks import (
+    _pick_notification_phrase,  # pyright: ignore[reportPrivateUsage]
     _read_hook_input,  # pyright: ignore[reportPrivateUsage]
     _speak_phrase,  # pyright: ignore[reportPrivateUsage]
     classify_signal,
@@ -42,6 +43,7 @@ def _make_config(
     vibe: str | None = None,
     vibe_signals: str | None = "tests-pass@12:00",
     voice: str | None = None,
+    repo_name: str | None = None,
 ) -> VoxConfig:
     return VoxConfig(
         notify=notify,
@@ -53,6 +55,7 @@ def _make_config(
         vibe=vibe,
         vibe_tags=None,
         vibe_signals=vibe_signals,
+        repo_name=repo_name,
     )
 
 
@@ -697,6 +700,101 @@ class TestQuipPools:
 
     def test_pre_compact_phrases_count(self) -> None:
         assert len(PRE_COMPACT_PHRASES) >= 7
+
+
+# ---------------------------------------------------------------------------
+# repo_name prefix tests
+# ---------------------------------------------------------------------------
+
+
+class TestRepoNamePrefix:
+    """Verify repo_name is prepended to spoken text across all speech paths."""
+
+    @patch("punt_vox.hooks._speak_via_voxd")
+    def test_speak_phrase_prepends_repo_name(self, mock_speak: MagicMock) -> None:
+        """_speak_phrase prepends 'repo. phrase' when repo_name is set."""
+        config = _make_config(notify="c", speak="y", repo_name="vox")
+        _speak_phrase(("On it.",), config, chime_signal="done")
+        text = mock_speak.call_args[0][0]
+        assert text.startswith("vox. ")
+        assert text == "vox. On it."
+
+    @patch("punt_vox.hooks._speak_via_voxd")
+    def test_speak_phrase_no_prefix_when_repo_name_none(
+        self, mock_speak: MagicMock
+    ) -> None:
+        """_speak_phrase omits prefix when repo_name is None."""
+        config = _make_config(notify="c", speak="y", repo_name=None)
+        _speak_phrase(("On it.",), config, chime_signal="done")
+        text = mock_speak.call_args[0][0]
+        assert text == "On it."
+
+    @patch("punt_vox.hooks._chime_via_voxd")
+    def test_speak_phrase_chime_mode_ignores_repo_name(
+        self, mock_chime: MagicMock
+    ) -> None:
+        """Chime mode skips speech entirely — repo_name irrelevant."""
+        config = _make_config(notify="c", speak="n", repo_name="vox")
+        _speak_phrase(("On it.",), config, chime_signal="done")
+        mock_chime.assert_called_once_with("done")
+
+    def test_pick_notification_phrase_prepends_repo_name(self) -> None:
+        """_pick_notification_phrase prepends repo_name to permission phrases."""
+        text = _pick_notification_phrase("permission_prompt", "", repo_name="quarry")
+        assert text.startswith("quarry. ")
+
+    def test_pick_notification_phrase_no_prefix_when_none(self) -> None:
+        """_pick_notification_phrase omits prefix when repo_name is None."""
+        text = _pick_notification_phrase("idle_prompt", "", repo_name=None)
+        assert not text.startswith("None")
+
+    @patch("punt_vox.hooks._speak_via_voxd")
+    def test_handle_notification_passes_repo_name(self, mock_speak: MagicMock) -> None:
+        """handle_notification threads repo_name to the spoken phrase."""
+        config = _make_config(speak="y", repo_name="biff")
+        handle_notification({"notification_type": "permission_prompt"}, config)
+        text = mock_speak.call_args[0][0]
+        assert text.startswith("biff. ")
+
+    @patch("punt_vox.hooks.write_fields")
+    @patch("punt_vox.hooks.find_config_dir")
+    def test_handle_stop_prepends_repo_name_to_reason(
+        self, _mock_path: MagicMock, _mock_write: MagicMock
+    ) -> None:
+        """handle_stop includes repo_name in the block reason string."""
+        config = _make_config(repo_name="vox")
+        result = handle_stop({}, config)
+        assert result is not None
+        reason = str(result["reason"])
+        assert reason.startswith("vox. ")
+
+    @patch("punt_vox.hooks.write_fields")
+    @patch("punt_vox.hooks.find_config_dir")
+    def test_handle_stop_no_prefix_when_repo_name_none(
+        self, _mock_path: MagicMock, _mock_write: MagicMock
+    ) -> None:
+        """handle_stop reason is a plain phrase when repo_name is None."""
+        config = _make_config(repo_name=None)
+        result = handle_stop({}, config)
+        assert result is not None
+        reason = str(result["reason"])
+        assert any(reason == phrase for phrase in STOP_PHRASES)
+
+    @patch("punt_vox.hooks._speak_via_voxd")
+    def test_handle_pre_compact_prepends_repo_name(self, mock_speak: MagicMock) -> None:
+        """handle_pre_compact speaks with repo_name prefix."""
+        config = _make_config(notify="c", speak="y", repo_name="ethos")
+        handle_pre_compact(config)
+        text = mock_speak.call_args[0][0]
+        assert text.startswith("ethos. ")
+
+    @patch("punt_vox.hooks._speak_via_voxd")
+    def test_handle_session_end_prepends_repo_name(self, mock_speak: MagicMock) -> None:
+        """handle_session_end speaks with repo_name prefix."""
+        config = _make_config(notify="y", speak="y", vibe_signals=None, repo_name="lux")
+        handle_session_end(config, Path("/fake/.punt-labs/vox"))
+        text = mock_speak.call_args[0][0]
+        assert text.startswith("lux. ")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **vox-3ol**: Spoken notifications prefix the repo name (e.g. "vox. Needs your approval.") for multi-session disambiguation. `repo_name` derived from `config_dir.parent.parent.name`, threaded through `VoxConfig` to `_speak_phrase` and `_pick_notification_phrase`. 12 new tests.
- **vox-vtk**: `make check` now includes a `docs` target running `npx markdownlint-cli2` matching the CI docs job. `.tmp/` added to markdownlint ignores.
- **CHANGELOG**: entries for both features under [Unreleased]

Closes vox-3ol, vox-vtk.

## Test plan

- [x] 1415 tests pass (`make check` clean, including new markdownlint gate)
- [x] 12 new hook tests cover all speech paths (with/without repo_name, chime mode, stop reason)
- [x] 2 new config tests (repo_name derivation, None when no config_dir)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to hook speech text generation and local developer tooling (`make check`), with added tests covering the new behavior.
> 
> **Overview**
> **Spoken hook quips now include the repo name prefix** (e.g. `repo. Needs your approval.`) across stop, notification, and continuous-mode speech paths by threading a derived `repo_name` through `VoxConfig` and prepending it when generating spoken text.
> 
> **Developer quality gates are tightened** by adding a `docs` target that runs `markdownlint-cli2` and including it in `make check`; `.tmp/` is also added to markdownlint ignore patterns. Changelog and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554ff50ab2d18821146a0fe031477e5ca95eda3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->