### PR TITLE
chore: release v4.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.10.0",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.10.0] - 2026-07-05
+
 ### Added
 
 - **Background music is now a self-driving playlist**: `/music on` plays the first track the moment it is ready, then generates the rest of the pool (up to 12) in the **background with no commands**, and **auto-advances** to a different track as each one ends. Once the pool has 12 it stops generating and **rotates** (shuffle, never back-to-back) forever at zero credits. A vibe/style change finishes the current song, then switches to that vibe's pool. This replaces bas7's manual-skip rotation, which only advanced on `/music next` and otherwise looped a single track. Internally the loop was rebuilt (`MusicLoop` auto-advance + a scheduler-owned cancellable `PoolFiller` + a `Playlist` selection unit), and all disk access now sits behind an injected `TrackStore` protocol (filesystem impl in production, in-memory fake in tests). Behavior is proven by loop-level tests that drive the real playback loop. Closes vox-1rxb (rebuild of #291/bas7).

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="4.9.0"
+VERSION="4.10.0"
 BINARY="vox"
 
 # --- Step 1: Prerequisites ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "4.9.0"
+version = "4.10.0"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/src/punt_vox/__init__.py
+++ b/src/punt_vox/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "4.9.0"
+__version__ = "4.10.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1145,7 +1145,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "4.9.0"
+version = "4.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical version and metadata updates with no runtime code changes in the PR diff.
> 
> **Overview**
> **Release v4.10.0** — version strings move from `4.9.0` to `4.10.0` in `pyproject.toml`, `src/punt_vox/__init__.py`, `install.sh`, `uv.lock`, and `.claude-plugin/plugin.json` (plugin id **`vox-dev` → `vox`**).
> 
> `CHANGELOG.md` gains a dated **`[4.10.0] - 2026-07-05`** heading; the listed features and fixes (self-driving background music, TTS cache observability, ethos vendoring, health-check refactor, vibe persistence, daemon uninstall, hooks, etc.) are documented there but **not** part of this diff — this PR is the version/changelog cut only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aee39b4421691450349d325ff24a26b817900d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->