### PR TITLE
build(deps): move dev tools to PEP 735 [dependency-groups]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`/music next` command**: skip to a new generated track while the current one keeps playing (gapless). New `music_next` WebSocket message, MCP tool, and CLI subcommand. Closes vox-n3me.
 
+### Changed
+
+- **Dev tooling moved to PEP 735 `[dependency-groups]`**: `mypy`, `pyright`, `ruff`, `pytest`, `pytest-asyncio`, and `pytest-cov` now live in `[dependency-groups].dev` instead of `[project.optional-dependencies].dev`. A plain `uv sync` installs them automatically — `--extra dev` is no longer needed (and no longer accepted). `lux` remains an end-user extra. CI's `uv sync --frozen --all-extras` continues to install everything, since uv auto-includes the `dev` group unless `--no-dev` is passed.
+
 ### Fixed
 
 - **MCP server state went stale after CLI config writes**: the MCP server seeded `SessionState` from config at startup but never re-read. CLI commands like `vox vibe auto` wrote to `vox.local.md` but the MCP server retained the old values, causing `/music on` to report stale mood. All MCP tools now call `_refresh_state_from_config()` to re-read config before acting. Closes vox-duw.

--- a/README.md
+++ b/README.md
@@ -431,7 +431,8 @@ Provider API keys (`ELEVENLABS_API_KEY`, `OPENAI_API_KEY`, `AWS_*`) live in `~/.
 ## Development
 
 ```bash
-uv sync --all-extras    # Install dependencies
+uv sync                 # Install dev tools (auto via [dependency-groups].dev)
+uv sync --all-extras    # Also install the `lux` optional extra
 make check              # Run all quality gates
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ vox = "punt_vox.__main__:app"
 voxd = "punt_vox.voxd:entrypoint"
 
 [project.optional-dependencies]
+lux = ["punt-lux>=0.9.0"]
+
+[dependency-groups]
 dev = [
     "mypy>=1.18.1",
     "pyright>=1.1.400",
@@ -53,7 +56,6 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
 ]
-lux = ["punt-lux>=0.9.0"]
 
 [build-system]
 requires = ["uv_build>=0.9.14,<0.10.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -1151,6 +1151,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+lux = [
+    { name = "punt-lux" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pyright" },
@@ -1158,9 +1163,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
-]
-lux = [
-    { name = "punt-lux" },
 ]
 
 [package.metadata]
@@ -1171,19 +1173,23 @@ requires-dist = [
     { name = "botocore-stubs", specifier = ">=1.35.0" },
     { name = "elevenlabs", specifier = ">=2.0.0" },
     { name = "mcp", specifier = ">=1.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.1" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "punt-lux", marker = "extra == 'lux'", specifier = ">=0.9.0" },
     { name = "pydub", specifier = ">=0.25.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.400" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13.0" },
     { name = "typer", specifier = ">=0.24.1" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "lux"]
+provides-extras = ["lux"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.18.1" },
+    { name = "pyright", specifier = ">=1.1.400" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "ruff", specifier = ">=0.13.0" },
+]
 
 [[package]]
 name = "py-key-value-aio"


### PR DESCRIPTION
## Summary

- `uv sync` (no flags) wasn't installing mypy / pyright / ruff / pytest / pytest-asyncio / pytest-cov, so a fresh clone hit `Failed to spawn: pytest` on `make test`. The tools lived under `[project.optional-dependencies].dev`, which uv treats as end-user opt-in extras — not default dev tooling.
- Move them to a PEP 735 `[dependency-groups].dev` table. uv auto-includes dependency-groups on `uv sync` unless `--no-dev` is passed, so a plain `uv sync` now installs them. The `lux` entry stays in `[project.optional-dependencies]` — it's a genuine end-user extra (`pip install punt-vox[lux]`).
- CI is unaffected: both workflows already run `uv sync --frozen --all-extras`, which continues to install `lux` and now also picks up the dev group automatically. The `--extra dev` invocation is gone; uv errors loudly if anyone still passes it (verified via `--dry-run`).
- README's Development block now distinguishes the plain dev setup from the `lux`-included variant. CHANGELOG entry under `[Unreleased] / Changed`.
- Lockfile regenerated: revision 2 → 3, `dev` moved from `provides-extras` to `[package.dev-dependencies]` / `requires-dev`. Six dev tools resolved fresh (mypy → 2.1.0, pyright → 1.1.409, ruff → 0.15.12, pytest → 9.0.3, pytest-asyncio → 1.3.0, pytest-cov → 7.1.0); the newer mypy/pyright shed three previously-needed `pyright: ignore` comments — suppression ratchet decreased by 3.

## Test plan

- [x] Wipe `.venv`, run plain `uv sync`, confirm pytest/mypy/pyright/ruff present in `.venv/bin/`.
- [x] `make test` passes (1603 tests).
- [x] `make check` passes end-to-end (ruff, shellcheck, mypy, pyright, markdownlint, pytest, OO ratchet trivial-pass, coupling trivial-pass, suppression ratchet −3).
- [x] Simulated CI: `uv sync --all-extras` resolves `lux` extra on top of dev group.
- [x] `uv sync --extra dev` now fails loudly (`Extra dev is not defined`) — no silent install set degradation.
- [x] `feature-dev:code-reviewer` and `pr-review-toolkit:silent-failure-hunter` both clean after one fix cycle (README clarification).
- [ ] CI green (lint, test, docs workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes dependency metadata, developer setup docs, and the lockfile; runtime code paths are unaffected. Main risk is CI/local setup drift if tooling expects the old `dev` extra (`--extra dev`).
> 
> **Overview**
> **Moves dev tooling from extras to PEP 735 dependency groups.** `mypy`, `pyright`, `ruff`, `pytest`, `pytest-asyncio`, and `pytest-cov` are now declared under `[dependency-groups].dev` (with `lux` remaining an end-user `[project.optional-dependencies]` extra), so a plain `uv sync` installs dev tools without `--extra dev`.
> 
> Docs and metadata are updated to match (`README` dev setup instructions, `CHANGELOG` entry), and `uv.lock` is regenerated to reflect the new dev-dependency encoding (dev no longer listed as a provided extra; dev deps now live under `requires-dev`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5000e25dff2e0d28204d5acc8f1663315d28a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->