### PR TITLE
chore: release v4.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.9.0",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.0] - 2026-07-03
+
 ### Added
 
 - **`/music next` command**: skip to a new generated track while the current one keeps playing (gapless). New `music_next` WebSocket message, MCP tool, and CLI subcommand. Closes vox-n3me.

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.8.1"
+VERSION="4.9.0"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.8.1"
+version = "4.9.0"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.8.1"
+__version__ = "4.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -1135,7 +1135,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.8.1"
+version = "4.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
Release v4.9.0 — ships DES-038 clean LaunchAgent install (migration removed, install health check hardened). Version bump + CHANGELOG + plugin prod-name swap + install.sh SHA. Recut from a clean tree after the prior attempt (closed #277) swept untracked WIP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump and changelog; no runtime code paths change in this diff.
> 
> **Overview**
> **Release cut for v4.9.0** — no application logic changes in this diff; it pins the release across packaging and install surfaces.
> 
> Bumps **4.8.1 → 4.9.0** in `pyproject.toml`, `__init__.py`, `install.sh`, `uv.lock`, and `.claude-plugin/plugin.json`. The Claude plugin **`name` switches from `vox-dev` to `vox`** for marketplace/production installs.
> 
> **CHANGELOG** adds the **[4.9.0] - 2026-07-03** section documenting what ships in this tag (e.g. `/music next`, dev deps in PEP 735 `[dependency-groups]`, LaunchAgent install, MCP config refresh, music/hook fixes) — those behaviors land in other commits; this PR is the versioned release artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57dd7b53a0c2855a6815abe9870fb30e42c925a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->