### PR TITLE
chore: release v4.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.8.1",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.1] - 2026-05-12
+
 ### Fixed
 
 - **Long audio cut off at 30 seconds**: `_PLAYBACK_TIMEOUT_DEFAULT_S` in voxd was 30s, used as the fallback when ffprobe can't determine audio duration. Long `/recap` summaries producing >30s of audio were killed mid-sentence. Raised to 120s. Music playback is unaffected (separate playback path with no timeout).

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.8.0"
+VERSION="4.8.1"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.8.0"
+version = "4.8.1"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.8.0"
+__version__ = "4.8.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,7 +1081,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.8.0"
+version = "4.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: mainly version bumps and plugin metadata updates, with no functional code changes included in this diff.
> 
> **Overview**
> Bumps the project to **v4.8.1** across packaging/install surfaces (`pyproject.toml`, `uv.lock`, `install.sh`, `src/punt_vox/__init__.py`) and updates the Claude plugin manifest (renames plugin from `vox-dev` to `vox`, version to `4.8.1`).
> 
> Updates `CHANGELOG.md` with the v4.8.1 release note documenting a fix for long audio being cut off due to the voxd playback timeout fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d55f9aac07ff33c409c67b39c8db05edf988ed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->