### PR TITLE
fix(voxd): re-export entrypoint so fresh installs can run voxd

### DIFF
--- a/src/punt_vox/voxd/__init__.py
+++ b/src/punt_vox/voxd/__init__.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from punt_vox.voxd.daemon import build_app
+from punt_vox.voxd.daemon import build_app, entrypoint
 from punt_vox.voxd.health import DaemonHealth
 from punt_vox.voxd.music.generator import TrackGenerator
 from punt_vox.voxd.playback import (
@@ -20,4 +20,5 @@ __all__ = [
     "TrackGenerator",
     "_music_player_command",
     "build_app",
+    "entrypoint",
 ]


### PR DESCRIPTION
## Summary

`pyproject.toml` declares the voxd entry point as `punt_vox.voxd:entrypoint`, but during the daemon decomposition (PR #262 and follow-ons) `voxd/__init__.py` stopped re-exporting `entrypoint`. A fresh \`make install\` of the working tree produces a voxd binary that crashes on startup:

\`\`\`
ImportError: cannot import name 'entrypoint' from 'punt_vox.voxd'
\`\`\`

The function is still defined in \`voxd/daemon.py\` and listed in that file's \`__all__\`; the package-level \`__init__.py\` just needs to re-export it.

## Why this wasn't caught

\`make check\` passes against source, but \`make install\` + \`voxd --port ...\` was never run in CI after the decomposition. The new CLAUDE.md inner-loop step 3 (\`make install\` + restart voxd) added in PR #271 is designed to catch exactly this.

## Verification

After the fix, four MCP \`unmute\` calls executed end-to-end through ElevenLabs (the auto-picked provider):

| # | Path | Result |
|---|------|--------|
| 1 | single-text | synth + play |
| 2 | same text again | cache-hit message |
| 3 | 3-sentence text | split + parallel synth |
| 4 | 2-segment multi-voice (roger + matilda) | both segments played |

## Test plan

- [ ] Fresh \`make install\` followed by \`voxd --port 8421\` starts without ImportError
- [ ] At least one \`mcp__plugin_vox_mic__unmute\` call from a hosting agent completes synthesis

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small packaging/API export fix that only affects how the `voxd` console script resolves its entry point at import time.
> 
> **Overview**
> Fixes fresh installs where the `voxd` console script (`punt_vox.voxd:entrypoint`) failed to import by re-exporting `entrypoint` from `punt_vox/voxd/__init__.py` (alongside `build_app`) and adding it to `__all__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ee53de461cb0d744017b173e4bee364415fff48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->