### PR TITLE
docs: update RESUME.md with final session state

### DIFF
--- a/RESUME.md
+++ b/RESUME.md
@@ -1,12 +1,12 @@
 # OO Refactoring Status
 
-Last updated: 2026-05-14
-Branch: `refactor/phase-efg-coupling` (PR #264, open)
-Main: `2b47d7a` (PR #263 merged)
+Last updated: 2026-05-15
+Main: `a9dc3fc` (PR #265 merged)
+All PRs merged. No open branches.
 
 ## What Was Done
 
-### PRs Merged (main)
+### PRs Merged (10 total)
 
 | PR | Title | Key changes |
 |----|-------|-------------|
@@ -18,23 +18,8 @@ Main: `2b47d7a` (PR #263 merged)
 | #261 | SessionConfig + DoctorCheck | server.py refactor, doctor.py extraction |
 | #262 | SynthesisSpec + ConfigStore + music package | types_synthesis.py, config.py, voxd/music/ |
 | #263 | server dedup + playback/synthesis cleanup | `_process_segments`, SessionConfig encapsulation, `play_audio` decomposition, `_api_key_context` |
-
-### PR #264 (Open, Not Yet Merged)
-
-Contains everything from Phase E/F/G plus dead code removal:
-
-- **Coupling fixes**: VOX_DATA_DIR moved to paths.py, watcher routes
-  through VoxClientSync, doctor circular dep broken
-- **Phase E**: OutputFormatter, ApiKeyResolver, AudioMigration,
-  DaemonRestarter extracted from `__main__.py` and wired
-- **Phase F**: Provider voice caches moved to instance attributes
-  (elevenlabs, polly, say, espeak)
-- **Phase G**: client.py `__new__` conversion, chime.py wired into watcher
-- **Dead code**: 22 service shims, generate_audios protocol method,
-  dead keys/dirs/paths functions, voxd re-exports pruned
-- **Other agent's work included**: VoiceResolver, chunked synthesis,
-  convert.py, local_play.py, ProviderRegistry, applet removal,
-  suppression ratchet, oo_coupling.py tool
+| #264 | Phase E/F/G + coupling fixes + dead code | OutputFormatter, ApiKeyResolver, AudioMigration, DaemonRestarter, provider voice caches, chime wiring, 315 lines dead code removed, oo_coupling.py tool |
+| #265 | Tighten max-complexity to 10 | pyproject.toml, tool lint fixes, clean per-file-ignores |
 
 ## Current Metrics
 
@@ -45,9 +30,9 @@ Contains everything from Phase E/F/G plus dead code removal:
 | method_ratio | 0.66 | >= 0.80 | FAIL |
 | encapsulation_ratio | 1.00 | >= 1.0 | PASS |
 | avg_params | 1.11 | <= 4.0 | PASS |
-| max_complexity | 30 | <= 10 | FAIL |
-| avg_complexity | 2.69 | <= 5.0 | PASS |
-| module_size | 1232 | <= 300 | FAIL |
+| max_complexity | 21 | <= 10 | FAIL |
+| avg_complexity | 2.67 | <= 5.0 | PASS |
+| module_size | 1042 | <= 300 | FAIL |
 | classes_per_module | 5 | <= 3 | FAIL |
 | class_to_func_ratio | 0.59 | >= 0.5 | PASS |
 | init_violations | 1 | == 0 | FAIL |
@@ -58,7 +43,7 @@ Contains everything from Phase E/F/G plus dead code removal:
 
 | Metric | Value | Target | Status |
 |--------|-------|--------|--------|
-| efferent_coupling | 19 | <= 7 | FAIL |
+| efferent_coupling | 20 | <= 7 | FAIL |
 | public_names | 51 | <= 15 | FAIL |
 | circular_imports | 0 | == 0 | PASS |
 | max_lcom | 1.0 | <= 0.8 | FAIL |
@@ -68,7 +53,7 @@ Contains everything from Phase E/F/G plus dead code removal:
 
 - 74 source files in src/punt_vox/
 - 1533 tests passing
-- 24,639 total source lines
+- max-complexity threshold: 10 (tightened from 15)
 
 ## What Remains — v3 Execution Plan
 
@@ -110,15 +95,15 @@ Blocked on Phase 2.
 | 12 | audio_migration CC reduction | audio_migration.py | NOT STARTED |
 | 13 | server.py CC reduction | server.py | NOT STARTED |
 | 14 | `__main__.py` CC reduction | `__main__.py` | NOT STARTED |
-| 15 | chunked synthesis helper | providers/ | DONE (other agent) |
-| 16 | delete music_handlers.py | voxd/ | DONE (already deleted) |
+| 15 | chunked synthesis helper | providers/ | DONE |
+| 16 | delete music_handlers.py | voxd/ | DONE |
 | 17 | `__all__` on every module | all modules | NOT STARTED |
 
 ### Worst Files (where to focus)
 
 | File | Lines | Key failures |
 |------|-------|-------------|
-| `__main__.py` | 1232 | method_ratio 0.0, max_complexity 30, module_size |
+| `__main__.py` | 1042 | method_ratio 0.0, max_complexity 21, module_size |
 | `server.py` | ~800 | max_complexity 19 |
 | `voxd/synthesis.py` | 472 | module_size, method_ratio |
 | `watcher.py` | 397 | method_ratio 0.375, max_complexity |
@@ -127,26 +112,23 @@ Blocked on Phase 2.
 
 ## How to Resume
 
-1. **Merge PR #264 first.** It has 4 commits on `refactor/phase-efg-coupling`.
-   CI should be passing. Resolve review threads and merge.
-
-2. **Start Phase 1 (Steps 1–4).** These are small, independent value
-   object extractions. Each is 1–2 files. CacheKey is the smallest.
+1. **Start Phase 1 (Steps 1–4).** Small, independent value object
+   extractions. Each is 1–2 files. CacheKey is the smallest.
    All can run in parallel on separate branches.
 
-3. **Then Phase 2 (Steps 5–11).** Start with Signal/SignalLog (Step 5)
+2. **Then Phase 2 (Steps 5–11).** Start with Signal/SignalLog (Step 5)
    because Vibe (Step 6) depends on it. Voice (Step 7) and SynthesisSpec
    (Step 8) are independent. Utterance (Step 11) comes last — it depends
    on SynthesisSpec and Segment.
 
-4. **Then Phase 3 (Steps 12–17).** Extract Method on the remaining
+3. **Then Phase 3 (Steps 12–17).** Extract Method on the remaining
    complex functions. This is mechanical once the domain objects exist.
 
 ## Key Design Decisions
 
 - **Vibe is a data carrier only.** It does NOT absorb
-  apply_vibe_for_synthesis (that needs provider knowledge) or
-  resolve_tags (that belongs on SignalLog). See peer review in
+  `apply_vibe_for_synthesis` (that needs provider knowledge) or
+  `resolve_tags` (that belongs on SignalLog). See peer review in
   oo-execution-plan-v3.md.
 
 - **Utterance is the request, not the lifecycle.** Text, SynthesisSpec,
@@ -159,29 +141,33 @@ Blocked on Phase 2.
   directory boundaries.
 
 - **ProviderSelection dropped.** Subset of SynthesisSpec fields.
-  Expressed as SynthesisSpec.resolved() factory method instead.
+  Expressed as `SynthesisSpec.resolved()` factory method instead.
 
 - **HealthStatus dropped.** DaemonHealth already returns the data,
   consumers immediately serialize. No second consumer.
 
-- **ConfigField dropped.** Two frozensets + one function is simpler
+- **ConfigField dropped.** Two frozensets and one function is simpler
   than 9 dataclass instances with validator callables.
+
+- **max-complexity threshold is 10.** Tightened from 15. 9 files have
+  per-file-ignores for existing violations to be fixed in Phase 3.
 
 ## Reference Documents
 
 | Document | What it contains |
 |----------|-----------------|
-| `oo-execution-plan-v3.md` | Complete 17-step plan with peer review revisions |
-| `hidden-classes-analysis.md` | 7 hidden domain classes identified by rej |
-| `package-restructure-design.md` | Coupling analysis — why no new packages |
-| `oo-design-assessment-v2.md` | Initial per-file assessment |
-| `music-package-design.md` | Music subsystem redesign (done) |
-| `oo-refactoring-plan.md` | Original 52-step plan (Steps 0–17 done) |
+| `docs/oo-refactor/oo-execution-plan-v3.md` | Complete 17-step plan with peer review revisions |
+| `docs/oo-refactor/hidden-classes-analysis.md` | 7 hidden domain classes identified by rej |
+| `docs/oo-refactor/package-restructure-design.md` | Coupling analysis — why no new packages |
+| `docs/oo-refactor/oo-design-assessment-v2.md` | Initial per-file assessment |
+| `docs/oo-refactor/music-package-design.md` | Music subsystem redesign (done) |
+| `docs/oo-refactor/oo-refactoring-plan.md` | Original 52-step plan (Steps 0–17 done) |
 
 ## Coordination
 
-- **Other agent (tty252)**: Works on voxd/music/ files and provider
-  refactoring. Do not touch their files without biff coordination.
+- **Other agent (tty252)**: Worked on voxd/music/ files, provider
+  refactoring, VoiceResolver, chunked synthesis, suppression ratchet.
+  Coordinate via biff before editing shared files.
 - **Biff**: Always reply to messages. Use `/biff:read` to check inbox.
-- **Shared files**: voxd/`__init__`.py, voxd/daemon.py, pyproject.toml —
+- **Shared files**: `voxd/__init__.py`, `voxd/daemon.py`, `pyproject.toml` —
   coordinate via biff before editing.


### PR DESCRIPTION
Updates RESUME.md to reflect all 10 merged PRs, current metrics, and accurate v3 plan status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates to reflect merged PRs, refreshed metrics, and updated execution-plan status; no runtime code changes.
> 
> **Overview**
> Updates `RESUME.md` to reflect the refactor effort being fully merged (adds PRs `#264`/`#265`, removes the “open PR” section), and refreshes current OO/coupling metrics and thresholds.
> 
> Adjusts the v3 execution plan status/wording (e.g., marks chunked synthesis and `music_handlers.py` deletion as done), clarifies resume steps/design decisions, and normalizes doc links/coordination notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac0dfd9437c717ffdae14df000fab79cf9e34c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->