### PR TITLE
fix(voxd): raise playback timeout default from 30s to 120s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Long audio cut off at 30 seconds**: `_PLAYBACK_TIMEOUT_DEFAULT_S` in voxd was 30s, used as the fallback when ffprobe can't determine audio duration. Long `/recap` summaries producing >30s of audio were killed mid-sentence. Raised to 120s. Music playback is unaffected (separate playback path with no timeout).
+
 ## [4.8.0] - 2026-05-12
 
 ### Added

--- a/src/punt_vox/voxd.py
+++ b/src/punt_vox/voxd.py
@@ -410,7 +410,7 @@ _AUDIO_ENV_KEYS: tuple[str, ...] = (
 # Playback under 50ms is a "success" that almost certainly played nothing.
 _SUSPICIOUS_ELAPSED_S = 0.05
 
-_PLAYBACK_TIMEOUT_DEFAULT_S = 30.0
+_PLAYBACK_TIMEOUT_DEFAULT_S = 120.0
 _PLAYBACK_TIMEOUT_PADDING_S = 10.0
 _PROBE_TIMEOUT_S = 5.0
 

--- a/tests/test_voxd.py
+++ b/tests/test_voxd.py
@@ -231,7 +231,7 @@ class TestPlayAudioProportionalTimeout:
     """``_play_audio`` uses probed duration for its timeout."""
 
     def test_uses_probed_duration_for_timeout(self, tmp_path: Path) -> None:
-        """A 34s file gets timeout = max(34+10, 30) = 44s, not 30s."""
+        """A 150s file gets timeout = max(150+10, 120) = 160s."""
         audio = tmp_path / "out.mp3"
         audio.write_bytes(b"\xff\xfbfake mp3 body")
         ctx = _make_ctx()
@@ -246,7 +246,7 @@ class TestPlayAudioProportionalTimeout:
             return await original_wait_for(coro, timeout=timeout)  # type: ignore[arg-type]
 
         with (
-            patch("punt_vox.voxd._probe_duration", AsyncMock(return_value=34.3)),
+            patch("punt_vox.voxd._probe_duration", AsyncMock(return_value=150.0)),
             patch(
                 "punt_vox.voxd.asyncio.create_subprocess_exec",
                 AsyncMock(return_value=proc),
@@ -257,7 +257,7 @@ class TestPlayAudioProportionalTimeout:
             asyncio.run(_play_audio(audio, ctx))
 
         assert len(captured_timeout) == 1
-        assert captured_timeout[0] == pytest.approx(44.3, abs=0.1)  # pyright: ignore[reportUnknownMemberType]
+        assert captured_timeout[0] == pytest.approx(160.0, abs=0.1)  # pyright: ignore[reportUnknownMemberType]
 
     def test_falls_back_to_default_when_probe_fails(self, tmp_path: Path) -> None:
         audio = tmp_path / "out.mp3"
@@ -288,7 +288,7 @@ class TestPlayAudioProportionalTimeout:
         assert captured_timeout[0] == _PLAYBACK_TIMEOUT_DEFAULT_S
 
     def test_short_duration_uses_default_minimum(self, tmp_path: Path) -> None:
-        """A 5s file gets timeout = max(5+10, 30) = 30s (default wins)."""
+        """A 5s file gets timeout = max(5+10, 120) = 120s (default wins)."""
         audio = tmp_path / "out.mp3"
         audio.write_bytes(b"\xff\xfbfake mp3 body")
         ctx = _make_ctx()


### PR DESCRIPTION
## Summary

- Raise `_PLAYBACK_TIMEOUT_DEFAULT_S` from 30s to 120s in voxd
- This is the fallback when ffprobe can't determine audio duration
- Long `/recap` summaries (>30s of audio) were killed mid-sentence
- Music playback unaffected (separate subprocess path, no timeout)

## Test plan

- [x] 1415 tests pass (`make check` clean)
- [x] Timeout tests updated for new 120s default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk constant change: only extends the default timeout used when `ffprobe` can’t determine duration, with corresponding test/changelog updates; main impact is potentially longer waits before a stuck playback is killed.
> 
> **Overview**
> Prevents long speech playback from being killed early by raising `voxd`’s fallback `_PLAYBACK_TIMEOUT_DEFAULT_S` from **30s → 120s** when audio duration probing fails.
> 
> Updates the proportional-timeout unit tests to reflect the new minimum timeout behavior, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a5e93c3c3a6e0f334144dbd589ce382e89f974c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->