### PR TITLE
test: make suite hermetic vs the real vox config — fixes the real 'always sad' vibe revert (vox-73m5 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The test suite no longer overwrites the developer's real vox config**: `DEFAULT_CONFIG_DIR` is a *relative* path (`.punt-labs/vox`) and `find_config_dir()` walks up from the cwd, so tests that drove a config-writing path without redirecting the dir — the `vibe` MCP tool, the `/vibe` CLI command — clobbered the live `.punt-labs/vox/vox.local.md` on every `make test`, silently resetting the session vibe (the "always reverts to sad" symptom, since fixtures wrote `vibe: "sad"` / empty into it). An autouse `hermetic_config` fixture now redirects every *ambient* config resolution — `ConfigStore(None)`, the module-level `read_config`/`write_field`/`write_fields` wrappers, `server._find_config_dir()`, and the `__main__` CLI commands — to a per-test tmp dir, so no test can read or write the real config through the default path. A `test_suite_does_not_touch_real_config` regression guard asserts the redirect stays active and that the real config bytes are untouched after driving the default read/write paths.
+
 ## [4.10.0] - 2026-07-05
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,63 @@ def tmp_output_dir(tmp_path: Path) -> Path:
     return out
 
 
+# ---------------------------------------------------------------------------
+# Config hermeticity — belt-and-suspenders isolation from the real vox config
+# ---------------------------------------------------------------------------
+#
+# ``DEFAULT_CONFIG_DIR`` is a *relative* path (``.punt-labs/vox``) and
+# ``find_config_dir()`` walks up from the cwd.  Run from the repo root, both
+# resolve to the developer's *real* ``.punt-labs/vox/``.  Any test that drives a
+# config-writing path without redirecting the dir -- the ``vibe`` MCP tool, the
+# ``/vibe`` CLI command -- would clobber the live config (vox-73m5: the session
+# vibe "always reverts to sad" because test fixtures wrote into it).  The
+# autouse fixture below makes every *ambient* config resolution land in a
+# per-test tmp dir, so no test can read or write the real config through the
+# default path.
+
+
+@pytest.fixture(autouse=True)
+def hermetic_config(  # pyright: ignore[reportUnusedFunction]
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """Redirect every default vox-config resolution to a per-test tmp dir.
+
+    Covers all three ways production code reaches the config with no explicit
+    directory:
+
+    * ``ConfigStore(None)`` and the module-level ``read_config`` /
+      ``read_field`` / ``write_field`` / ``write_fields`` wrappers, which fall
+      back to ``config.DEFAULT_CONFIG_DIR``;
+    * ``server._find_config_dir()``, which re-imports ``find_config_dir`` from
+      ``dirs`` at call time;
+    * the ``/vibe`` / ``notify`` / ``voice`` CLI commands, which read
+      ``__main__.find_config_dir``.
+
+    ``hooks.find_config_dir`` is *not* redirected: hooks always pass an explicit
+    ``cwd``, so they resolve relative to isolated payload directories and never
+    touch the real config.  Tests that exercise config-resolution walking
+    (``test_dirs``, ``test_config``) call ``find_config_dir`` through their own
+    module-level import, a binding captured before this patch, so their explicit
+    ``start=`` behaviour is preserved.
+
+    The redirect dir is minted from ``tmp_path_factory`` rather than the test's
+    own ``tmp_path`` so it never appears when a test enumerates ``tmp_path`` or
+    rebuilds ``tmp_path/.punt-labs/vox`` itself.
+    """
+    config_dir = tmp_path_factory.mktemp("vox-config") / ".punt-labs" / "vox"
+    config_dir.mkdir(parents=True)
+
+    def _resolve(_start: Path | None = None) -> Path:
+        """Stand-in for ``find_config_dir`` that never escapes the tmp dir."""
+        return config_dir
+
+    monkeypatch.setattr("punt_vox.config.DEFAULT_CONFIG_DIR", config_dir)
+    monkeypatch.setattr("punt_vox.dirs.DEFAULT_CONFIG_DIR", config_dir)
+    monkeypatch.setattr("punt_vox.dirs.find_config_dir", _resolve)
+    monkeypatch.setattr("punt_vox.__main__.find_config_dir", _resolve)
+    return config_dir
+
+
 def _repo_free_base() -> Path:
     """Return a temp base directory with no ``.punt-labs/vox`` ancestor.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -935,31 +935,37 @@ class TestVibeCommand:
         import punt_vox.config as cfg
 
         monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["vibe", "excited"])
         assert result.exit_code == 0
         assert "excited" in result.output
+        assert 'vibe: "excited"' in (tmp_path / "vox.local.md").read_text()
 
     def test_vibe_auto(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
         monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["vibe", "auto"])
         assert result.exit_code == 0
         assert "auto" in result.output
+        assert 'vibe_mode: "auto"' in (tmp_path / "vox.local.md").read_text()
 
     def test_vibe_off(self, tmp_path: Path, monkeypatch: MagicMock) -> None:
         import punt_vox.config as cfg
 
         monkeypatch.setattr(cfg, "DEFAULT_CONFIG_DIR", tmp_path)
+        monkeypatch.setattr("punt_vox.__main__.find_config_dir", lambda: tmp_path)
 
         runner = CliRunner()
         result = runner.invoke(app, ["vibe", "off"])
         assert result.exit_code == 0
         assert "off" in result.output
+        assert 'vibe_mode: "off"' in (tmp_path / "vox.local.md").read_text()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ from punt_vox.config import (
     write_field,
     write_fields,
 )
-from punt_vox.dirs import DEFAULT_CONFIG_DIR, find_config_dir
+from punt_vox.dirs import find_config_dir
 
 # -- Helpers ---------------------------------------------------------------
 
@@ -113,8 +113,21 @@ class TestReadConfig:
         cfg = read_config(config_dir=config_dir)
         assert cfg.repo_name == "my-repo"
 
-    def test_repo_name_none_when_config_dir_none(self) -> None:
-        """repo_name is None when no config_dir is provided."""
+    def test_repo_name_none_when_config_dir_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """repo_name is None for the shallow default (relative) config dir.
+
+        The autouse ``hermetic_config`` fixture points ``DEFAULT_CONFIG_DIR`` at
+        a deep tmp dir, so pin the *production* default (the relative
+        ``.punt-labs/vox``) here and ``chdir`` somewhere with no real config to
+        keep the read hermetic while still exercising the None path.
+        """
+        import punt_vox.config as config_mod
+
+        monkeypatch.chdir(tmp_path)
+        relative_default = Path(".punt-labs") / "vox"
+        monkeypatch.setattr(config_mod, "DEFAULT_CONFIG_DIR", relative_default)
         cfg = read_config(config_dir=None)
         assert cfg.repo_name is None
 
@@ -372,8 +385,15 @@ class TestConfigStoreConstruction:
     """ConfigStore construction and dir property."""
 
     def test_default_dir(self) -> None:
+        """A dir-less ConfigStore adopts the module's current DEFAULT_CONFIG_DIR.
+
+        Read the live attribute rather than the import-time binding so the
+        invariant holds under the autouse ``hermetic_config`` redirect.
+        """
+        import punt_vox.config as config_mod
+
         store = ConfigStore()
-        assert store.dir == DEFAULT_CONFIG_DIR
+        assert store.dir == config_mod.DEFAULT_CONFIG_DIR
 
     def test_custom_dir(self, tmp_path: Path) -> None:
         store = ConfigStore(tmp_path)

--- a/tests/test_config_isolation.py
+++ b/tests/test_config_isolation.py
@@ -1,0 +1,61 @@
+"""Regression guards proving the suite never touches the real vox config.
+
+The developer's live ``.punt-labs/vox/vox.local.md`` was being overwritten
+whenever anyone ran ``make test``: fixtures drove the ``vibe`` MCP tool and the
+``/vibe`` CLI command through config-writing paths that resolved
+``DEFAULT_CONFIG_DIR`` (a *relative* path) against the repo root.  The autouse
+``hermetic_config`` fixture in ``conftest.py`` now redirects every ambient
+resolution to a per-test tmp dir.  These tests fail loudly if that redirect ever
+regresses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import punt_vox.config as config_mod
+import punt_vox.dirs as dirs_mod
+from punt_vox.config import read_config, write_field, write_fields
+from punt_vox.dirs import find_repo_root
+
+
+def _real_config_dir() -> Path:
+    """Return the repo's real ``.punt-labs/vox`` dir, bypassing the redirect."""
+    repo_root = find_repo_root()
+    assert repo_root is not None, "tests must run inside the vox git repo"
+    return repo_root / ".punt-labs" / "vox"
+
+
+class TestSuiteDoesNotTouchRealConfig:
+    """The autouse redirect must be active and total for every test."""
+
+    def test_redirect_is_active(self, hermetic_config: Path) -> None:
+        """Default resolution points at the tmp dir, not the relative default."""
+        assert hermetic_config == config_mod.DEFAULT_CONFIG_DIR
+        assert hermetic_config == dirs_mod.DEFAULT_CONFIG_DIR
+        assert hermetic_config == dirs_mod.find_config_dir()
+        assert hermetic_config != Path(".punt-labs") / "vox"
+
+    def test_default_write_lands_in_tmp(self, hermetic_config: Path) -> None:
+        """A dir-less write reaches the tmp config, not the repo config."""
+        write_field("vibe", "SENTINEL")
+        write_fields({"vibe_mode": "manual", "vibe_tags": "[excited]"})
+
+        local = hermetic_config / "vox.local.md"
+        assert local.exists()
+        text = local.read_text()
+        assert 'vibe: "SENTINEL"' in text
+        assert 'vibe_mode: "manual"' in text
+
+    def test_real_config_untouched_by_default_paths(self) -> None:
+        """Driving default read/write paths never creates or edits the real config."""
+        real_local = _real_config_dir() / "vox.local.md"
+        before = real_local.read_bytes() if real_local.exists() else None
+
+        # Exercise the exact paths that leaked: dir-less read + dir-less writes.
+        read_config()
+        write_field("vibe", "leak-check")
+        write_fields({"vibe": "leak-check-2", "vibe_mode": "off"})
+
+        after = real_local.read_bytes() if real_local.exists() else None
+        assert after == before, "default config path wrote to the real vox config"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -663,6 +663,17 @@ class TestRecord:
 class TestVibeTool:
     """Tests for the vibe MCP tool."""
 
+    @pytest.fixture(autouse=True)
+    def _isolated(self, _patch_config: Path) -> Path:
+        """Pin the vibe tool's config writes to an isolated tmp dir.
+
+        The autouse ``hermetic_config`` fixture already redirects the default
+        path, but ``vibe`` writes through ``_find_config_dir()`` -> the config
+        default; requesting ``_patch_config`` states that dependency explicitly
+        rather than leaning on ambient redirect state.
+        """
+        return _patch_config
+
     def test_set_mood(self) -> None:
         import punt_vox.server as srv
 


### PR DESCRIPTION
## The actual 'always sad' bug

The session vibe kept reverting to `sad`/`off` no matter what. vox-73m5 (#294) fixed a real git-resurrection path but not this — the **dominant** cause: **the test suite writes its fixtures into the developer's live config on every `make test`.**

`DEFAULT_CONFIG_DIR = ".punt-labs/vox"` is a relative path. Two tests exercised config-writing code without isolating the dir, so writes landed in the real repo config when the suite runs from the repo root:
- `test_server.py` (vibe MCP tool → `write_fields(updates, None)` → `ConfigStore(None)`) wrote `vibe: "sad"`.
- `test_cli.py` (`/vibe` command → `find_config_dir() or DEFAULT_CONFIG_DIR`) wrote `vibe: ""`.

Since the operator and the agents run `make test` constantly, every run wiped the vibe to the `sad` fixture. Proven by bisect and confirmed fixed by live sentinel test.

## Fix — make the suite hermetic

- **Autouse `hermetic_config` fixture** (tests/conftest.py): redirects every ambient config resolver (`config.DEFAULT_CONFIG_DIR`, `dirs.DEFAULT_CONFIG_DIR`, `dirs.find_config_dir`, `__main__.find_config_dir`) to a per-test tmp dir. No test can touch the real `.punt-labs/vox/` again.
- Made `test_server.py` / `test_cli.py` isolation explicit.
- **Regression guard** (tests/test_config_isolation.py): `test_suite_does_not_touch_real_config` snapshots the real config bytes, drives dir-less read/write, asserts unchanged; plus `test_redirect_is_active`, `test_default_write_lands_in_tmp`.
- Production `DEFAULT_CONFIG_DIR` left relative (intended cwd-relative 'current repo' resolution); the hermetic fixture is the required fix.

## Verification (live, by the COO)

Wrote `vibe: "SENTINEL-COO"` to the real `.punt-labs/vox/vox.local.md`, ran the **full suite** → 1817 passed, sentinel survived byte-for-byte. `make check` EXIT=0 (+7 tests). CHANGELOG updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and fixture changes only; production config resolution is unchanged. Risk is limited to test harness regressions if the redirect is removed.
> 
> **Overview**
> Fixes the dominant cause of the session vibe **always reverting to `sad`**: running `make test` from the repo root let config-writing tests hit the real `.punt-labs/vox/vox.local.md` because `DEFAULT_CONFIG_DIR` is relative and `find_config_dir()` walks up from cwd.
> 
> Adds an **autouse `hermetic_config` fixture** that redirects ambient resolution (`config`/`dirs` `DEFAULT_CONFIG_DIR`, `dirs.find_config_dir`, `__main__.find_config_dir`) to a per-test tmp dir. **Regression guards** in `test_config_isolation.py` assert the redirect is active and that default read/write paths never change the real config bytes. Vibe CLI and MCP tests are tightened with explicit dir patches and on-disk assertions; `test_config` is adjusted so cases that need the production relative default still work under the redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43765131fca3c995b2964c8dc73611d88777c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->