### PR TITLE
fix(server): refresh SessionState from config on every MCP tool call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP server state went stale after CLI config writes**: the MCP server seeded `SessionState` from config at startup but never re-read. CLI commands like `vox vibe auto` wrote to `vox.local.md` but the MCP server retained the old values, causing `/music on` to report stale mood. All MCP tools now call `_refresh_state_from_config()` to re-read config before acting. Closes vox-duw.
+
 ## [4.8.1] - 2026-05-12
 
 ### Fixed

--- a/docs/config-split-design.md
+++ b/docs/config-split-design.md
@@ -2,7 +2,7 @@
 
 ## 1. File Layout
 
-```
+```text
 .punt-labs/vox/
   vox.md          # tracked in git — durable user preferences
   vox.local.md    # gitignored — ephemeral session state
@@ -12,7 +12,6 @@
 Both files use the same YAML frontmatter format (`---` fences, `key: "value"` pairs) as the current `config.md`. No format change.
 
 The legacy `.vox/` directory and `.vox/config.md` are removed entirely. The tracked `.vox/config.md` is deleted from git. `find_config()` drops the legacy path check.
-
 
 ## 2. Field-to-File Routing
 
@@ -43,7 +42,6 @@ ALLOWED_CONFIG_KEYS: frozenset[str] = DURABLE_KEYS | EPHEMERAL_KEYS
 ```
 
 `write_field` and `write_fields` use field membership in `DURABLE_KEYS` vs `EPHEMERAL_KEYS` to pick the target file. No caller needs to know which file a field lives in.
-
 
 ## 3. Read Semantics
 
@@ -78,7 +76,6 @@ def read_field(field: str, config_dir: Path | None = None) -> str | None:
     return _read_single_field(d / "vox.md", field)
 ```
 
-
 ## 4. Write Semantics
 
 `write_field()` and `write_fields()` route each key to the correct file. When `write_fields` receives a mix of durable and ephemeral keys, it batches writes per file (one read-write cycle per file, not per key).
@@ -103,7 +100,6 @@ def write_fields(updates: dict[str, str], config_dir: Path | None = None) -> Non
     if ephemeral_updates:
         _write_batch(d / "vox.local.md", ephemeral_updates)
 ```
-
 
 ## 5. Path Changes
 
@@ -138,7 +134,6 @@ def find_config_dir(start: Path | None = None) -> Path | None:
 
 Drop `_LEGACY_REPO_DIR` and all `.vox/` references.
 
-
 ## 6. Caller-by-Caller Changes
 
 ### 6.1 config.py
@@ -155,6 +150,7 @@ Drop `_LEGACY_REPO_DIR` and all `.vox/` references.
 This is a clean break — all callers are updated in the same PR.
 
 **Internal implementation:**
+
 - Extract `_parse_frontmatter(path) -> dict[str, str]` from the current `read_config` body.
 - Extract `_write_single(path, key, value)` and `_write_batch(path, updates)` from the current `write_field`/`write_fields` bodies.
 - Add `DURABLE_KEYS`, `EPHEMERAL_KEYS` constants.
@@ -171,6 +167,7 @@ This is a clean break — all callers are updated in the same PR.
 ### 6.3 hooks.py
 
 **Imports (line 34-39):**
+
 ```python
 # Before
 from punt_vox.config import VoxConfig, read_config, write_field, write_fields
@@ -182,6 +179,7 @@ from punt_vox.dirs import DEFAULT_CONFIG_DIR, find_config_dir
 ```
 
 **handle_stop (line 268-269):**
+
 ```python
 # Before
 config_path = find_config() or DEFAULT_CONFIG_PATH
@@ -191,9 +189,11 @@ write_fields({"vibe_tags": tags, "vibe_signals": ""}, config_path)
 config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
 write_fields({"vibe_tags": tags, "vibe_signals": ""}, config_dir)
 ```
+
 Both `vibe_tags` and `vibe_signals` are ephemeral keys — `write_fields` routes them to `vox.local.md` automatically.
 
 **handle_post_bash (line 314, 348, 355):**
+
 ```python
 # Before
 def handle_post_bash(data: dict[str, object], config_path: Path) -> None:
@@ -209,9 +209,11 @@ def handle_post_bash(data: dict[str, object], config_dir: Path) -> None:
     ...
     write_field("vibe_signals", new_signals, config_dir)
 ```
+
 `vibe_signals` is ephemeral — `write_field` routes to `vox.local.md`.
 
 **handle_session_end (line 511, 527):**
+
 ```python
 # Before
 def handle_session_end(config: VoxConfig, config_path: Path) -> None:
@@ -245,6 +247,7 @@ Note: The current `if not config_path.exists(): return` guard is vestigial — `
 ### 6.4 server.py
 
 **_find_config (line 76-80):**
+
 ```python
 # Before
 def _find_config() -> Path | None:
@@ -258,6 +261,7 @@ def _find_config_dir() -> Path | None:
 ```
 
 **_seed_state_from_config (line 83-101):**
+
 ```python
 # Before
 def _seed_state_from_config(config_path: Path | None) -> SessionState:
@@ -275,9 +279,11 @@ def _seed_state_from_config(config_dir: Path | None) -> SessionState:
     cfg = read_config(config_dir=config_dir)
     ...
 ```
+
 No file existence check needed — `read_config` handles missing files.
 
 **vibe tool (line 472-474):**
+
 ```python
 # Before
 from punt_vox.config import write_fields
@@ -287,9 +293,11 @@ write_fields(updates, _find_config())
 from punt_vox.config import write_fields
 write_fields(updates, _find_config_dir())
 ```
+
 `vibe` tool writes a mix: `vibe_mode` goes to `vox.md`, `vibe`/`vibe_tags`/`vibe_signals` go to `vox.local.md`. `write_fields` handles the routing automatically.
 
 **notify tool (line 749-751):**
+
 ```python
 # Before
 from punt_vox.config import write_fields
@@ -299,9 +307,11 @@ write_fields(updates, _find_config())
 from punt_vox.config import write_fields
 write_fields(updates, _find_config_dir())
 ```
+
 `notify` writes `notify` (durable), `speak` (durable), `voice` (durable) — all route to `vox.md`.
 
 **speak tool (line 793-795):**
+
 ```python
 # Before
 from punt_vox.config import write_fields
@@ -311,9 +321,11 @@ write_fields(updates, _find_config())
 from punt_vox.config import write_fields
 write_fields(updates, _find_config_dir())
 ```
+
 `speak` writes `speak` (durable), `voice` (durable) — all route to `vox.md`.
 
 **run_server (line 873-880):**
+
 ```python
 # Before
 config_path = _find_config()
@@ -332,9 +344,10 @@ if config_dir is not None:
         _speak_explicit = True
 ```
 
-### 6.5 __main__.py
+### 6.5 **main**.py
 
 **Imports (line 27-31):**
+
 ```python
 # Before
 from punt_vox.config import read_config, write_field, write_fields
@@ -346,6 +359,7 @@ from punt_vox.dirs import DEFAULT_CONFIG_DIR, default_output_dir, find_config_di
 ```
 
 **vibe_cmd (lines 636-647):**
+
 ```python
 # Before
 cp = find_config() or DEFAULT_CONFIG_PATH
@@ -357,9 +371,11 @@ cd = find_config_dir() or DEFAULT_CONFIG_DIR
 if mood == "auto":
     write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "auto"}, config_dir=cd)
 ```
+
 This writes a mix: `vibe_mode` (durable) goes to `vox.md`; `vibe_tags`, `vibe` (ephemeral) go to `vox.local.md`. `write_fields` routes automatically.
 
 **notify_cmd (lines 671-678):**
+
 ```python
 # Before
 config_path = find_config() or DEFAULT_CONFIG_PATH
@@ -379,9 +395,11 @@ if mode == "c" or (first_init and mode == "y"):
 ...
 write_fields(updates, config_dir=config_dir)
 ```
+
 The `first_init` check changes from file-existence to field-existence: if `notify` has never been written to `vox.md`, this is a first-time setup. The tracked `vox.md` ships with `notify: "n"`, so `first_init` is False for cloned repos — correct, since the default already has `speak: "y"`. All keys (`notify`, `speak`, `voice`) are durable — route to `vox.md`.
 
 **speak_cmd (line 705):**
+
 ```python
 # Before
 write_field("speak", mode, config_path=find_config() or DEFAULT_CONFIG_PATH)
@@ -389,9 +407,11 @@ write_field("speak", mode, config_path=find_config() or DEFAULT_CONFIG_PATH)
 # After
 write_field("speak", mode, config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
 ```
+
 `speak` is durable — routes to `vox.md`.
 
 **voice_cmd (line 720):**
+
 ```python
 # Before
 write_field("voice", name, config_path=find_config() or DEFAULT_CONFIG_PATH)
@@ -399,9 +419,11 @@ write_field("voice", name, config_path=find_config() or DEFAULT_CONFIG_PATH)
 # After
 write_field("voice", name, config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
 ```
+
 `voice` is durable — routes to `vox.md`.
 
 **status_cmd (line 743):**
+
 ```python
 # Before
 cfg = read_config(config_path=find_config() or DEFAULT_CONFIG_PATH)
@@ -416,6 +438,7 @@ Remove the legacy `.vox/` directory check entirely. No migration, clean break.
 ### 6.6 resolve.py
 
 **resolve_voice_and_language (line 85):**
+
 ```python
 # Before
 voice = _config.read_field("voice", config_path or _config.DEFAULT_CONFIG_PATH)
@@ -427,6 +450,7 @@ voice = _config.read_field("voice", config_dir or _config.DEFAULT_CONFIG_DIR)
 The function signature changes from `config_path: Path | None` to `config_dir: Path | None`.
 
 **apply_vibe (lines 139-140):**
+
 ```python
 # Before
 tags = override_tags or _config.read_field(
@@ -441,10 +465,10 @@ tags = override_tags or _config.read_field(
 
 The function signature changes from `config_path: Path | None` to `config_dir: Path | None`.
 
-
 ## 6.7 watcher.py
 
 **make_notification_consumer (line 172-183):**
+
 ```python
 # Before
 def make_notification_consumer(
@@ -465,9 +489,10 @@ def make_notification_consumer(
 
 Import update (line 23): `from punt_vox.config import read_config` — unchanged (no path import needed).
 
-### 6.8 providers/__init__.py
+### 6.8 providers/**init**.py
 
 **get_provider (line 145-179):**
+
 ```python
 # Before
 def get_provider(
@@ -489,7 +514,6 @@ def get_provider(
 ```
 
 Called from `voxd.py` (lines 1177, 1336, 1673) with `config_path=None` — rename the kwarg to `config_dir=None`. Also called from `watcher.py` line 210 with no argument (uses default) — no change needed.
-
 
 ## 7. .gitignore Changes
 
@@ -513,7 +537,6 @@ git rm --cached .vox/config.md
 # Then remove .vox/ directory if empty
 ```
 
-
 ## 8. Initial Tracked vox.md Content
 
 The file ships with sensible defaults — a user who clones the repo gets working vox without creating any config:
@@ -528,7 +551,6 @@ vibe_mode: "auto"
 
 No `voice`, `provider`, or `model` — those default to auto-detection at runtime. The YAML frontmatter format is preserved for consistency with the existing reader.
 
-
 ## 9. MCP Server Instructions Update
 
 The MCP server instructions (line 37 of server.py) reference `.punt-labs/vox/config.md`. Update to:
@@ -538,7 +560,6 @@ The MCP server instructions (line 37 of server.py) reference `.punt-labs/vox/con
 ".punt-labs/vox/vox.md or .punt-labs/vox/vox.local.md. "
 "All config state is available through MCP tools or hook context."
 ```
-
 
 ## 10. Test Strategy
 
@@ -561,26 +582,25 @@ Test the core routing logic in isolation. No I/O mocking needed — use `tmp_pat
 
 ### Unit tests: dirs.py
 
-13. **`test_find_config_dir_walks_up`** — create `.punt-labs/vox/vox.md` in a parent, call `find_config_dir` from a child, verify directory found.
-14. **`test_find_config_dir_finds_ephemeral_only`** — directory with only `vox.local.md`, verify found.
-15. **`test_find_config_dir_no_legacy`** — create `.vox/config.md`, verify `find_config_dir` does NOT find it.
+1. **`test_find_config_dir_walks_up`** — create `.punt-labs/vox/vox.md` in a parent, call `find_config_dir` from a child, verify directory found.
+2. **`test_find_config_dir_finds_ephemeral_only`** — directory with only `vox.local.md`, verify found.
+3. **`test_find_config_dir_no_legacy`** — create `.vox/config.md`, verify `find_config_dir` does NOT find it.
 
 ### Integration tests: hooks.py
 
-16. **`test_post_bash_writes_to_vox_local_md`** — `handle_post_bash` writes `vibe_signals` to `vox.local.md`, not `vox.md`.
-17. **`test_stop_hook_writes_tags_to_vox_local_md`** — `handle_stop` writes `vibe_tags` and clears `vibe_signals` in `vox.local.md`.
-18. **`test_session_end_clears_signals_in_vox_local_md`** — `handle_session_end` clears `vibe_signals` in `vox.local.md`.
+1. **`test_post_bash_writes_to_vox_local_md`** — `handle_post_bash` writes `vibe_signals` to `vox.local.md`, not `vox.md`.
+2. **`test_stop_hook_writes_tags_to_vox_local_md`** — `handle_stop` writes `vibe_tags` and clears `vibe_signals` in `vox.local.md`.
+3. **`test_session_end_clears_signals_in_vox_local_md`** — `handle_session_end` clears `vibe_signals` in `vox.local.md`.
 
-### Integration tests: CLI (__main__.py)
+### Integration tests: CLI (**main**.py)
 
-19. **`test_vibe_cmd_writes_mixed`** — `vox vibe auto` writes `vibe_mode` to `vox.md` and clears `vibe`/`vibe_tags` in `vox.local.md`.
-20. **`test_notify_cmd_writes_durable`** — `vox notify y` writes to `vox.md` only.
-21. **`test_voice_cmd_writes_durable`** — `vox voice fin` writes to `vox.md` only.
+1. **`test_vibe_cmd_writes_mixed`** — `vox vibe auto` writes `vibe_mode` to `vox.md` and clears `vibe`/`vibe_tags` in `vox.local.md`.
+2. **`test_notify_cmd_writes_durable`** — `vox notify y` writes to `vox.md` only.
+3. **`test_voice_cmd_writes_durable`** — `vox voice fin` writes to `vox.md` only.
 
 ### Existing test updates
 
 All existing tests that pass `config_path=` to config functions switch to `config_dir=`. Most tests already use `tmp_path` — they need to create `tmp_path / "vox.md"` and/or `tmp_path / "vox.local.md"` instead of `tmp_path / "config.md"`.
-
 
 ## 11. Migration
 
@@ -592,7 +612,6 @@ No migration. Per the contract: no users yet, clean break.
 - All existing local `.punt-labs/vox/config.md` files (created by hooks at runtime) are already gitignored and will be orphaned — they are harmless. The new code does not read `config.md` from the new path.
 
 The doctor command's legacy `.vox/` check is removed entirely.
-
 
 ## 12. Implementation Scope
 

--- a/docs/config-split-design.md
+++ b/docs/config-split-design.md
@@ -1,0 +1,619 @@
+# Config Split Design: vox.md + vox.local.md
+
+## 1. File Layout
+
+```
+.punt-labs/vox/
+  vox.md          # tracked in git — durable user preferences
+  vox.local.md    # gitignored — ephemeral session state
+  ephemeral/      # gitignored — ephemeral audio (unchanged)
+```
+
+Both files use the same YAML frontmatter format (`---` fences, `key: "value"` pairs) as the current `config.md`. No format change.
+
+The legacy `.vox/` directory and `.vox/config.md` are removed entirely. The tracked `.vox/config.md` is deleted from git. `find_config()` drops the legacy path check.
+
+
+## 2. Field-to-File Routing
+
+| Field | File | Rationale |
+|-------|------|-----------|
+| `voice` | `vox.md` | User's preferred voice — persists across sessions |
+| `provider` | `vox.md` | User's preferred TTS provider |
+| `model` | `vox.md` | User's preferred TTS model |
+| `notify` | `vox.md` | Notification mode default |
+| `speak` | `vox.md` | Spoken notifications default |
+| `vibe_mode` | `vox.md` | Vibe detection mode default |
+| `vibe` | `vox.local.md` | Current mood string — session-scoped |
+| `vibe_tags` | `vox.local.md` | Resolved expressive tags — session-scoped |
+| `vibe_signals` | `vox.local.md` | Accumulated signal tokens — hottest field, cleared every session |
+
+**Routing constant:**
+
+```python
+DURABLE_KEYS: frozenset[str] = frozenset({
+    "model", "notify", "provider", "speak", "vibe_mode", "voice",
+})
+
+EPHEMERAL_KEYS: frozenset[str] = frozenset({
+    "vibe", "vibe_tags", "vibe_signals",
+})
+
+ALLOWED_CONFIG_KEYS: frozenset[str] = DURABLE_KEYS | EPHEMERAL_KEYS
+```
+
+`write_field` and `write_fields` use field membership in `DURABLE_KEYS` vs `EPHEMERAL_KEYS` to pick the target file. No caller needs to know which file a field lives in.
+
+
+## 3. Read Semantics
+
+`read_config()` merges both files. Ephemeral wins on conflict (though conflicts should not arise given disjoint key sets — the merge order is defensive).
+
+```python
+def read_config(config_dir: Path | None = None) -> VoxConfig:
+    """Read all config fields, merging vox.md and vox.local.md."""
+    d = config_dir or DEFAULT_CONFIG_DIR
+    fields: dict[str, str] = {}
+
+    # Base layer: durable prefs
+    durable = d / "vox.md"
+    if durable.exists():
+        fields.update(_parse_frontmatter(durable))
+
+    # Overlay: ephemeral session state (wins on conflict)
+    ephemeral = d / "vox.local.md"
+    if ephemeral.exists():
+        fields.update(_parse_frontmatter(ephemeral))
+
+    return _fields_to_config(fields)
+```
+
+`read_field()` checks the correct file based on `EPHEMERAL_KEYS` membership. Ephemeral keys read from `vox.local.md`; everything else (durable and unknown) reads from `vox.md`.
+
+```python
+def read_field(field: str, config_dir: Path | None = None) -> str | None:
+    d = config_dir or DEFAULT_CONFIG_DIR
+    if field in EPHEMERAL_KEYS:
+        return _read_single_field(d / "vox.local.md", field)
+    return _read_single_field(d / "vox.md", field)
+```
+
+
+## 4. Write Semantics
+
+`write_field()` and `write_fields()` route each key to the correct file. When `write_fields` receives a mix of durable and ephemeral keys, it batches writes per file (one read-write cycle per file, not per key).
+
+```python
+def write_field(key: str, value: str, config_dir: Path | None = None) -> None:
+    d = config_dir or DEFAULT_CONFIG_DIR
+    target = d / ("vox.md" if key in DURABLE_KEYS else "vox.local.md")
+    _write_single(target, key, value)
+
+def write_fields(updates: dict[str, str], config_dir: Path | None = None) -> None:
+    for key in updates:
+        if key not in ALLOWED_CONFIG_KEYS:
+            allowed = ", ".join(sorted(ALLOWED_CONFIG_KEYS))
+            msg = f"Unknown config key '{key}'. Allowed: {allowed}"
+            raise ValueError(msg)
+    d = config_dir or DEFAULT_CONFIG_DIR
+    durable_updates = {k: v for k, v in updates.items() if k in DURABLE_KEYS}
+    ephemeral_updates = {k: v for k, v in updates.items() if k in EPHEMERAL_KEYS}
+    if durable_updates:
+        _write_batch(d / "vox.md", durable_updates)
+    if ephemeral_updates:
+        _write_batch(d / "vox.local.md", ephemeral_updates)
+```
+
+
+## 5. Path Changes
+
+### dirs.py
+
+Replace the single-file default path with a directory path:
+
+```python
+# Before
+DEFAULT_CONFIG_PATH = _REPO_SUBDIR / "config.md"
+
+# After
+DEFAULT_CONFIG_DIR = _REPO_SUBDIR   # Path(".punt-labs/vox")
+```
+
+`find_config()` changes from finding a single file to finding a directory that contains `vox.md` or `vox.local.md`:
+
+```python
+def find_config_dir(start: Path | None = None) -> Path | None:
+    """Walk up from start (default: cwd) to find .punt-labs/vox/ dir.
+
+    Returns the directory if either vox.md or vox.local.md exists inside it.
+    No legacy fallback — .vox/ is removed.
+    """
+    path = (start or Path.cwd()).resolve()
+    for parent in (path, *path.parents):
+        d = parent / _REPO_SUBDIR
+        if (d / "vox.md").exists() or (d / "vox.local.md").exists():
+            return d
+    return None
+```
+
+Drop `_LEGACY_REPO_DIR` and all `.vox/` references.
+
+
+## 6. Caller-by-Caller Changes
+
+### 6.1 config.py
+
+**Signature changes — every function switches from `config_path: Path` to `config_dir: Path`:**
+
+| Function | Current signature | New signature |
+|----------|-------------------|---------------|
+| `read_field` | `(field, config_path=None)` | `(field, config_dir=None)` |
+| `read_config` | `(config_path=None)` | `(config_dir=None)` |
+| `write_field` | `(key, value, config_path=None)` | `(key, value, config_dir=None)` |
+| `write_fields` | `(updates, config_path=None)` | `(updates, config_dir=None)` |
+
+This is a clean break — all callers are updated in the same PR.
+
+**Internal implementation:**
+- Extract `_parse_frontmatter(path) -> dict[str, str]` from the current `read_config` body.
+- Extract `_write_single(path, key, value)` and `_write_batch(path, updates)` from the current `write_field`/`write_fields` bodies.
+- Add `DURABLE_KEYS`, `EPHEMERAL_KEYS` constants.
+- Remove `DEFAULT_CONFIG_PATH` re-export (replaced by `DEFAULT_CONFIG_DIR`).
+- Remove `find_config` re-export (replaced by `find_config_dir`).
+
+### 6.2 dirs.py
+
+- Remove `_LEGACY_REPO_DIR = Path(".vox")`.
+- Rename `DEFAULT_CONFIG_PATH` to `DEFAULT_CONFIG_DIR = _REPO_SUBDIR`.
+- Rename `find_config()` to `find_config_dir()`, drop legacy `.vox/` fallback.
+- `ephemeral_dir()` is unchanged (already uses `_REPO_SUBDIR`).
+
+### 6.3 hooks.py
+
+**Imports (line 34-39):**
+```python
+# Before
+from punt_vox.config import VoxConfig, read_config, write_field, write_fields
+from punt_vox.dirs import DEFAULT_CONFIG_PATH, find_config
+
+# After
+from punt_vox.config import VoxConfig, read_config, write_field, write_fields
+from punt_vox.dirs import DEFAULT_CONFIG_DIR, find_config_dir
+```
+
+**handle_stop (line 268-269):**
+```python
+# Before
+config_path = find_config() or DEFAULT_CONFIG_PATH
+write_fields({"vibe_tags": tags, "vibe_signals": ""}, config_path)
+
+# After
+config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+write_fields({"vibe_tags": tags, "vibe_signals": ""}, config_dir)
+```
+Both `vibe_tags` and `vibe_signals` are ephemeral keys — `write_fields` routes them to `vox.local.md` automatically.
+
+**handle_post_bash (line 314, 348, 355):**
+```python
+# Before
+def handle_post_bash(data: dict[str, object], config_path: Path) -> None:
+    ...
+    current = read_config(config_path).vibe_signals or ""
+    ...
+    write_field("vibe_signals", new_signals, config_path)
+
+# After
+def handle_post_bash(data: dict[str, object], config_dir: Path) -> None:
+    ...
+    current = read_config(config_dir).vibe_signals or ""
+    ...
+    write_field("vibe_signals", new_signals, config_dir)
+```
+`vibe_signals` is ephemeral — `write_field` routes to `vox.local.md`.
+
+**handle_session_end (line 511, 527):**
+```python
+# Before
+def handle_session_end(config: VoxConfig, config_path: Path) -> None:
+    ...
+    write_field("vibe_signals", "", config_path)
+
+# After
+def handle_session_end(config: VoxConfig, config_dir: Path) -> None:
+    ...
+    write_field("vibe_signals", "", config_dir)
+```
+
+**All CLI hook commands (stop_cmd, post_bash_cmd, notification_cmd, etc.):**
+Pattern is identical across all — change `find_config()` to `find_config_dir()` and `DEFAULT_CONFIG_PATH` to `DEFAULT_CONFIG_DIR`:
+
+```python
+# Before (repeated ~8 times across lines 538-624)
+config_path = find_config() or DEFAULT_CONFIG_PATH
+if not config_path.exists():
+    return
+config = read_config(config_path)
+
+# After
+config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+# No existence check needed — read_config handles missing files gracefully
+config = read_config(config_dir)
+```
+
+Note: The current `if not config_path.exists(): return` guard is vestigial — `read_config` already returns safe defaults when the file is missing. With the split, this becomes even more natural since `read_config(config_dir)` handles zero, one, or both files missing. Remove the guard.
+
+### 6.4 server.py
+
+**_find_config (line 76-80):**
+```python
+# Before
+def _find_config() -> Path | None:
+    from punt_vox.dirs import find_config
+    return find_config()
+
+# After
+def _find_config_dir() -> Path | None:
+    from punt_vox.dirs import find_config_dir
+    return find_config_dir()
+```
+
+**_seed_state_from_config (line 83-101):**
+```python
+# Before
+def _seed_state_from_config(config_path: Path | None) -> SessionState:
+    if config_path is None or not config_path.exists():
+        return SessionState()
+    from punt_vox.config import read_config
+    cfg = read_config(config_path=config_path)
+    ...
+
+# After
+def _seed_state_from_config(config_dir: Path | None) -> SessionState:
+    if config_dir is None:
+        return SessionState()
+    from punt_vox.config import read_config
+    cfg = read_config(config_dir=config_dir)
+    ...
+```
+No file existence check needed — `read_config` handles missing files.
+
+**vibe tool (line 472-474):**
+```python
+# Before
+from punt_vox.config import write_fields
+write_fields(updates, _find_config())
+
+# After
+from punt_vox.config import write_fields
+write_fields(updates, _find_config_dir())
+```
+`vibe` tool writes a mix: `vibe_mode` goes to `vox.md`, `vibe`/`vibe_tags`/`vibe_signals` go to `vox.local.md`. `write_fields` handles the routing automatically.
+
+**notify tool (line 749-751):**
+```python
+# Before
+from punt_vox.config import write_fields
+write_fields(updates, _find_config())
+
+# After
+from punt_vox.config import write_fields
+write_fields(updates, _find_config_dir())
+```
+`notify` writes `notify` (durable), `speak` (durable), `voice` (durable) — all route to `vox.md`.
+
+**speak tool (line 793-795):**
+```python
+# Before
+from punt_vox.config import write_fields
+write_fields(updates, _find_config())
+
+# After
+from punt_vox.config import write_fields
+write_fields(updates, _find_config_dir())
+```
+`speak` writes `speak` (durable), `voice` (durable) — all route to `vox.md`.
+
+**run_server (line 873-880):**
+```python
+# Before
+config_path = _find_config()
+_state = _seed_state_from_config(config_path)
+if config_path is not None and config_path.exists():
+    from punt_vox.config import read_field
+    if read_field("speak", config_path) is not None:
+        _speak_explicit = True
+
+# After
+config_dir = _find_config_dir()
+_state = _seed_state_from_config(config_dir)
+if config_dir is not None:
+    from punt_vox.config import read_field
+    if read_field("speak", config_dir) is not None:
+        _speak_explicit = True
+```
+
+### 6.5 __main__.py
+
+**Imports (line 27-31):**
+```python
+# Before
+from punt_vox.config import read_config, write_field, write_fields
+from punt_vox.dirs import DEFAULT_CONFIG_PATH, default_output_dir, find_config
+
+# After
+from punt_vox.config import read_config, write_field, write_fields
+from punt_vox.dirs import DEFAULT_CONFIG_DIR, default_output_dir, find_config_dir
+```
+
+**vibe_cmd (lines 636-647):**
+```python
+# Before
+cp = find_config() or DEFAULT_CONFIG_PATH
+if mood == "auto":
+    write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "auto"}, config_path=cp)
+
+# After
+cd = find_config_dir() or DEFAULT_CONFIG_DIR
+if mood == "auto":
+    write_fields({"vibe_tags": "", "vibe": "", "vibe_mode": "auto"}, config_dir=cd)
+```
+This writes a mix: `vibe_mode` (durable) goes to `vox.md`; `vibe_tags`, `vibe` (ephemeral) go to `vox.local.md`. `write_fields` routes automatically.
+
+**notify_cmd (lines 671-678):**
+```python
+# Before
+config_path = find_config() or DEFAULT_CONFIG_PATH
+first_init = not config_path.exists()
+updates: dict[str, str] = {"notify": mode}
+if mode == "c" or (first_init and mode == "y"):
+    updates["speak"] = "y"
+...
+write_fields(updates, config_path=config_path)
+
+# After
+config_dir = find_config_dir() or DEFAULT_CONFIG_DIR
+first_init = read_field("notify", config_dir) is None
+updates: dict[str, str] = {"notify": mode}
+if mode == "c" or (first_init and mode == "y"):
+    updates["speak"] = "y"
+...
+write_fields(updates, config_dir=config_dir)
+```
+The `first_init` check changes from file-existence to field-existence: if `notify` has never been written to `vox.md`, this is a first-time setup. The tracked `vox.md` ships with `notify: "n"`, so `first_init` is False for cloned repos — correct, since the default already has `speak: "y"`. All keys (`notify`, `speak`, `voice`) are durable — route to `vox.md`.
+
+**speak_cmd (line 705):**
+```python
+# Before
+write_field("speak", mode, config_path=find_config() or DEFAULT_CONFIG_PATH)
+
+# After
+write_field("speak", mode, config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
+```
+`speak` is durable — routes to `vox.md`.
+
+**voice_cmd (line 720):**
+```python
+# Before
+write_field("voice", name, config_path=find_config() or DEFAULT_CONFIG_PATH)
+
+# After
+write_field("voice", name, config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
+```
+`voice` is durable — routes to `vox.md`.
+
+**status_cmd (line 743):**
+```python
+# Before
+cfg = read_config(config_path=find_config() or DEFAULT_CONFIG_PATH)
+
+# After
+cfg = read_config(config_dir=find_config_dir() or DEFAULT_CONFIG_DIR)
+```
+
+**doctor (line 1038-1051):**
+Remove the legacy `.vox/` directory check entirely. No migration, clean break.
+
+### 6.6 resolve.py
+
+**resolve_voice_and_language (line 85):**
+```python
+# Before
+voice = _config.read_field("voice", config_path or _config.DEFAULT_CONFIG_PATH)
+
+# After
+voice = _config.read_field("voice", config_dir or _config.DEFAULT_CONFIG_DIR)
+```
+
+The function signature changes from `config_path: Path | None` to `config_dir: Path | None`.
+
+**apply_vibe (lines 139-140):**
+```python
+# Before
+tags = override_tags or _config.read_field(
+    "vibe_tags", config_path or _config.DEFAULT_CONFIG_PATH
+)
+
+# After
+tags = override_tags or _config.read_field(
+    "vibe_tags", config_dir or _config.DEFAULT_CONFIG_DIR
+)
+```
+
+The function signature changes from `config_path: Path | None` to `config_dir: Path | None`.
+
+
+## 6.7 watcher.py
+
+**make_notification_consumer (line 172-183):**
+```python
+# Before
+def make_notification_consumer(
+    config_path: Path | None = None,
+    ...
+) -> SessionEventConsumer:
+    ...
+    config = read_config(config_path)
+
+# After
+def make_notification_consumer(
+    config_dir: Path | None = None,
+    ...
+) -> SessionEventConsumer:
+    ...
+    config = read_config(config_dir)
+```
+
+Import update (line 23): `from punt_vox.config import read_config` — unchanged (no path import needed).
+
+### 6.8 providers/__init__.py
+
+**get_provider (line 145-179):**
+```python
+# Before
+def get_provider(
+    name: str | None = None,
+    config_path: Path | None = None,
+    **kwargs: str | None,
+) -> TTSProvider:
+    ...
+    config = read_config(config_path=config_path)
+
+# After
+def get_provider(
+    name: str | None = None,
+    config_dir: Path | None = None,
+    **kwargs: str | None,
+) -> TTSProvider:
+    ...
+    config = read_config(config_dir=config_dir)
+```
+
+Called from `voxd.py` (lines 1177, 1336, 1673) with `config_path=None` — rename the kwarg to `config_dir=None`. Also called from `watcher.py` line 210 with no argument (uses default) — no change needed.
+
+
+## 7. .gitignore Changes
+
+```gitignore
+# Before
+# Per-repo vox session state (config, ephemeral audio)
+.punt-labs/vox/
+
+# After
+# Per-repo vox ephemeral state (session config, audio)
+.punt-labs/vox/vox.local.md
+.punt-labs/vox/ephemeral/
+```
+
+This tracks everything under `.punt-labs/vox/` except the two ephemeral paths. The durable `vox.md` becomes tracked.
+
+Also remove `.vox/config.md` from git tracking:
+
+```bash
+git rm --cached .vox/config.md
+# Then remove .vox/ directory if empty
+```
+
+
+## 8. Initial Tracked vox.md Content
+
+The file ships with sensible defaults — a user who clones the repo gets working vox without creating any config:
+
+```yaml
+---
+notify: "n"
+speak: "y"
+vibe_mode: "auto"
+---
+```
+
+No `voice`, `provider`, or `model` — those default to auto-detection at runtime. The YAML frontmatter format is preserved for consistency with the existing reader.
+
+
+## 9. MCP Server Instructions Update
+
+The MCP server instructions (line 37 of server.py) reference `.punt-labs/vox/config.md`. Update to:
+
+```python
+"Do NOT use Read, Write, or Bash tools to access "
+".punt-labs/vox/vox.md or .punt-labs/vox/vox.local.md. "
+"All config state is available through MCP tools or hook context."
+```
+
+
+## 10. Test Strategy
+
+### Unit tests: config.py
+
+Test the core routing logic in isolation. No I/O mocking needed — use `tmp_path`.
+
+1. **`test_write_field_routes_durable_to_vox_md`** — write `voice`, read back from `vox.md` file, confirm `vox.local.md` untouched.
+2. **`test_write_field_routes_ephemeral_to_vox_local_md`** — write `vibe_signals`, confirm it lands in `vox.local.md`, `vox.md` untouched.
+3. **`test_write_fields_mixed_keys_routes_correctly`** — pass `{"notify": "y", "vibe_tags": "[calm]"}`, verify `notify` in `vox.md` and `vibe_tags` in `vox.local.md`.
+4. **`test_read_config_merges_both_files`** — write durable fields to `vox.md`, ephemeral to `vox.local.md`, verify `read_config` returns all.
+5. **`test_read_config_ephemeral_wins_on_conflict`** — write same key to both files, verify ephemeral value returned. (Defensive — should not happen in practice.)
+6. **`test_read_config_missing_files`** — neither file exists, verify safe defaults.
+7. **`test_read_config_only_durable`** — only `vox.md` exists, ephemeral fields get defaults.
+8. **`test_read_config_only_ephemeral`** — only `vox.local.md` exists, durable fields get defaults.
+9. **`test_read_field_durable_key`** — `read_field("voice", ...)` reads from `vox.md`.
+10. **`test_read_field_ephemeral_key`** — `read_field("vibe_signals", ...)` reads from `vox.local.md`.
+11. **`test_write_field_creates_dir`** — write to nonexistent dir, verify dir created.
+12. **`test_write_field_rejects_unknown_key`** — verify `ValueError` for unknown key.
+
+### Unit tests: dirs.py
+
+13. **`test_find_config_dir_walks_up`** — create `.punt-labs/vox/vox.md` in a parent, call `find_config_dir` from a child, verify directory found.
+14. **`test_find_config_dir_finds_ephemeral_only`** — directory with only `vox.local.md`, verify found.
+15. **`test_find_config_dir_no_legacy`** — create `.vox/config.md`, verify `find_config_dir` does NOT find it.
+
+### Integration tests: hooks.py
+
+16. **`test_post_bash_writes_to_vox_local_md`** — `handle_post_bash` writes `vibe_signals` to `vox.local.md`, not `vox.md`.
+17. **`test_stop_hook_writes_tags_to_vox_local_md`** — `handle_stop` writes `vibe_tags` and clears `vibe_signals` in `vox.local.md`.
+18. **`test_session_end_clears_signals_in_vox_local_md`** — `handle_session_end` clears `vibe_signals` in `vox.local.md`.
+
+### Integration tests: CLI (__main__.py)
+
+19. **`test_vibe_cmd_writes_mixed`** — `vox vibe auto` writes `vibe_mode` to `vox.md` and clears `vibe`/`vibe_tags` in `vox.local.md`.
+20. **`test_notify_cmd_writes_durable`** — `vox notify y` writes to `vox.md` only.
+21. **`test_voice_cmd_writes_durable`** — `vox voice fin` writes to `vox.md` only.
+
+### Existing test updates
+
+All existing tests that pass `config_path=` to config functions switch to `config_dir=`. Most tests already use `tmp_path` — they need to create `tmp_path / "vox.md"` and/or `tmp_path / "vox.local.md"` instead of `tmp_path / "config.md"`.
+
+
+## 11. Migration
+
+No migration. Per the contract: no users yet, clean break.
+
+- Delete `.vox/config.md` from git (`git rm .vox/config.md`).
+- Remove the `.vox/` directory.
+- Add `.punt-labs/vox/vox.md` to git with initial content from section 8.
+- All existing local `.punt-labs/vox/config.md` files (created by hooks at runtime) are already gitignored and will be orphaned — they are harmless. The new code does not read `config.md` from the new path.
+
+The doctor command's legacy `.vox/` check is removed entirely.
+
+
+## 12. Implementation Scope
+
+All changes fit a single PR touching these files:
+
+| File | Nature of change |
+|------|------------------|
+| `src/punt_vox/dirs.py` | Rename path constant, rename `find_config` -> `find_config_dir`, drop legacy |
+| `src/punt_vox/config.py` | Split read/write routing, new constants, parameter rename, update `__all__` |
+| `src/punt_vox/hooks.py` | Parameter rename throughout, drop vestigial existence guards |
+| `src/punt_vox/server.py` | Parameter rename, update instructions string |
+| `src/punt_vox/__main__.py` | Parameter rename, `first_init` field check, remove legacy doctor checks |
+| `src/punt_vox/resolve.py` | Parameter rename |
+| `src/punt_vox/watcher.py` | Parameter rename (`config_path` -> `config_dir`) |
+| `src/punt_vox/providers/__init__.py` | Parameter rename (`config_path` -> `config_dir`) |
+| `.gitignore` | Replace blanket `.punt-labs/vox/` ignore with specific excludes |
+| `.punt-labs/vox/vox.md` | New tracked file (initial config) |
+| `.vox/config.md` | Deleted from git |
+| `tests/test_config.py` | New routing tests, update existing tests |
+| `tests/test_hooks.py` | Update to use `config_dir` |
+| `tests/test_server.py` | Update to use `config_dir` |
+| `tests/test_cli.py` | Update to use `config_dir`, add `first_init` test |
+| `tests/test_watcher.py` | Update to use `config_dir` |
+| `tests/conftest.py` | Update shared fixtures |

--- a/docs/music-set-rotation-design.md
+++ b/docs/music-set-rotation-design.md
@@ -82,7 +82,7 @@ When music turns on or the vibe changes:
 
 The `_music_loop` changes structurally:
 
-```
+```python
 while music_mode == "on":
     ctx.music_tracks = _discover_and_shuffle(ctx)
     ctx.music_track_index = 0

--- a/docs/music-set-rotation-design.md
+++ b/docs/music-set-rotation-design.md
@@ -1,0 +1,322 @@
+# Music Set Rotation Design
+
+## Goal
+
+Enhance `_music_loop` from single-track looping to per-vibe set rotation
+with background fill. After initial generation the daemon plays from a
+local library at zero credit cost, generating new tracks only when the
+set is incomplete.
+
+## Current State
+
+`_music_loop` in `voxd.py` generates one track via
+`ElevenLabsMusicProvider.generate_track()`, then loops it. Vibe changes
+cancel any in-flight generation and start a new one while the old track
+keeps playing (DES-033 gapless handoff). Tracks are saved to
+`~/Music/vox/tracks/` as `{vibe}-{style}-{YYYYMMDD-HHMM}.mp3` (DES-035).
+Music plays in a separate subprocess at reduced volume (DES-030). One
+session owns the music at a time (DES-031).
+
+## Design
+
+### 1. Track Set State on DaemonContext
+
+Three new flat fields on `DaemonContext`, following the existing pattern
+of mutable state on the context object:
+
+```python
+self.music_tracks: list[Path] = []     # discovered + generated, in shuffle order
+self.music_track_index: int = 0        # next track to play
+self.music_set_size: int = 10          # default, configurable (per music_on)
+```
+
+Remove `self.music_track: Path | None` -- the track list replaces it.
+Keep `music_track_name`, `music_replay`, `music_proc`, `music_state`,
+`music_changed`, `music_vibe`, `music_style`, `music_owner`,
+`music_mode` as-is.
+
+No new dataclass. The context already carries `music_vibe` and
+`music_style`; duplicating them in a separate object would create a
+synchronization obligation for no benefit. A vibe change rebuilds the
+track list from scratch, so the vibe and the track list are never out
+of sync in a meaningful way.
+
+### 2. Track Discovery
+
+A new `_discover_tracks()` function scans `~/Music/vox/tracks/` for
+files whose name starts with `{vibe_slug}-{style_slug}-`:
+
+```python
+def _discover_tracks(vibe: str, style: str) -> list[Path]:
+    """Find existing tracks for this vibe+style combination."""
+    output_dir = _music_output_dir()
+    if not output_dir.is_dir():
+        return []
+    vibe_slug = _slugify(vibe, max_len=20) or "ambient"
+    style_slug = _slugify(style, max_len=20) or "mix"
+    prefix = f"{vibe_slug}-{style_slug}-"
+    return sorted(
+        p for p in output_dir.glob(f"{prefix}*.mp3")
+        if p.is_file()
+    )
+```
+
+`sorted()` produces lexicographic order, which is chronological because
+filenames end with `YYYYMMDD-HHMM`. No `stat()` calls are needed.
+
+This is compatible with `_auto_track_name()` which already produces
+`{vibe}-{style}-{YYYYMMDD-HHMM}` filenames. Existing tracks from
+single-track mode are discovered automatically.
+
+### 3. Track Set Lifecycle in MusicLoop
+
+When music turns on or the vibe changes:
+
+1. Call `_discover_tracks(vibe, style)` to find cached tracks.
+2. Shuffle the discovered list (`random.shuffle`).
+3. Set `ctx.music_tracks = tracks`, `ctx.music_track_index = 0`.
+4. If `len(ctx.music_tracks) > 0`, start playing immediately from
+   index 0.
+5. If `len(ctx.music_tracks) < ctx.music_set_size`, spawn a background
+   generation task to fill the gap.
+
+The `_music_loop` changes structurally:
+
+```
+while music_mode == "on":
+    ctx.music_tracks = _discover_and_shuffle(ctx)
+    ctx.music_track_index = 0
+
+    # Start playing immediately if we have any tracks
+    if ctx.music_tracks:
+        start playback of ctx.music_tracks[ctx.music_track_index]
+
+    # Fill loop: generate missing tracks in background
+    gen_task = None
+    if len(ctx.music_tracks) < ctx.music_set_size:
+        gen_task = create_task(_generate_music_track(ctx))
+
+    # Playback rotation loop (same inner wait structure as today)
+    while music_mode == "on":
+        wait on: proc.wait(), music_changed.wait(), gen_task
+
+        if proc ended naturally:
+            # Advance to next track in set
+            ctx.music_track_index = (ctx.music_track_index + 1) % len(ctx.music_tracks)
+            break  # respawn with next track
+
+        if gen_task completed successfully:
+            new_track = gen_task.result()
+            ctx.music_tracks.append(new_track)
+            if len(ctx.music_tracks) < ctx.music_set_size:
+                gen_task = create_task(_generate_music_track(ctx))
+            else:
+                gen_task = None  # set is full, stop generating
+
+        if gen_task failed:
+            # Same retry logic as today (backoff, max 3 attempts)
+            # The current track keeps playing
+
+        if music_changed (vibe change):
+            # Cancel gen_task, rebuild track list for new vibe
+            break to outer loop
+
+        if music_mode == "off":
+            kill everything, break
+```
+
+When `ctx.music_tracks` is empty (no cached tracks and first generation
+is needed), the loop falls through to the generation-first path -- same
+as the current `current_track is None` branch. This preserves the
+existing gapless handoff guarantee from DES-033.
+
+### 4. Background Fill Without Blocking Speech
+
+No change needed. Music generation already runs in `asyncio.to_thread()`
+inside `ElevenLabsMusicProvider.generate_track()`. Speech and chimes use
+the separate `_playback_consumer` queue and `_playback_mutex`. Music
+plays in its own subprocess at reduced volume (DES-030). The two paths
+are already independent.
+
+Background fill generates tracks sequentially — one at a time, not in
+parallel. When a track completes, it is appended to the track list; if
+the set is still incomplete, the next generation starts. This avoids
+multiplying concurrent ElevenLabs API requests and keeps credit spend
+predictable.
+
+The only contention point is the ElevenLabs API key. Generation and
+speech synthesis can run concurrently -- ElevenLabs allows multiple
+concurrent requests per key. If rate-limiting becomes an issue, the
+generation task will raise `ApiError` and the retry logic handles it.
+
+### 5. Rotation Logic
+
+Tracks rotate in shuffle order. When a track finishes playing (ffplay
+exits), the index advances:
+`ctx.music_track_index = (ctx.music_track_index + 1) % len(ctx.music_tracks)`.
+When the index wraps around to 0, reshuffle the list (avoid repeating
+the same order).
+
+No track is ever deleted by the rotation. The set grows up to
+`ctx.music_set_size` and then stays fixed. New generation stops once
+the set is full.
+
+### 6. Vibe Change Handling
+
+When `music_changed` fires and the vibe has actually changed
+(compare `(vibe, style)` against `ctx.music_vibe, ctx.music_style`):
+
+1. Cancel any in-flight generation task.
+2. Do NOT kill the current playback subprocess yet (gapless handoff).
+3. Discover and shuffle tracks for the new vibe via `_discover_tracks()`.
+4. Set `ctx.music_tracks`, `ctx.music_track_index = 0`.
+5. If new track list has tracks: kill old subprocess, start first track.
+6. If new track list is empty: start generation. Old track keeps playing
+   until generation completes (existing DES-033 behavior).
+7. Once the new track is ready or a cached track starts: spawn
+   background fill if set is incomplete.
+
+If the vibe changes again during background fill, the fill task is
+cancelled and the process repeats for the newest vibe.
+
+### 7. Set Size Configuration
+
+`set_size` is passed via the `music_on` WebSocket message as an
+optional integer field. It defaults to 10 if omitted.
+
+```python
+# In _handle_music_on:
+set_size = int(msg.get("set_size", 10))
+ctx.music_set_size = max(1, min(set_size, 10))  # clamp 1-10
+```
+
+The MCP server (`server.py`) and CLI (`__main__.py`) pass it through:
+
+- CLI: `vox music on --set-size 5`
+- MCP: `music_on` tool parameter `set_size`
+
+No persistent config file for this -- it is per-session. The default
+of 10 is a module-level constant `_DEFAULT_SET_SIZE = 10`.
+
+### 8. Cost Model
+
+- ~2000 credits per track (ElevenLabs music generation, 2-minute track)
+- Default set of 3 = ~6000 credits per vibe
+- After initial generation, replay is free (zero credits)
+- Vibe change to a new vibe costs up to 6000 credits for 3 tracks
+- Vibe change back to a previously-played vibe costs 0 credits
+  (tracks are cached on disk)
+
+### 9. Replay and music_replay Flag
+
+The existing `music_replay` flag handles `/music play <name>` and
+`/music on --name <name>`. This continues to work: when
+`music_replay=True`, the loop uses `ctx.music_track` directly and
+skips the track set/discovery logic. The named track plays as a
+single-track loop (existing behavior).
+
+Set rotation applies only when no explicit `--name` is given.
+
+### 10. Edge Cases
+
+**Empty library (first use):** `_discover_tracks()` returns `[]`.
+The loop falls to the generation-first path, generates one track,
+starts playing it, then spawns background fill for the remaining 2.
+Identical to current behavior for the first track; fill is new.
+
+**Mid-generation vibe change:** Cancel the in-flight generation task
+(existing behavior). Build new track list for new vibe. If cached tracks
+exist for the new vibe, start immediately. Otherwise generate-first.
+No track from the cancelled generation is saved (consistent with
+current behavior -- `_generate_music_track` writes only on success).
+
+**Set size change:** The set size is set per `music_on` invocation.
+Changing it mid-session requires `/music off` then `/music on
+--set-size N`. If the new size is smaller than the existing track
+count, the extra tracks remain on disk but only `music_set_size` tracks
+are included in the rotation (keep the first N tracks in sorted order,
+which is the N oldest by the `YYYYMMDD-HHMM` suffix).
+
+**Disk full:** `_generate_music_track` raises `OSError`. The retry
+logic handles it -- after 3 failures, music disables. Same as today.
+
+**Corrupt track file:** ffplay exits with non-zero rc. The rotation
+advances to the next track. The corrupt file stays on disk (no
+auto-deletion).
+
+**Concurrent sessions:** Only the music owner's session drives
+generation and rotation. Non-owning sessions hear the music but
+cannot change the track set (DES-031 unchanged).
+
+## Changed Files
+
+### `src/punt_vox/voxd.py`
+
+- Add `music_tracks`, `music_track_index`, and `music_set_size` fields
+  to `DaemonContext`.
+- Remove `music_track` field (replaced by `music_tracks` list).
+- Add `_discover_tracks(vibe, style) -> list[Path]` function.
+- Rewrite `_music_loop` inner structure: track discovery, rotation
+  index, background fill task, reshuffle on wrap.
+- Update `_generate_music_track` to accept an explicit track name
+  (decouple from `ctx.music_track_name` for background generation).
+- Update `_handle_music_on`: parse `set_size`, set `ctx.music_set_size`.
+- Update `_handle_music_vibe`: clear `ctx.music_tracks` so the loop
+  rebuilds for the new vibe.
+- Update `_handle_music_play`: set `music_replay=True`, bypass track
+  set logic (no change from current behavior).
+- Update `_handle_music_off`: clear `ctx.music_tracks`,
+  reset `ctx.music_track_index`.
+- Add `_DEFAULT_SET_SIZE = 10` constant.
+- Update `_health_payload_full` to include track set info (track count,
+  set size, current index).
+
+### `src/punt_vox/__main__.py`
+
+- Add `--set-size` option to `music on` command.
+- Pass `set_size` through `VoxClientSync.music()`.
+
+### `src/punt_vox/client.py`
+
+- Add `set_size` parameter to `VoxClientSync.music()` and
+  `VoxClient.music()`.
+
+### `src/punt_vox/server.py`
+
+- Add `set_size` parameter to the `music_on` MCP tool.
+- Pass through to voxd via client.
+
+### `tests/test_voxd_music.py` (new file or extend existing)
+
+- Test `_discover_tracks` with various file layouts.
+- Test track rotation (index advancement, reshuffle on wrap).
+- Test background fill: mock `ElevenLabsMusicProvider.generate_track`,
+  verify generation stops at `music_set_size`.
+- Test vibe change mid-fill: verify old gen task cancelled, new
+  track list built.
+- Test empty library path.
+- Test set_size clamping (0 -> 1, 100 -> 10).
+- Test `music_replay` bypass (named track skips track set logic).
+
+## Test Strategy
+
+Unit tests for the new pure functions (`_discover_tracks`, index
+advancement logic) are straightforward. The `_music_loop` integration
+tests should use the existing pattern from the test suite: mock the
+`ElevenLabsMusicProvider` and subprocess creation, drive the loop by
+setting `DaemonContext` fields and signaling `music_changed`.
+
+Key behavioral tests:
+
+1. Start with 2 cached tracks, set_size=10. Verify: plays immediately,
+   generates 1 more, then stops generating.
+2. Start with 0 cached tracks. Verify: generates first track, starts
+   playing, generates 2 more in background.
+3. Vibe change with 3 cached tracks for new vibe. Verify: switches
+   immediately, no generation.
+4. Vibe change with 0 cached tracks. Verify: old track continues
+   until new one is ready (DES-033 gapless).
+5. Set fills to `music_set_size`. Verify: no further generation tasks
+   created.
+6. Named replay (`--name`). Verify: bypasses track set, loops single
+   track.

--- a/docs/remote-voxd-design.md
+++ b/docs/remote-voxd-design.md
@@ -1,0 +1,344 @@
+# Design: Remote voxd Connectivity
+
+**Author:** Raymond H (rmh)
+**Date:** 2026-05-12
+**Mission:** m-2026-05-12-009
+**Status:** PROPOSED
+
+## Problem
+
+voxd binds to `127.0.0.1:8421` and clients discover port/token from
+local files (`~/.punt-labs/vox/run/serve.port`, `serve.token`). SSH
+reverse tunnels have already proven the protocol works across hosts.
+Two barriers remain: the client hardcodes localhost, and the server
+only binds localhost.
+
+## Design
+
+Three client-side env vars, one server-side env var. When client env
+vars are set, file-based discovery is bypassed entirely.
+
+### Env Vars
+
+| Var | Side | Default | Purpose |
+|-----|------|---------|---------|
+| `VOXD_HOST` | client | `127.0.0.1` | WebSocket host for voxd |
+| `VOXD_PORT` | client | read `serve.port` file | WebSocket port for voxd |
+| `VOXD_TOKEN` | client | read `serve.token` file | Auth token for voxd |
+| `VOXD_BIND` | server | `127.0.0.1` | Address voxd binds to |
+
+### Client Resolution Order
+
+In `client.py`, at the top of the module:
+
+```python
+def _env_host() -> str:
+    """Return VOXD_HOST or default."""
+    return os.environ.get("VOXD_HOST", "127.0.0.1")
+
+def _env_port() -> int | None:
+    """Return VOXD_PORT as int, or None to fall back to file."""
+    raw = os.environ.get("VOXD_PORT")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("VOXD_PORT=%r is not an integer, ignoring", raw)
+        return None
+
+def _env_token() -> str | None:
+    """Return VOXD_TOKEN, or None to fall back to file."""
+    return os.environ.get("VOXD_TOKEN")
+```
+
+Resolution for each parameter follows the same pattern -- env var
+wins, file-based discovery is the fallback:
+
+| Parameter | 1st (env var) | 2nd (file) | 3rd (hardcoded) |
+|-----------|---------------|------------|------------------|
+| host | `VOXD_HOST` | -- | `127.0.0.1` |
+| port | `VOXD_PORT` | `serve.port` | error (daemon not running) |
+| token | `VOXD_TOKEN` | `serve.token` | `None` (no auth) |
+
+When `VOXD_HOST` is set to a remote address, `VOXD_PORT` and
+`VOXD_TOKEN` should also be set -- the file-based discovery only
+makes sense for a local daemon. The client does not enforce this; it
+simply follows the resolution order above. If the user sets
+`VOXD_HOST=remote-box` but not `VOXD_PORT`, the client will try to
+read `serve.port` from the local filesystem, which will either contain
+the local daemon's port or be absent (raising `VoxdConnectionError`
+with a clear message).
+
+### Server Bind Address
+
+In `voxd.py`, the `main()` function already accepts `--host` via
+typer. Use typer's `envvar=` parameter to wire `VOXD_BIND` as the
+env-var source for `--host`, giving standard CLI precedence for free:
+
+```python
+DEFAULT_HOST = "127.0.0.1"
+
+@cli.callback(invoke_without_command=True)
+def main(
+    port: int = typer.Option(DEFAULT_PORT, "--port", "-p", help="Listen port"),
+    host: str = typer.Option(DEFAULT_HOST, "--host", envvar="VOXD_BIND", help="Listen host"),
+) -> None:
+    ...
+    config = uvicorn.Config(app, host=host, port=port, ...)
+```
+
+Precedence: `--host` (explicit CLI flag) > `VOXD_BIND` (env var) >
+`DEFAULT_HOST` (`127.0.0.1`). Typer handles this natively -- no
+manual `os.environ.get()` needed in `main()`.
+
+When binding to a non-localhost address, voxd logs a WARNING:
+
+```python
+if host not in ("127.0.0.1", "::1"):
+    logger.warning(
+        "Binding to %s -- voxd is accessible from the network. "
+        "Ensure VOXD_TOKEN is set on all clients.",
+        host,
+    )
+```
+
+Access logging stays enabled, but the token must be stripped from
+logged URIs. The auth token appears in the WebSocket upgrade request
+as `?token=<value>`. A uvicorn log filter redacts the query string
+from access log lines:
+
+```python
+class _TokenRedactFilter(logging.Filter):
+    _TOKEN_RE = re.compile(r"\?token=[^\s\"']+")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if hasattr(record, "msg") and isinstance(record.msg, str):
+            record.msg = self._TOKEN_RE.sub("?token=REDACTED", record.msg)
+        return True
+```
+
+Applied to uvicorn's access logger at startup. This preserves
+operational visibility (connection counts, status codes, timing)
+while preventing token leakage to log files.
+
+### Service Unit Changes
+
+In `service.py`, when `VOXD_BIND` is set at install time, bake it
+into the service unit as an environment variable. The voxd binary
+reads `VOXD_BIND` at runtime via `typer.Option(..., envvar="VOXD_BIND")`
+-- no `--host` flag needs to be passed in the exec args.
+
+**systemd** (`_systemd_unit_content`):
+
+```python
+def _systemd_unit_content(user: str) -> str:
+    ...
+    bind = os.environ.get("VOXD_BIND")
+    if bind is not None:
+        # Add to env_block alongside PATH and audio vars
+        env_block lines += f'Environment="VOXD_BIND={bind}"'
+```
+
+**launchd** (`_launchd_plist_content`):
+
+```python
+def _launchd_plist_content(user: str) -> str:
+    ...
+    bind = os.environ.get("VOXD_BIND")
+    # Add to EnvironmentVariables dict if set:
+    #   <key>VOXD_BIND</key>
+    #   <string>{escaped_bind}</string>
+```
+
+This follows the existing pattern: `PATH` and audio vars are already
+baked into service units from the installing shell's environment.
+
+## Changed Files
+
+### `src/punt_vox/client.py`
+
+1. Add `import os` to stdlib imports.
+2. Add `_env_host()`, `_env_port()`, `_env_token()` module-level
+   helpers (9 lines total, shown above).
+3. Change `VoxClient.__init__` default for `host` from `"127.0.0.1"`
+   to `_env_host()`.
+4. In `_resolve_port()`: check `_env_port()` before reading
+   `serve.port`. If `self._explicit_port` is set (caller passed
+   `port=`), it still wins.
+5. In `_resolve_token()`: check `_env_token()` before reading
+   `serve.token`. If `self._explicit_token` is set, it still wins.
+6. Change `VoxClientSync.__init__` default for `host` from
+   `"127.0.0.1"` to `_env_host()`.
+
+Specifically, the resolution in `_resolve_port` becomes:
+
+```python
+def _resolve_port(self) -> int:
+    if self._port is not None:
+        return self._port
+    env = _env_port()
+    if env is not None:
+        return env
+    port = read_port_file()
+    if port is None:
+        msg = "voxd port file not found. Is the daemon running? Start it with: voxd"
+        raise VoxdConnectionError(msg)
+    return port
+```
+
+And `_resolve_token`:
+
+```python
+def _resolve_token(self) -> str | None:
+    if self._token is not None:
+        return self._token
+    env = _env_token()
+    if env is not None:
+        return env
+    return read_token_file()
+```
+
+### `src/punt_vox/voxd.py`
+
+1. Add `envvar="VOXD_BIND"` to the `--host` typer Option declaration.
+   This gives `--host > VOXD_BIND > DEFAULT_HOST` precedence natively.
+   No manual `os.environ.get()` call needed.
+2. Add a `logger.warning()` when `host` is not `127.0.0.1` or `::1`
+   (non-localhost bind).
+3. Add a `_TokenRedactFilter` log filter that strips `?token=...`
+   from access log messages. Apply it to uvicorn's access logger at
+   startup. Access logging stays enabled for operational visibility.
+   (~12 lines changed)
+
+### `src/punt_vox/service.py`
+
+1. In `_systemd_unit_content()`: after building `audio_lines`, append
+   a `VOXD_BIND` environment line if the var is set in the installing
+   shell. (4 lines)
+2. In `_launchd_plist_content()`: add a `<key>VOXD_BIND</key>` entry
+   to the `EnvironmentVariables` dict if set. (5 lines)
+
+### `src/punt_vox/__main__.py`
+
+1. In the `doctor` command: after probing the daemon, display any
+   active `VOXD_*` env var overrides in the output. Example:
+
+   ```
+   OK  Daemon: running on port 8421 (provider: elevenlabs, version 4.7.5)
+       (via VOXD_HOST=192.168.1.100, VOXD_PORT=8421)
+   ```
+
+   Check `VOXD_HOST`, `VOXD_PORT`, `VOXD_TOKEN` and append a
+   parenthetical line listing those that are set. (~8 lines)
+
+All other CLI commands that construct `VoxClientSync()` with no
+arguments will pick up the env-var defaults through the updated
+`__init__` signatures -- no changes needed there.
+
+### `src/punt_vox/hooks.py`
+
+No changes needed. `_make_client()` returns `VoxClientSync()` with no
+arguments -- env var defaults flow through automatically.
+
+### `src/punt_vox/server.py`
+
+No changes needed. `_voxd_client()` returns `VoxClientSync()` with no
+arguments -- same reasoning.
+
+### Tests
+
+- `tests/test_client.py`: parametrized tests for env var resolution
+  (`monkeypatch.setenv`). Verify VOXD_HOST, VOXD_PORT, VOXD_TOKEN
+  override defaults. Verify invalid VOXD_PORT is ignored with warning.
+- `tests/test_service.py`: verify VOXD_BIND is baked into generated
+  systemd unit content and launchd plist content when set.
+- `tests/test_cli.py`: verify `vox doctor` reports active VOXD_*
+  env var overrides in its output.
+- `tests/test_voxd.py` (or inline): verify non-localhost bind emits
+  a WARNING log.
+
+## What Does NOT Change
+
+- **WebSocket protocol.** No message format changes. The `ws://` URI
+  scheme, JSON message types, auth token query parameter -- all
+  identical.
+- **Token generation.** voxd still generates and writes `serve.token`
+  on startup. Local clients still read it from the file. Remote
+  clients override it with `VOXD_TOKEN`.
+- **Port file.** voxd still writes `serve.port` after bind. Local
+  clients still read it.
+- **Default behavior.** With no env vars set, behavior is identical to
+  today: bind `127.0.0.1:8421`, discover port/token from files.
+- **No new dependencies.** `os.environ.get` is stdlib.
+- **No mcp-proxy integration.** Vox does not use mcp-proxy today and
+  this design does not add it. The MCP server (`vox mcp`) runs via
+  stdio and connects to voxd as a local client. This design makes the
+  voxd connection configurable; the MCP transport is orthogonal.
+- **`service.py` install flow.** No new sudo calls, no new files. The
+  only change is an optional extra `Environment=` line in the
+  generated unit content.
+
+## Security
+
+**Network-exposed voxd** -- when `VOXD_BIND=0.0.0.0`, voxd listens on
+all interfaces. The existing token-based auth is the security boundary:
+
+1. **Token is required.** Every WebSocket connection must present the
+   token via `?token=<value>` query parameter. Connections without a
+   valid token are rejected before any message processing.
+
+2. **Token is random.** Generated by `secrets.token_urlsafe(32)` on
+   first startup, stored at `~/.punt-labs/vox/run/serve.token` with
+   mode 0700 on the parent directory.
+
+3. **Token transmission.** The remote client receives the token
+   out-of-band (the user copies it, sets `VOXD_TOKEN` in
+   `.envrc`). It is transmitted in the WebSocket URI query string over
+   unencrypted `ws://`.
+
+4. **No TLS.** voxd does not terminate TLS. For remote use over
+   untrusted networks, an SSH tunnel provides encryption (same pattern
+   already validated in testing). The token prevents unauthorized
+   access; the tunnel prevents eavesdropping.
+
+5. **Threat model.** An attacker on the network can observe the token
+   in cleartext if no tunnel is used. Mitigation: document that
+   `VOXD_BIND=0.0.0.0` without an SSH tunnel exposes the token and
+   should only be used on trusted LANs. This matches quarry's model
+   (quarry uses TLS with self-signed certs for remote; vox is
+   lower-stakes -- audio playback, not data access).
+
+6. **No new attack surface on default config.** With no env vars set,
+   voxd binds `127.0.0.1` only. Network exposure is strictly opt-in.
+
+## Alignment
+
+### Quarry pattern
+
+Quarry uses `mcp-proxy` with a TOML config file
+(`~/.punt-labs/mcp-proxy/quarry.toml`) that stores the WebSocket URL
+and auth headers. This design does not adopt that pattern because vox
+has a simpler topology: the vox MCP server (`vox mcp`) is a thin
+client of voxd, not a standalone daemon. The mcp-proxy pattern is
+appropriate when the MCP server itself is the daemon (quarry, lux).
+For vox, the connection that needs remote configuration is
+`VoxClient -> voxd`, not `Claude Code -> vox mcp`.
+
+The env var names follow quarry's conventions (product-prefixed,
+uppercase, underscore-separated). The resolution order (env var >
+file > default) matches quarry's client-side pattern.
+
+### Lux mcp-proxy-proposal
+
+The lux proposal introduces `luxd` as a session hub daemon with
+`mcp-proxy` bridging stdio to WebSocket. Vox's architecture is
+different: voxd is a pure audio server, not an MCP server. The
+`vox mcp` process is a FastMCP stdio server that happens to use voxd
+as a backend. Making voxd remotely accessible solves the cross-host
+problem without the proxy layer.
+
+If vox later adopts mcp-proxy (for MCP server lifecycle benefits), the
+env vars introduced here remain correct -- they configure the
+`VoxClient -> voxd` connection, which is independent of the
+`Claude Code -> vox mcp` transport.

--- a/docs/remote-voxd-design.md
+++ b/docs/remote-voxd-design.md
@@ -224,7 +224,7 @@ def _resolve_token(self) -> str | None:
 1. In the `doctor` command: after probing the daemon, display any
    active `VOXD_*` env var overrides in the output. Example:
 
-   ```
+   ```text
    OK  Daemon: running on port 8421 (provider: elevenlabs, version 4.7.5)
        (via VOXD_HOST=192.168.1.100, VOXD_PORT=8421)
    ```

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -105,23 +105,24 @@ def _seed_state_from_config(config_dir: Path | None) -> SessionState:
 def _refresh_state_from_config() -> None:
     """Re-read config files and update _state with current values.
 
-    Ephemeral fields (vibe, vibe_tags, vibe_signals, vibe_mode, notify,
-    speak) always take the config value -- the config file is the source
-    of truth since CLI and hooks write there directly.
+    Config-sourced fields (notify, speak, vibe_mode, vibe, vibe_tags,
+    vibe_signals) always take the config value — the config file is
+    the source of truth since CLI and hooks write there directly.
 
-    For voice, provider, and model the MCP tool may have set a value that
-    was not persisted to config (e.g. an in-tool override).  Only overwrite
-    _state when config has a non-None value so those overrides survive.
+    For voice, provider, and model the MCP tool may have set a value
+    that was not persisted to config (e.g. an in-tool override).  Only
+    overwrite _state when config has a non-None value so those
+    overrides survive.
     """
+    global _speak_explicit
     config_dir = _find_config_dir()
     if config_dir is None:
         return
 
-    from punt_vox.config import read_config
+    from punt_vox.config import read_config, read_field
 
     cfg = read_config(config_dir=config_dir)
 
-    # Ephemeral fields -- always take config value
     _state.vibe = cfg.vibe
     _state.vibe_tags = cfg.vibe_tags
     _state.vibe_signals = cfg.vibe_signals or ""
@@ -129,7 +130,9 @@ def _refresh_state_from_config() -> None:
     _state.notify = cfg.notify
     _state.speak = cfg.speak
 
-    # Durable identity fields -- only overwrite when config has a value
+    if read_field("speak", config_dir) is not None:
+        _speak_explicit = True
+
     if cfg.voice is not None:
         _state.voice = cfg.voice
     if cfg.provider is not None:
@@ -622,6 +625,8 @@ def music_play(name: str) -> str:
     Finds the track in the music library and starts looping it.
     No generation, no credits used.
 
+    .. note:: Calls ``_refresh_state_from_config()`` for consistency.
+
     Args:
         name: Track name (as shown by music_list).
 
@@ -629,6 +634,7 @@ def music_play(name: str) -> str:
         JSON string with a human-readable ``message`` field and
         the raw voxd response fields.
     """
+    _refresh_state_from_config()
     client = _voxd_client()
     try:
         resp = client.music_play(name, owner_id=_state.session_id)
@@ -663,6 +669,7 @@ def music_list() -> str:
         JSON string with a human-readable ``message`` field and
         the track list from voxd.
     """
+    _refresh_state_from_config()
     client = _voxd_client()
     try:
         resp = client.music_list()

--- a/src/punt_vox/server.py
+++ b/src/punt_vox/server.py
@@ -102,6 +102,42 @@ def _seed_state_from_config(config_dir: Path | None) -> SessionState:
     )
 
 
+def _refresh_state_from_config() -> None:
+    """Re-read config files and update _state with current values.
+
+    Ephemeral fields (vibe, vibe_tags, vibe_signals, vibe_mode, notify,
+    speak) always take the config value -- the config file is the source
+    of truth since CLI and hooks write there directly.
+
+    For voice, provider, and model the MCP tool may have set a value that
+    was not persisted to config (e.g. an in-tool override).  Only overwrite
+    _state when config has a non-None value so those overrides survive.
+    """
+    config_dir = _find_config_dir()
+    if config_dir is None:
+        return
+
+    from punt_vox.config import read_config
+
+    cfg = read_config(config_dir=config_dir)
+
+    # Ephemeral fields -- always take config value
+    _state.vibe = cfg.vibe
+    _state.vibe_tags = cfg.vibe_tags
+    _state.vibe_signals = cfg.vibe_signals or ""
+    _state.vibe_mode = cfg.vibe_mode
+    _state.notify = cfg.notify
+    _state.speak = cfg.speak
+
+    # Durable identity fields -- only overwrite when config has a value
+    if cfg.voice is not None:
+        _state.voice = cfg.voice
+    if cfg.provider is not None:
+        _state.provider = cfg.provider
+    if cfg.model is not None:
+        _state.model = cfg.model
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -200,6 +236,7 @@ def unmute(
     Returns:
         JSON string with synthesis results.
     """
+    _refresh_state_from_config()
     _validate_voice_settings(stability, similarity, style)
 
     # ephemeral is accepted for callers (architecture spec) but voxd
@@ -339,6 +376,7 @@ def record(
     Returns:
         JSON string with synthesis results including file path.
     """
+    _refresh_state_from_config()
     _validate_voice_settings(stability, similarity, style)
 
     # Normalize input: text -> single segment.
@@ -451,6 +489,7 @@ def vibe(
     Returns:
         JSON string with the updated vibe state.
     """
+    _refresh_state_from_config()
     updates: dict[str, str] = {}
     if mood is not None:
         updates["vibe"] = mood
@@ -531,6 +570,7 @@ def music(
         JSON string with a human-readable ``message`` field and
         the raw voxd response fields.
     """
+    _refresh_state_from_config()
     if mode not in ("on", "off"):
         return _error(f"Invalid mode '{mode}'. Use on/off.")
 
@@ -674,6 +714,7 @@ def who(language: str | None = None) -> str:
         JSON string with provider, current voice, featured voices,
         and full voice list.
     """
+    _refresh_state_from_config()
     client = _voxd_client()
 
     try:
@@ -729,6 +770,7 @@ def notify(
     Returns:
         JSON string with the updated config fields.
     """
+    _refresh_state_from_config()
     if mode not in ("y", "n", "c"):
         return _error(f"Invalid mode '{mode}'. Use y/n/c.")
 
@@ -778,6 +820,7 @@ def speak(
         JSON string with the updated fields.
     """
     global _speak_explicit
+    _refresh_state_from_config()
 
     if mode not in ("y", "n"):
         return _error(f"Invalid mode '{mode}'. Use y/n.")
@@ -806,6 +849,7 @@ def status() -> str:
         JSON string with provider, voice, notify mode, speak mode,
         vibe mode, and current vibe.
     """
+    _refresh_state_from_config()
     return json.dumps(
         {
             "provider": _state.provider,
@@ -832,6 +876,7 @@ def show_vox() -> str:
     Returns:
         JSON string with status ("ok" or "error" with message).
     """
+    _refresh_state_from_config()
     from punt_vox.applet import show_applet
     from punt_vox.config import VoxConfig
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -20,6 +20,7 @@ from punt_vox.resolve import (
 )
 from punt_vox.server import (
     SessionState,
+    _refresh_state_from_config,
     music,
     music_list,
     music_play,
@@ -54,11 +55,17 @@ def _patch_config(  # pyright: ignore[reportUnusedFunction]
 
 @pytest.fixture(autouse=True)
 def _fresh_session(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
-    """Reset server session state before every test."""
+    """Reset server session state before every test.
+
+    Also stubs _find_config_dir to return None so _refresh_state_from_config
+    is a no-op by default.  Tests that need refresh behavior override via
+    the _refresh_config fixture.
+    """
     import punt_vox.server as srv
 
     monkeypatch.setattr(srv, "_state", SessionState())
     monkeypatch.setattr(srv, "_speak_explicit", False)
+    monkeypatch.setattr(srv, "_find_config_dir", lambda: None)
 
 
 # ---------------------------------------------------------------------------
@@ -1421,3 +1428,261 @@ class TestMusicListTool:
         result = json.loads(music_list())
 
         assert result["error"] == "daemon unreachable"
+
+
+# ---------------------------------------------------------------------------
+# _refresh_state_from_config tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _refresh_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:  # pyright: ignore[reportUnusedFunction]
+    """Patch _find_config_dir and DEFAULT_CONFIG_DIR for refresh tests."""
+    import punt_vox.config as cfg
+    import punt_vox.dirs as dirs
+    import punt_vox.server as srv
+
+    monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(dirs, "DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(srv, "_find_config_dir", lambda: tmp_path)
+    return tmp_path
+
+
+class TestRefreshStateFromConfig:
+    """Tests for _refresh_state_from_config reading external changes."""
+
+    def test_ephemeral_fields_always_updated(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Vibe/tags/signals written externally are picked up on refresh."""
+        import punt_vox.server as srv
+
+        srv._state.vibe = "old-mood"
+        srv._state.vibe_tags = "[old]"
+        srv._state.vibe_signals = "old-signal"
+
+        (_refresh_config / "vox.local.md").write_text(
+            "---\n"
+            'vibe: "happy"\n'
+            'vibe_tags: "[warm]"\n'
+            'vibe_signals: "tests-pass@10:00"\n'
+            "---\n"
+        )
+
+        _refresh_state_from_config()
+
+        assert srv._state.vibe == "happy"
+        assert srv._state.vibe_tags == "[warm]"
+        assert srv._state.vibe_signals == "tests-pass@10:00"
+
+    def test_ephemeral_cleared_when_config_empty(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When config has no vibe fields, in-memory vibe is cleared."""
+        import punt_vox.server as srv
+
+        srv._state.vibe = "stale-mood"
+        srv._state.vibe_tags = "[stale]"
+        srv._state.vibe_signals = "stale-signal"
+
+        # Config exists but has no vibe fields
+        (_refresh_config / "vox.local.md").write_text("---\n---\n")
+        (_refresh_config / "vox.md").write_text("---\n---\n")
+
+        _refresh_state_from_config()
+
+        assert srv._state.vibe is None
+        assert srv._state.vibe_tags is None  # type: ignore[unreachable]
+        assert srv._state.vibe_signals == ""
+
+    def test_durable_fields_updated_from_config(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """notify, speak, vibe_mode always take config value."""
+        import punt_vox.server as srv
+
+        srv._state.notify = "n"
+        srv._state.speak = "n"
+        srv._state.vibe_mode = "off"
+
+        (_refresh_config / "vox.md").write_text(
+            '---\nnotify: "c"\nspeak: "y"\nvibe_mode: "auto"\n---\n'
+        )
+
+        _refresh_state_from_config()
+
+        assert srv._state.notify == "c"
+        assert srv._state.speak == "y"
+        assert srv._state.vibe_mode == "auto"
+
+    def test_voice_only_overwritten_when_config_has_value(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In-memory voice survives refresh when config has no voice."""
+        import punt_vox.server as srv
+
+        srv._state.voice = "matilda"
+
+        # Config has no voice field
+        (_refresh_config / "vox.md").write_text("---\n---\n")
+
+        _refresh_state_from_config()
+
+        assert srv._state.voice == "matilda"
+
+    def test_voice_overwritten_when_config_has_value(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Config voice overwrites in-memory voice."""
+        import punt_vox.server as srv
+
+        srv._state.voice = "matilda"
+
+        (_refresh_config / "vox.md").write_text('---\nvoice: "roger"\n---\n')
+
+        _refresh_state_from_config()
+
+        assert srv._state.voice == "roger"
+
+    def test_provider_survives_when_config_empty(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In-memory provider override survives when config has no provider."""
+        import punt_vox.server as srv
+
+        srv._state.provider = "openai"
+
+        (_refresh_config / "vox.md").write_text("---\n---\n")
+
+        _refresh_state_from_config()
+
+        assert srv._state.provider == "openai"
+
+    def test_model_survives_when_config_empty(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In-memory model override survives when config has no model."""
+        import punt_vox.server as srv
+
+        srv._state.model = "eleven_v3"
+
+        (_refresh_config / "vox.md").write_text("---\n---\n")
+
+        _refresh_state_from_config()
+
+        assert srv._state.model == "eleven_v3"
+
+    def test_no_config_dir_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When _find_config_dir returns None, refresh is a no-op."""
+        import punt_vox.server as srv
+
+        monkeypatch.setattr(srv, "_find_config_dir", lambda: None)
+        srv._state.vibe = "should-survive"
+
+        _refresh_state_from_config()
+
+        assert srv._state.vibe == "should-survive"
+
+
+class TestRefreshIntegrationWithTools:
+    """Verify tool calls pick up external config writes via refresh."""
+
+    def test_status_reflects_external_vibe_change(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLI writes vibe to config; status tool reads the new value."""
+        import punt_vox.server as srv
+
+        srv._state.vibe = "sad"
+        srv._state.vibe_tags = "[gloomy]"
+
+        # Simulate CLI writing new vibe to config
+        write_fields(
+            {"vibe": "happy", "vibe_tags": "[cheerful]"},
+            _refresh_config,
+        )
+
+        result = json.loads(status())
+
+        assert result["vibe"] == "happy"
+        assert result["vibe_tags"] == "[cheerful]"
+
+    def test_status_reflects_external_notify_change(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """External notify write is reflected in status."""
+        import punt_vox.server as srv
+
+        srv._state.notify = "n"
+
+        write_field("notify", "c", _refresh_config)
+
+        result = json.loads(status())
+
+        assert result["notify"] == "c"
+
+    def test_music_gets_fresh_vibe(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """music tool reads fresh vibe from config, not stale in-memory."""
+        import punt_vox.server as srv
+
+        srv._state.vibe = "old-mood"
+        srv._state.vibe_tags = "[old]"
+
+        # External write clears vibe (e.g. `vox vibe auto`)
+        write_fields({"vibe": "", "vibe_tags": ""}, _refresh_config)
+
+        mock_client = MagicMock()
+        mock_client.music.return_value = {
+            "type": "music_on",
+            "id": "x",
+            "status": "generating",
+        }
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        music(mode="on")
+
+        call_kwargs = mock_client.music.call_args[1]
+        # Vibe should be empty -- the config cleared it
+        assert call_kwargs["vibe"] == ""
+        assert call_kwargs["vibe_tags"] == ""
+
+    def test_unmute_uses_refreshed_voice(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """unmute picks up voice written to config externally."""
+        import punt_vox.server as srv
+
+        srv._state.voice = "matilda"
+
+        write_field("voice", "roger", _refresh_config)
+
+        mock_client = MagicMock()
+        mock_client.synthesize.return_value = SynthesizeResult(request_id="r1")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        unmute(text="Hello")
+
+        call_kwargs = mock_client.synthesize.call_args[1]
+        assert call_kwargs["voice"] == "roger"
+
+    def test_unmute_preserves_inmemory_provider_when_config_empty(
+        self, _refresh_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Provider set via MCP tool survives refresh when config is empty."""
+        import punt_vox.server as srv
+
+        srv._state.provider = "openai"
+
+        # Config has no provider field
+        (_refresh_config / "vox.md").write_text("---\n---\n")
+
+        mock_client = MagicMock()
+        mock_client.synthesize.return_value = SynthesizeResult(request_id="r2")
+        monkeypatch.setattr("punt_vox.server._voxd_client", lambda: mock_client)
+
+        unmute(text="Hello")
+
+        call_kwargs = mock_client.synthesize.call_args[1]
+        assert call_kwargs["provider"] == "openai"

--- a/tests/test_server_partition.py
+++ b/tests/test_server_partition.py
@@ -28,11 +28,16 @@ from punt_vox.server import SessionState, notify, speak
 
 @pytest.fixture(autouse=True)
 def _fresh_session(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
-    """Reset server session state before every test."""
+    """Reset server session state before every test.
+
+    Stubs _find_config_dir to return None so _refresh_state_from_config
+    is a no-op -- partition tests control state via _set_state only.
+    """
     import punt_vox.server as srv
 
     monkeypatch.setattr(srv, "_state", SessionState())
     monkeypatch.setattr(srv, "_speak_explicit", False)
+    monkeypatch.setattr(srv, "_find_config_dir", lambda: None)
 
 
 def _set_state(


### PR DESCRIPTION
## Summary

- MCP server's `SessionState` went stale after CLI/hook writes to config files
- All 10 MCP tools now call `_refresh_state_from_config()` before acting
- Ephemeral fields (vibe, tags, signals, mode, notify, speak) always take config value
- Durable fields (voice, provider, model) only overwrite when config has a non-None value

Closes vox-duw.

## Test plan

- [x] 1428 tests pass (`make check` clean)
- [x] 13 new tests verify config refresh: external vibe write, notify write, voice persistence, stale signals cleared

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all MCP tool entrypoints and changes how in-memory session state is reconciled with on-disk config, which could subtly affect overrides and behavior if refresh logic is wrong. Changes are localized to the MCP server and covered by new refresh-focused tests.
> 
> **Overview**
> Fixes stale MCP `SessionState` by introducing `_refresh_state_from_config()` and calling it at the start of each MCP tool so CLI/hook config writes are reflected immediately.
> 
> Refresh semantics always sync vibe/notify/speak fields from config, while only overwriting `voice`/`provider`/`model` when config explicitly sets them (preserving in-tool overrides), and adds/updates tests to validate refresh behavior and tool integration; also documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79525a2c980d97e6623563a81eb15b63a006c94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->