### PR TITLE
fix(hooks): config-IO error handling, stdin-error logging, and config-resolution test isolation (vox-nb7i, vox-gsh4, vox-ygbl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hooks no longer crash on config I/O errors**: `handle_post_bash` and `handle_session_end` now guard their `read_config`/`write_field` calls — a corrupt or unwritable `vox.local.md` logs a warning and the hook returns cleanly instead of raising a non-zero exit that could block the Claude Code tool it gates. Closes vox-nb7i.
+- **Unexpected hook stdin read failures are now logged**: `_read_hook_input` logs any genuine `OSError` (with its errno) at WARNING instead of silently returning `{}`; the expected empty/closed-pipe case (no errno) stays quiet. Closes vox-gsh4.
+
 ## [4.9.0] - 2026-07-03
 
 ### Added

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -20,6 +20,7 @@ Events:
 from __future__ import annotations
 
 import dataclasses
+import errno
 import json
 import logging
 import os
@@ -74,9 +75,18 @@ def _hook_callback(ctx: typer.Context) -> None:  # pyright: ignore[reportUnusedF
         configure_logging(stderr_level="WARNING")
 
 
-# ---------------------------------------------------------------------------
 # Shared helpers
-# ---------------------------------------------------------------------------
+
+# Genuine read failures worth logging; an empty/closed pipe (errno None) stays quiet.
+_UNEXPECTED_ERRNOS: frozenset[int] = frozenset(
+    {errno.EBADF, errno.EIO, errno.EMFILE, errno.EINTR}
+)
+
+
+def _warn_unexpected_read_error(exc: OSError) -> None:
+    """Log a genuine stdin read failure; stay quiet on an empty pipe."""
+    if exc.errno in _UNEXPECTED_ERRNOS:
+        logger.warning("hook stdin read failed: errno %s (%s)", exc.errno, exc)
 
 
 def _read_hook_input() -> dict[str, object]:
@@ -101,7 +111,10 @@ def _read_hook_input() -> dict[str, object]:
         if not raw.strip():
             return {}
         data: object = json.loads(raw)
-    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+    except OSError as exc:
+        _warn_unexpected_read_error(exc)
+        return {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return {}
     if not isinstance(data, dict):
         return {}
@@ -113,9 +126,7 @@ def _emit(output: dict[str, object]) -> None:
     typer.echo(json.dumps(output))
 
 
-# ---------------------------------------------------------------------------
 # Repo name resolution from session cwd
-# ---------------------------------------------------------------------------
 
 
 def _repo_name_from_cwd(cwd: Path | None) -> str | None:
@@ -136,9 +147,7 @@ def _with_repo_name(config: VoxConfig, cwd: Path | None) -> VoxConfig:
     return config
 
 
-# ---------------------------------------------------------------------------
 # Voxd client helpers
-# ---------------------------------------------------------------------------
 
 
 def _make_client() -> VoxClientSync:
@@ -198,9 +207,7 @@ def _chime_via_voxd(signal: str, *, wait: bool = True) -> None:
         logger.warning("voxd not running, skipping chime")
 
 
-# ---------------------------------------------------------------------------
 # Stop handler — decision-block pattern
-# ---------------------------------------------------------------------------
 
 
 def handle_stop(
@@ -256,16 +263,14 @@ def handle_stop(
     return {"decision": "block", "reason": phrase}
 
 
-# ---------------------------------------------------------------------------
 # PostToolUse Bash — signal accumulator
-# ---------------------------------------------------------------------------
 
 _SIGNAL_PATTERNS: list[tuple[str, list[str]]] = [
     # Lint patterns before tests — "errors" appears in both contexts,
     # so the more specific "Found N error" and "0 errors" must match first.
     ("lint-fail", [r"Found [0-9]+ error"]),
     ("lint-pass", [r"All checks passed", r"0 errors"]),
-    ("tests-pass", [r"[0-9]+ passed", r"tests? ok", "\u2713.*passed"]),
+    ("tests-pass", [r"[0-9]+ passed", r"tests? ok", "✓.*passed"]),
     ("tests-fail", [r"FAILED", r"AssertionError", r"ERRORS?\b"]),
     ("merge-conflict", [r"CONFLICT"]),
     ("git-push-ok", [r"Everything up-to-date", r"->.*main"]),
@@ -308,14 +313,15 @@ def handle_post_bash(payload: BashPayload, config_dir: Path) -> None:
     if signal is None:
         return
 
-    log = SignalLog.deserialize(read_config(config_dir).vibe_signals or "")
-    log.append(Signal.now(signal))
-    write_field("vibe_signals", log.serialize(), config_dir)
+    try:
+        log = SignalLog.deserialize(read_config(config_dir).vibe_signals or "")
+        log.append(Signal.now(signal))
+        write_field("vibe_signals", log.serialize(), config_dir)
+    except (OSError, ValueError) as exc:
+        logger.warning("post-bash: cannot save vibe signal in %s: %s", config_dir, exc)
 
 
-# ---------------------------------------------------------------------------
 # Notification — permission/idle prompt audio alerts
-# ---------------------------------------------------------------------------
 
 
 def _pick_notification_phrase(
@@ -366,9 +372,7 @@ def handle_notification(payload: NotificationPayload, config: VoxConfig) -> None
     _speak_via_voxd(text, config)
 
 
-# ---------------------------------------------------------------------------
 # Shared speech helper — used by continuous mode hooks
-# ---------------------------------------------------------------------------
 
 
 def _speak_phrase(
@@ -394,9 +398,7 @@ def _speak_phrase(
     _speak_via_voxd(text, config)
 
 
-# ---------------------------------------------------------------------------
 # PreCompact — playful 'be right back' before context compaction
-# ---------------------------------------------------------------------------
 
 
 def handle_pre_compact(config: VoxConfig) -> None:
@@ -413,9 +415,7 @@ def handle_pre_compact(config: VoxConfig) -> None:
     _speak_phrase(PRE_COMPACT_PHRASES, config, chime_signal="compact")
 
 
-# ---------------------------------------------------------------------------
 # UserPromptSubmit — acknowledgment in continuous mode
-# ---------------------------------------------------------------------------
 
 
 def handle_user_prompt_submit(config: VoxConfig) -> None:
@@ -435,9 +435,7 @@ def handle_user_prompt_submit(config: VoxConfig) -> None:
     _speak_phrase(ACKNOWLEDGE_PHRASES, config, chime_signal="acknowledge")
 
 
-# ---------------------------------------------------------------------------
 # SubagentStart / SubagentStop — continuous mode announcements
-# ---------------------------------------------------------------------------
 
 
 def handle_subagent_start(config: VoxConfig) -> None:
@@ -472,9 +470,15 @@ def handle_subagent_stop(config: VoxConfig) -> None:
     _speak_phrase(SUBAGENT_STOP_PHRASES, config, chime_signal="subagent")
 
 
-# ---------------------------------------------------------------------------
 # SessionEnd — farewell speech
-# ---------------------------------------------------------------------------
+
+
+def _clear_vibe_signals(config_dir: Path) -> None:
+    """Reset accumulated vibe signals, warning instead of raising on failure."""
+    try:
+        write_field("vibe_signals", "", config_dir)
+    except (OSError, ValueError) as exc:
+        logger.warning("session-end: cannot clear signals in %s: %s", config_dir, exc)
 
 
 def handle_session_end(config: VoxConfig, config_dir: Path) -> None:
@@ -493,12 +497,10 @@ def handle_session_end(config: VoxConfig, config_dir: Path) -> None:
 
     # Clean slate for next session
     if config.vibe_signals:
-        write_field("vibe_signals", "", config_dir)
+        _clear_vibe_signals(config_dir)
 
 
-# ---------------------------------------------------------------------------
 # CLI commands
-# ---------------------------------------------------------------------------
 
 
 def _resolve_continuous_config() -> tuple[VoxConfig, Path] | None:

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -20,7 +20,6 @@ Events:
 from __future__ import annotations
 
 import dataclasses
-import errno
 import json
 import logging
 import os
@@ -77,15 +76,15 @@ def _hook_callback(ctx: typer.Context) -> None:  # pyright: ignore[reportUnusedF
 
 # Shared helpers
 
-# Genuine read failures worth logging; an empty/closed pipe (errno None) stays quiet.
-_UNEXPECTED_ERRNOS: frozenset[int] = frozenset(
-    {errno.EBADF, errno.EIO, errno.EMFILE, errno.EINTR}
-)
-
 
 def _warn_unexpected_read_error(exc: OSError) -> None:
-    """Log a genuine stdin read failure; stay quiet on an empty pipe."""
-    if exc.errno in _UNEXPECTED_ERRNOS:
+    """Log a genuine stdin read failure; stay quiet on a non-fd stdin.
+
+    A real empty or closed pipe returns ``b""`` and never raises, so any
+    ``OSError`` carrying an errno is a genuine failure worth logging.
+    ``errno`` is None only for a non-fd stdin (e.g. ``StringIO`` in tests).
+    """
+    if exc.errno is not None:
         logger.warning("hook stdin read failed: errno %s (%s)", exc.errno, exc)
 
 
@@ -477,7 +476,7 @@ def _clear_vibe_signals(config_dir: Path) -> None:
     """Reset accumulated vibe signals, warning instead of raising on failure."""
     try:
         write_field("vibe_signals", "", config_dir)
-    except (OSError, ValueError) as exc:
+    except OSError as exc:
         logger.warning("session-end: cannot clear signals in %s: %s", config_dir, exc)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import io
+import shutil
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -11,6 +14,7 @@ import pytest
 from pydub import AudioSegment
 
 from punt_vox.core import TTSClient
+from punt_vox.dirs import find_config_dir
 from punt_vox.providers.elevenlabs import ElevenLabsProvider
 from punt_vox.providers.espeak import EspeakProvider, EspeakVoiceConfig
 from punt_vox.providers.openai import OpenAIProvider
@@ -30,6 +34,39 @@ def tmp_output_dir(tmp_path: Path) -> Path:
     out = tmp_path / "output"
     out.mkdir()
     return out
+
+
+def _repo_free_base() -> Path:
+    """Return a temp base directory with no ``.punt-labs/vox`` ancestor.
+
+    On dev boxes ``TMPDIR`` points at the repo's ``.tmp/`` (see .envrc),
+    which sits inside a real ``.punt-labs/vox`` config.  ``find_config_dir``
+    walks up into that ambient config, so tests asserting "no config
+    resolves" break.  Climb above any config found from the platform temp
+    root so the search starts clean — reproducing CI, where ``TMPDIR`` is
+    outside the repo.
+    """
+    base = Path(tempfile.gettempdir()).resolve()
+    while (found := find_config_dir(base)) is not None:
+        # found is ``<repo>/.punt-labs/vox``; step above <repo>.
+        base = found.parent.parent.parent
+    return base
+
+
+@pytest.fixture
+def no_config_dir(tmp_path: Path) -> Iterator[Path]:
+    """Yield a temp dir guaranteed to have no ``.punt-labs/vox`` ancestor.
+
+    ``tmp_path`` is unusable for config-resolution tests when ``TMPDIR``
+    lives inside the repo, because the upward walk reaches the real
+    config.  This fixture roots the tree above any such config and cleans
+    it up afterward.
+    """
+    path = Path(tempfile.mkdtemp(dir=_repo_free_base()))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def _generate_valid_mp3_bytes() -> bytes:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def _repo_free_base() -> Path:
 
 
 @pytest.fixture
-def no_config_dir(tmp_path: Path) -> Iterator[Path]:
+def no_config_dir() -> Iterator[Path]:
     """Yield a temp dir guaranteed to have no ``.punt-labs/vox`` ancestor.
 
     ``tmp_path`` is unusable for config-resolution tests when ``TMPDIR``

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -129,15 +129,16 @@ class TestFindConfigDir:
         result = find_config_dir(child)
         assert result == child_config
 
-    def test_legacy_config_md_resolves_none(self, tmp_path: Path) -> None:
+    def test_legacy_config_md_resolves_none(self, no_config_dir: Path) -> None:
         # A dir with only legacy config.md (no vox.md/vox.local.md) resolves None.
-        legacy_dir = tmp_path / ".punt-labs" / "vox"
+        # no_config_dir has no ambient .punt-labs/vox above it, so the walk
+        # cannot leak into the real repo config (fails under TMPDIR=.tmp).
+        legacy_dir = no_config_dir / ".punt-labs" / "vox"
         legacy_dir.mkdir(parents=True)
         (legacy_dir / "config.md").write_text("---\nnotify: y\n---\n")
-        isolated = tmp_path / "leaf"
+        isolated = no_config_dir / "leaf"
         isolated.mkdir()
-        with patch("punt_vox.dirs.Path.cwd", return_value=isolated):
-            result = find_config_dir(isolated)
+        result = find_config_dir(isolated)
         assert result is None
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import errno
+import logging
 import os
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, call, patch
 
 from punt_vox.config import VoxConfig
@@ -37,6 +40,9 @@ from punt_vox.quips import (
     SUBAGENT_STOP_PHRASES,
 )
 from punt_vox.signal import SignalLog
+
+if TYPE_CHECKING:
+    import pytest
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -388,6 +394,34 @@ class TestHandlePostBash:
         else:
             raise AssertionError("vibe_signals not found in config")
 
+    def test_write_failure_warns_and_returns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A corrupt/unwritable vox.local.md must not crash the PostToolUse hook.
+        config_dir = tmp_path
+        (config_dir / "vox.md").write_text('---\nnotify: "y"\n---\n')
+        payload = BashPayload(exit_code=0, stdout="5 passed in 1.2s")
+        with (
+            patch("punt_vox.hooks.write_field", side_effect=OSError("read-only fs")),
+            caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
+        ):
+            handle_post_bash(payload, config_dir)  # must not raise
+        assert any("post-bash" in r.getMessage() for r in caplog.records)
+
+    def test_read_failure_warns_and_returns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # A malformed config that raises on read is swallowed with a warning.
+        config_dir = tmp_path
+        (config_dir / "vox.md").write_text('---\nnotify: "y"\n---\n')
+        payload = BashPayload(exit_code=0, stdout="5 passed in 1.2s")
+        with (
+            patch("punt_vox.hooks.read_config", side_effect=ValueError("bad yaml")),
+            caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
+        ):
+            handle_post_bash(payload, config_dir)  # must not raise
+        assert any("post-bash" in r.getMessage() for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # handle_pre_compact tests
@@ -658,6 +692,19 @@ class TestHandleSessionEnd:
         handle_session_end(config, Path("/fake/.punt-labs/vox"))
         mock_write.assert_not_called()
 
+    @patch("punt_vox.hooks._speak_via_voxd")
+    def test_clear_failure_warns_and_returns(
+        self, _mock_speak: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # An unwritable vox.local.md must not crash the Stop/SessionEnd hook.
+        config = _make_config(notify="y", speak="y", vibe_signals="tests-pass@12:00")
+        with (
+            patch("punt_vox.hooks.write_field", side_effect=OSError("read-only fs")),
+            caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
+        ):
+            handle_session_end(config, Path("/fake/.punt-labs/vox"))  # must not raise
+        assert any("session-end" in r.getMessage() for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # Quip pool size tests
@@ -867,6 +914,67 @@ class TestReadHookInput:
         finally:
             r.close()
         assert result == {}
+
+    def test_unexpected_oserror_logs_errno(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A genuine read failure (EIO) logs the errno at WARNING, returns {}."""
+        r_fd, w_fd = os.pipe()
+        os.write(w_fd, b'{"x": 1}')  # ensure select() reports readable
+        r = os.fdopen(r_fd, "r")
+        try:
+            with (
+                patch("punt_vox.hooks.os.read", side_effect=OSError(errno.EIO, "io")),
+                caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
+                patch.object(sys, "stdin", r),
+            ):
+                result = _read_hook_input()
+        finally:
+            r.close()
+            os.close(w_fd)
+        assert result == {}
+        assert any(
+            str(errno.EIO) in rec.getMessage() and "errno" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_oserror_without_errno_stays_quiet(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An OSError with no errno (e.g. empty pipe) returns {} without warning."""
+        r_fd, w_fd = os.pipe()
+        os.write(w_fd, b'{"x": 1}')
+        r = os.fdopen(r_fd, "r")
+        try:
+            with (
+                patch("punt_vox.hooks.os.read", side_effect=OSError()),
+                caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
+                patch.object(sys, "stdin", r),
+            ):
+                result = _read_hook_input()
+        finally:
+            r.close()
+            os.close(w_fd)
+        assert result == {}
+        assert not [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
+
+    def test_closed_empty_stdin_stays_quiet(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """EOF with no data returns {} quietly — the expected empty path."""
+        r_fd, w_fd = os.pipe()
+        os.close(w_fd)
+        r = os.fdopen(r_fd, "r")
+        try:
+            with (
+                caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
+                patch.object(sys, "stdin", r),
+            ):
+                result = _read_hook_input()
+        finally:
+            r.close()
+        assert result == {}
+        assert not [rec for rec in caplog.records if rec.levelno >= logging.WARNING]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -992,10 +992,12 @@ class TestCommandsResolveFromCwd:
     @patch("punt_vox.hooks._speak_via_voxd")
     @patch("punt_vox.hooks._chime_via_voxd")
     def test_notification_cmd_silent_when_no_config(
-        self, mock_chime: MagicMock, mock_speak: MagicMock, tmp_path: Path
+        self, mock_chime: MagicMock, mock_speak: MagicMock, no_config_dir: Path
     ) -> None:
         # cwd points at a directory with no .punt-labs/vox config — silent.
-        bare = tmp_path / "punt-labs"
+        # no_config_dir has no ambient config above it, so find_config_dir
+        # cannot leak into the real repo config (fails under TMPDIR=.tmp).
+        bare = no_config_dir / "punt-labs"
         bare.mkdir()
         payload = {
             "cwd": str(bare),
@@ -1074,11 +1076,12 @@ class TestCommandsResolveFromCwd:
         text = mock_speak.call_args[0][0]
         assert text.startswith("vox. ")
 
-    def test_stop_cmd_silent_when_cwd_missing(self, tmp_path: Path) -> None:
+    def test_stop_cmd_silent_when_cwd_missing(self, no_config_dir: Path) -> None:
         # No cwd on the payload → no new pwd-fallback suppression added;
         # resolution falls through to find_config_dir(None). In an isolated
-        # dir with no config, the hook stays silent.
-        isolated = tmp_path / "isolated"
+        # dir with no config above it, the hook stays silent (no ambient
+        # repo config leaks in under TMPDIR=.tmp).
+        isolated = no_config_dir / "isolated"
         isolated.mkdir()
         payload = {"stop_hook_active": False}
         with (

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -918,13 +918,16 @@ class TestReadHookInput:
     def test_unexpected_oserror_logs_errno(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A genuine read failure (EIO) logs the errno at WARNING, returns {}."""
+        """Any errno logs at WARNING — even ENFILE, outside the old allow-list."""
         r_fd, w_fd = os.pipe()
         os.write(w_fd, b'{"x": 1}')  # ensure select() reports readable
         r = os.fdopen(r_fd, "r")
         try:
             with (
-                patch("punt_vox.hooks.os.read", side_effect=OSError(errno.EIO, "io")),
+                patch(
+                    "punt_vox.hooks.os.read",
+                    side_effect=OSError(errno.ENFILE, "too many open files"),
+                ),
                 caplog.at_level(logging.WARNING, logger="punt_vox.hooks"),
                 patch.object(sys, "stdin", r),
             ):
@@ -934,7 +937,7 @@ class TestReadHookInput:
             os.close(w_fd)
         assert result == {}
         assert any(
-            str(errno.EIO) in rec.getMessage() and "errno" in rec.getMessage()
+            str(errno.ENFILE) in rec.getMessage() and "errno" in rec.getMessage()
             for rec in caplog.records
         )
 


### PR DESCRIPTION
## Summary

Three small robustness fixes in vox's hook/config layer, shipping together (same area): hook error-handling hardening and a config-resolution test-isolation fix.

## The three fixes

- **vox-ygbl (P2)** — `tests/test_dirs.py::test_legacy_config_md_resolves_none` and `tests/test_hooks.py::test_notification_cmd_silent_when_no_config` failed on dev machines where `TMPDIR=.tmp/` (via `.envrc`) puts pytest's tmp dir *inside* the repo — `find_config_dir()` then walks up into the real `.punt-labs/vox` config instead of returning `None`. They pass in CI (TMPDIR outside the repo). Fixed with a `no_config_dir` conftest fixture that roots the temp tree *above* any ambient config; `find_config_dir()` itself is unchanged. Also hardened `test_stop_cmd_silent_when_cwd_missing`, which carried the same latent leak. **This is the papercut that broke `make check` and the v4.9.0 release gate throughout the prior session.**

- **vox-nb7i (P3)** — `handle_post_bash` and `handle_session_end` called `read_config`/`write_field` unguarded; a corrupt or unwritable `vox.local.md` would crash the PostToolUse/Stop hook and could block the tool response. Now guarded with `try/except (OSError, ValueError)` → `logger.warning` + graceful return. `handle_session_end`'s clear is extracted to `_clear_vibe_signals`.

- **vox-gsh4 (P3)** — `_read_hook_input` swallowed `OSError` silently. Now logs any genuine read failure (`errno is not None`) at WARNING with the errno; the only legitimately-quiet case (non-fd/empty stdin, `errno is None`) stays quiet. Still returns `{}`.

## Verification

- **1690 tests pass** (6 new error-path tests with `caplog` assertions) under **both** `TMPDIR=.tmp` (inside repo) and `TMPDIR=/tmp/x` (outside) — the ygbl fix holds regardless of TMPDIR.
- `ruff`, `mypy --strict`, `pyright` clean.
- **check-oo passes** — hooks.py `module_size` 468→464 and `avg_params` 1.07→1.06 both IMPROVED, no regressions.
- Deny-list repro: `OSError(ENFILE)` / `OSError(ECONNRESET)` log the errno; `OSError()` with `errno=None` stays quiet.

## Review

Local review clean after one fix round:
- `silent-failure-hunter` — caught the gsh4 errno *allow-list* (missed genuine failures with un-listed errnos); fixed to a deny-list (`errno is not None`).
- `code-reviewer` — caught an unused `tmp_path` param on the `no_config_dir` fixture; removed. Also removed a dead `ValueError` catch in `_clear_vibe_signals`.

## Notes for reviewers

- Client/hook layer only — no daemon/provider/server changes. Hooks log via `logger`, never `print`.
- OO baseline is unchanged in this PR: hooks.py improved within the existing baseline. Separate follow-up filed for pre-existing `installer.py` baseline drift (from #276) and the ethos submodule bump.

Closes vox-ygbl, vox-nb7i, vox-gsh4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive hook-layer changes only—warnings plus clean exit—plus test fixtures; no daemon, auth, or production config semantics changes.
> 
> **Overview**
> Hardens Claude Code hook handlers so **config read/write problems no longer take down PostToolUse or SessionEnd** with a non-zero exit. **`handle_post_bash`** wraps `read_config` / `write_field` in `try/except (OSError, ValueError)`, logs a warning, and returns; **`handle_session_end`** clears `vibe_signals` through new **`_clear_vibe_signals`** with the same pattern for write failures.
> 
> **`_read_hook_input`** now treats **`OSError` separately**: any error with an **`errno`** is logged at WARNING via **`_warn_unexpected_read_error`**; empty/closed stdin and `errno is None` still return `{}` quietly.
> 
> **Test isolation (vox-ygbl):** adds **`no_config_dir`** in conftest so temp trees start above any real `.punt-labs/vox` when `TMPDIR` lives inside the repo (e.g. `.tmp/`). **`test_dirs`** and **`test_hooks`** “no config” cases use it so `find_config_dir` cannot walk into the ambient repo config.
> 
> Changelog documents the hook fixes; six new **`caplog`** tests cover the error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30566137fef9925890e4e3869d4ad747393b12bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->