### PR TITLE
docs(music): vox-ig52 resilience spec + forbid named artists in /music prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`/music` prompt authoring now forbids named artists/composers/titles**: ElevenLabs Music rejects prompts that reference a specific artist, composer, band, or copyrighted work under its Terms of Service (`bad_prompt`, no track generated). The `/music` command guidance now bans them explicitly and shows how to evoke the same sound by describing form/instruments/mode/era instead ("romantic-era nocturne in E-flat" not "Chopin nocturne"). Prevents the silent "music won't start" failure hit when a classical-piano pool named composers. The systemic fix — surfacing generation failures through the `status` API instead of only the daemon log — is specced in `docs/vox-ig52-music-resilience.md` (vox-ig52).
+
 ### Fixed
 
 - **The test suite no longer overwrites the developer's real vox config**: `DEFAULT_CONFIG_DIR` is a *relative* path (`.punt-labs/vox`) and `find_config_dir()` walks up from the cwd, so tests that drove a config-writing path without redirecting the dir — the `vibe` MCP tool, the `/vibe` CLI command — clobbered the live `.punt-labs/vox/vox.local.md` on every `make test`, silently resetting the session vibe (the "always reverts to sad" symptom, since fixtures wrote `vibe: "sad"` / empty into it). An autouse `hermetic_config` fixture now redirects every *ambient* config resolution — `ConfigStore(None)`, the module-level `read_config`/`write_field`/`write_fields` wrappers, `server._find_config_dir()`, and the `__main__` CLI commands — to a per-test tmp dir, so no test can read or write the real config through the default path. A `test_suite_does_not_touch_real_config` regression guard asserts the redirect stays active and that the real config bytes are untouched after driving the default read/write paths.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1816,3 +1816,52 @@ depends inward on a protocol, not outward on the filesystem). This also directly
 serves the two-goals-together bar: the seam that makes disk access mockable is
 the same seam that raises cohesion and testability on `generator.py` and the new
 `filler.py`.
+
+---
+
+## DES-040: Daemon Failures Are Client-Observable Through the API, Not Logs
+
+**Date:** 2026-07-05
+**Status:** ACCEPTED (implementation tracked in vox-ig52)
+**Topic:** How `voxd` surfaces background-operation failures to clients
+
+### Problem
+
+Background music generation can fail, and when it did the failure was invisible
+to every client. Live 2026-07-05: a `/music on` prompt naming composers was
+rejected by ElevenLabs (`400 bad_prompt`/ToS). `voxd` logged `Music could not
+start; disabling` and raised; the user saw the panel say "generating…" then dead
+air. The only record of the reason was in `voxd-stderr.log` — which no MCP
+client, CLI caller, or user can read. A feature whose failure is invisible to its
+clients is indistinguishable from a hang.
+
+### Design
+
+Every state and failure a client cares about MUST be observable through the
+client interface — the MCP tool return value and the `status` tool — never only
+in the daemon log. The log is an operator debugging aid, not a client interface.
+For music: `status` carries a `music_state`
+(`off | generating | playing | rotating | retrying | failed`) plus a
+`music_last_error` with an actionable reason (for `bad_prompt`, include the
+provider's suggested rewrite so a calling agent can self-correct); permanent
+errors go to `failed`, transient ones to `retrying` with bounded backoff while
+the existing pool keeps playing. The silent disable is removed.
+
+### Why This Design
+
+This is the daemon-side corollary of the org's Phase-3 verification rule
+("observe via the project's introspection APIs"): the introspection surface
+(`status`) has to actually carry the failure. It also forces honest
+verification — you confirm a feature works by driving it and reading `status`,
+not by grepping a log. Operator, 2026-07-05: "Reading logs is not a strategy for
+our software clients."
+
+### Alternatives Considered
+
+| Alternative | Rejected Because |
+|-------------|-----------------|
+| Log-only (status quo) | Invisible to clients — the failure above |
+| Silent disable + retry forever | Hides permanent errors (`bad_prompt`, auth) that never succeed; still tells the client nothing |
+| Push notification only, no queryable state | A client that missed the event can't learn current state; the queryable field is the contract, a notification is an optional nicety |
+
+Full spec, error taxonomy, and z-spec state machine: `docs/vox-ig52-music-resilience.md`.

--- a/commands/music.md
+++ b/commands/music.md
@@ -92,6 +92,14 @@ You write the descriptions -- Python does not. Follow these rules:
 - **Genre-forward and literal.** Lead with the genre and let it dominate. Name
   the real instruments, mode/scale, and forms of the style. "Klezmer, freylekhs
   dance, clarinet and violin, in D freygish" -- not "upbeat happy music".
+- **Never name a specific artist, composer, band, or copyrighted work.**
+  ElevenLabs Music **rejects** these under its Terms of Service -- the request
+  fails with `bad_prompt` and no track is generated. Do NOT write "Chopin
+  nocturne", "in the style of Aphex Twin", "Clair de lune", or any named
+  person/title. Describe the music *itself* -- form, instruments, mode/scale,
+  era, tempo, key, mood -- so the description evokes the same sound without the
+  name: "romantic-era solo piano nocturne in E-flat major, lyrical right-hand
+  melody over rolling left-hand arpeggios" -- not "Chopin nocturne".
 - **Vary WITHIN the genre.** The 12 variations should be 12 distinct tracks of
   the *same* genre. Vary dance form, tempo (BPM), mode/key, lead-instrument
   emphasis, and mood shade. Do NOT drift toward genre-alien instruments or

--- a/docs/vox-ig52-music-resilience.md
+++ b/docs/vox-ig52-music-resilience.md
@@ -120,7 +120,7 @@ debugging the daemon; it is not a client interface.
 
 Amend `commands/music.md`: an explicit prohibition — **never name specific
 artists, composers, bands, or copyrighted song/piece titles** ("Chopin",
-"Clair-de-lune", "in the style of X"); ElevenLabs Music rejects them under ToS.
+"Clair de lune", "in the style of X"); ElevenLabs Music rejects them under ToS.
 Use **forms, instruments, modes/scales, eras, tempo, key, mood** instead
 (the Klezmer worked-example already models this; add the classical-piano
 counter-example — "nocturne in E-flat, rolling left-hand arpeggios" not
@@ -140,7 +140,7 @@ counter-example — "nocturne in E-flat, rolling left-hand arpeggios" not
 5. Modeled properties asserted **by name** in tests (e.g. `test_bad_prompt_sets_failed_state`,
    `test_transient_keeps_playing`, `test_full_pool_never_hard_fails`).
 6. `make check` EXIT=0; live-verified by the COO through `status` before the bead
-   closes (per [[feedback-live-verify-before-close]] — no close on `make check` alone).
+   closes — verified live before the bead closes, never on `make check` alone.
 
 ## 8. Execution plan (next session)
 

--- a/docs/vox-ig52-music-resilience.md
+++ b/docs/vox-ig52-music-resilience.md
@@ -1,0 +1,154 @@
+# vox-ig52 — Music Generation Resilience & Client-Observable Failure
+
+**Status:** Spec (to implement next session). Author: Claude (COO). Bead: `vox-ig52`.
+**Supersedes the original narrow framing** ("fill not recovering from transient
+provider errors") with the correct, broader one surfaced 2026-07-05.
+
+---
+
+## 1. Problem
+
+Background-music generation can fail, and when it does the failure is **invisible
+to every client**. Observed live 2026-07-05:
+
+- `/music on style "piano instrumental - classical style"` (vibe *sleepy*). The
+  agent-authored prompt named composers (Chopin, Debussy, Satie, …).
+- ElevenLabs Music rejected it: `400 bad_request`, `status: bad_prompt`,
+  *"Your prompt appears to have violated our Terms of Service"* (it even returned
+  a `prompt_suggestion` with the names stripped).
+- `voxd` logged `ERROR punt_vox.voxd.music.loop: Music could not start; disabling`
+  and raised `RuntimeError: could not generate the first track`.
+- **The user saw the panel say "generating…" and then nothing.** No error, no
+  reason, no state change. The only record was in `voxd-stderr.log`.
+
+Two defects:
+
+1. **Silent failure.** The daemon swallows the provider error, disables music, and
+   tells no client. (Silent-failure-hunter territory.)
+2. **Log-only observability.** The reason existed *only* in the daemon log. No MCP
+   client, CLI caller, or user can read that log — and they must not have to.
+   *Reading logs is not a strategy for software clients.*
+
+A third, contributing input problem (cheap to fix independently): the `/music`
+prompt-authoring guidance says "name forms/instruments/modes" but does not forbid
+named artists/composers/titles, which is exactly what ElevenLabs Music's ToS
+rejects.
+
+## 2. Design principle (the north star)
+
+> **Every state and failure a client cares about must be observable through the
+> client API — the `status` MCP tool and the tool return values — never only in a
+> log.**
+
+This mirrors the org's own Phase-3 verification rule ("observe via the project's
+introspection APIs", e.g. lux `list_errors`). Vox's introspection surface is the
+`status` tool; today it reports `music_mode` but not *whether generation
+succeeded or why it failed*. Closing that gap is the core of this work. The
+acceptance test observes failures **through `status`**, not the log.
+
+## 3. Music generation lifecycle — state machine (z-spec target)
+
+Model this formally with `/z-spec:code2model` **before** implementation (it
+qualifies: stateful subsystem, invariants across transitions, and a wrong
+transition silently corrupts UX — which is exactly what happened). Produce
+`docs/music-resilience.tex`, `fuzz -t` clean, ideally `/z-spec:test`
+model-checked.
+
+**States** (per `(vibe, style)` session):
+
+- `off` — no music.
+- `generating` — first track not yet ready (or fill in progress below full).
+- `playing` — a track is playing; pool may still be filling.
+- `rotating` — pool full (12); shuffling, zero credits.
+- `retrying` — a generation call failed with a **transient** error; backoff timer
+  active; music stays alive on whatever pool exists.
+- `failed` — generation cannot proceed (permanent error, e.g. `bad_prompt`, or
+  transient retries exhausted with an empty pool); music is not playing; a
+  `last_error` reason is retained and queryable.
+
+**Key invariants** (carry into the schema predicate):
+
+- `last_error` is non-empty **iff** state ∈ {`failed`} (and optionally retained as
+  advisory in `retrying`); it is cleared on the next successful generation or a
+  fresh `music on`.
+- `failed` is reachable from `generating`/`retrying`, never from `rotating`
+  (a full pool cannot hard-fail — it plays from disk at zero credits).
+- Entering `failed` **must** emit an observable transition (status flips +
+  `last_error` set), never a silent disable.
+- At most one fill task active (existing invariant, preserved).
+- `retrying` only for transient errors; `bad_prompt`/auth go straight to `failed`
+  (retrying a ToS-rejected prompt is pointless).
+
+**Transitions to specify** (pre/post): `TurnOn`, `FirstTrackOk`, `FirstTrackBadPrompt`,
+`FirstTrackTransient` (→ retrying), `RetryExhausted` (→ failed), `FillOk`,
+`FillError(kind)`, `Recover` (transient clears → resume), `VibeStyleChange`,
+`TurnOff`. Each must state its effect on `state` **and** `last_error` so the
+observability contract is provable from the model.
+
+## 4. Observability contract (client API)
+
+**`status` tool gains:**
+
+- `music_state`: one of `off | generating | playing | rotating | retrying | failed`.
+- `music_last_error`: string reason when `failed`/`retrying`, else empty. For
+  `bad_prompt`, include the human reason **and** the provider's `prompt_suggestion`
+  so a calling agent can re-author without guessing.
+- (Keep `music_mode` for back-compat, or fold it in — implementer's call, but do
+  not remove observability.)
+
+**`music` / `music_next` tool return values:**
+
+- Synchronous failures (missing key, immediate reject) return an error result with
+  the reason — not a cheerful "generating" panel.
+- For async first-track failure, the tool may still return "generating", but the
+  outcome becomes observable via `status` within one poll; a client that polls
+  `status` sees `failed` + reason. (If the notification system is wired, also emit
+  a spoken/panel notification on entering `failed` — nice-to-have, not required.)
+
+**Non-goal:** clients never parse `voxd-stderr.log`. The log stays for operators
+debugging the daemon; it is not a client interface.
+
+## 5. Error taxonomy → behavior
+
+| Provider signal | Class | Behavior |
+|---|---|---|
+| `400 bad_prompt` / ToS | permanent | → `failed`, `last_error` = reason + `prompt_suggestion`. No retry, pool not burned. Agent re-authors. |
+| `401/403` / missing key | auth | → `failed`, `last_error` = "Background music requires a valid ElevenLabs API key". (partly done) |
+| `429` / quota / `5xx` / timeout | transient | → `retrying`, bounded exponential backoff (cap N attempts). Keep playing existing pool. On success → resume; on exhaustion with empty pool → `failed`. |
+
+## 6. Input guard (independent, do first — cheap)
+
+Amend `commands/music.md`: an explicit prohibition — **never name specific
+artists, composers, bands, or copyrighted song/piece titles** ("Chopin",
+"Clair-de-lune", "in the style of X"); ElevenLabs Music rejects them under ToS.
+Use **forms, instruments, modes/scales, eras, tempo, key, mood** instead
+(the Klezmer worked-example already models this; add the classical-piano
+counter-example — "nocturne in E-flat, rolling left-hand arpeggios" not
+"Chopin nocturne"). This alone prevents the most likely `bad_prompt` trigger.
+
+## 7. Acceptance criteria (verified through the API, not the log)
+
+1. Drive a **deliberately bad** prompt (named composer) through the `music` tool →
+   within one poll, the `status` tool returns `music_state = failed` and a
+   `music_last_error` containing the provider reason + `prompt_suggestion`. **No
+   log reading in the test.**
+2. Simulate a transient error (mock 429) → `status` shows `retrying`, music keeps
+   playing the existing pool, and recovery resumes fill on success.
+3. A full (12) pool never enters `failed` on a provider hiccup — it rotates from
+   disk.
+4. `bad_prompt` does not disable/burn the pool; a corrected `music on` succeeds.
+5. Modeled properties asserted **by name** in tests (e.g. `test_bad_prompt_sets_failed_state`,
+   `test_transient_keeps_playing`, `test_full_pool_never_hard_fails`).
+6. `make check` EXIT=0; live-verified by the COO through `status` before the bead
+   closes (per [[feedback-live-verify-before-close]] — no close on `make check` alone).
+
+## 8. Execution plan (next session)
+
+1. **Input guard now-ish:** COO edits `commands/music.md` (§6). Independent, doc-only.
+2. **Design/model mission:** `jms` (Z) authors `docs/music-resilience.tex` from §3;
+   `fuzz -t` clean. COO reviews the model's findings, escalates any before impl.
+3. **Implementation mission:** `rmh` (owns `voxd` music + `server.py` status surface),
+   evaluator `bwk`/`mdm`. Single agent, **no worktree**. Implements §4/§5 to satisfy
+   the model; adds §7 tests. Commit-per-step.
+4. **Live verify:** COO drives the bad-prompt and transient paths, observes via the
+   `status` tool, confirms with operator, then closes `vox-ig52`.


### PR DESCRIPTION
Docs-only — Phase 3 verification N/A.

## What
1. **docs/vox-ig52-music-resilience.md** — the spec for making music generation failures **client-observable** (via the `status` tool + tool returns, never only the daemon log), with the error taxonomy (permanent `bad_prompt` / auth / transient), a z-spec-target state machine, the observability contract, and API-verified acceptance criteria. Reframes vox-ig52 from 'transient fill recovery' to the real problem surfaced 2026-07-05: a ToS `bad_prompt` rejection silently disabled music and the user saw dead air, with the reason only in `voxd-stderr.log`.
2. **commands/music.md** — explicit ban on named artists/composers/copyrighted titles (ElevenLabs Music rejects them under ToS → `bad_prompt`, no track). Shows the describe-the-sound alternative ('romantic-era nocturne in E-flat' not 'Chopin nocturne'). Prevents the failure we hit tonight.

## Why
The ElevenLabs ToS rejection made `/music on` (classical piano, named composers) silently fail. This ships the cheap input guard now and specs the systemic observability fix (vox-ig52) for next session.

## Verification
Docs-only. The music.md guard was validated live: after removing composer names, the same classical-piano pool generated cleanly (tracks written, playback started).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and prompt-authoring guidance only; no runtime behavior changes until vox-ig52 is implemented.
> 
> **Overview**
> **Docs-only** — ships an immediate `/music` prompt guard and documents the planned daemon fix for silent music failures (vox-ig52); no `voxd` or `status` code changes in this PR.
> 
> **`commands/music.md`** now explicitly forbids naming artists, composers, bands, or copyrighted titles in music prompts (ElevenLabs ToS → `bad_prompt`, no track). It adds a describe-the-sound alternative (e.g. romantic-era nocturne in E-flat, not "Chopin nocturne") to prevent the failure mode that blocked classical-piano pools.
> 
> **`docs/vox-ig52-music-resilience.md`** (new) reframes vox-ig52 around client-observable failures: extend **`status`** with `music_state` and `music_last_error`, error taxonomy (permanent `bad_prompt`/auth vs transient), a target state machine, API-verified acceptance criteria, and an execution plan for a follow-up implementation session.
> 
> **`DESIGN.md`** adds **DES-040** (failures must surface via MCP/`status`, not only daemon logs). **`CHANGELOG.md`** records the `/music` authoring change under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12df8a845f631af5d6a9a023017e4b3a1b1f3511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->