### PR TITLE
ci: enforce the OO ratchet in CI + require up-to-date branches (vox-br79)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # fetch-depth: 0 is load-bearing for the ratchet: the OO check resolves a
+      # merge-base and the coupling check diffs HEAD~1..HEAD; a shallow clone has
+      # neither the base commit nor HEAD~1.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -25,3 +30,26 @@ jobs:
       - run: uv run mypy src/ tests/
       - run: uv run pyright src/ tests/
       - run: shellcheck -x hooks/*.sh scripts/*.sh install.sh
+      # OO ratchet on a PR: compare code-at-HEAD against the baseline at the
+      # merge-base (S1/S2). --require-base AND the explicit fetch are both
+      # mandatory — with either missing, an unfetched/unresolvable base would
+      # fail open and let a regression pass. See docs/oo-ratchet-improvements.md.
+      - name: OO ratchet (PR — merge-base compare)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          if [ -z "${BASE}" ]; then
+            echo "FATAL: cannot resolve merge-base with origin/${{ github.base_ref }}" >&2
+            exit 1
+          fi
+          make check-oo OO_BASE="--base-ref ${BASE} --require-base"
+          make check-coupling
+      # OO ratchet on main after a merge: HEAD~1 is the squash's merge-base, so
+      # the ratchet re-runs on merged reality — the tripwire that catches a red
+      # main from a bad squash or a direct push (S1 push:[main] + §5 runbook).
+      - name: OO ratchet (main — post-merge tripwire)
+        if: github.event_name == 'push'
+        run: |
+          make check-oo OO_BASE="--base-ref HEAD~1 --require-base"
+          make check-coupling


### PR DESCRIPTION
PR2 of the ratchet redesign — turns the gate on. Tooling shipped in PR1 (#310). Bead vox-br79.

## S1 — check-oo + check-coupling in the required `lint` job
Folded two steps into the existing required `lint` job (no new required context → no open-PR deadlock). Checkout now `fetch-depth: 0`.
- **PR:** `git fetch origin <base>` → resolve `merge-base` → guard empty base (exit 1) → `make check-oo OO_BASE="--base-ref <mb> --require-base"` → `make check-coupling`.
- **push:main tripwire:** `make check-oo OO_BASE="--base-ref HEAD~1 --require-base"` → `make check-coupling` (catches a red main from a bad squash / direct push).
- **The load-bearing contract (gvr flagged):** `--require-base` AND the explicit `fetch` are present in both event types — verified `--require-base` fails closed on a bogus base. The empty-base guard closes the `set -e` command-substitution gap.

**PR2 self-CI:** proven locally — PR2 touches only `.github/`, so `check-oo`/`check-coupling` hit "No Python files touched -- trivial pass" (no self-deadlock). This PR's own `lint` run is the first live exercise of the gate.

## S10 — require up-to-date branches (APPLIED)
Enabled surgically on the `main` ruleset (flipped only `strict_required_status_checks_policy` → true; all 5 rules + required contexts `docs`/`lint`/`test` preserved, no weakening). Closes the concurrent-merge green-then-red gap.

## S9 — audit-on-main: DEFERRED (assessed)
Would require CI to commit `.oo-audit.jsonl` back to protected `main` (needs a bypass actor that permanently weakens protection, or an automated follow-up PR = spam/recursion) — the brittle push-to-main pattern the design says to avoid. S10 already shrinks the window it targeted, vox is low-volume, and the per-PR record is preserved by the visible baseline diff + the `source` field. Clean future form: a dispatched job opening a *normal* PR with the audit delta — its own bead if wanted.

## Notes / follow-ups
- `OO_BASE` is intentionally NOT threaded into `check-coupling` — `oo_coupling.py` has no `--base-ref` (it's a whole-tree `HEAD~1..HEAD` ratchet); `fetch-depth: 0` is load-bearing for it too.
- **Follow-up:** `check-coupling` is still the *old-style* ratchet (no merge-base, no `--require-base`), so it doesn't share `check-oo`'s squash-hole/fail-closed guarantees — worth redesigning `oo_coupling.py` the same way (or confirming it's regression-only + fail-closed) before relying on it as a hard gate.
- The ratchet still doesn't gate its own `tools/` (check-oo scores `src/punt_vox/`) — separate follow-up.

One commit (`df32444`), `.github/workflows/lint.yml` only. `make check` green on the branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new hard CI gate on every PR and main push; misconfigured git fetch or base resolution would block merges, though the explicit guards are designed to fail closed rather than skip checks.
> 
> **Overview**
> **Enables the OO ratchet gate in CI** by extending the existing required `lint` job (no new status check), so PRs and `main` pushes must pass `make check-oo` and `make check-coupling` alongside the existing linters.
> 
> Checkout now uses **`fetch-depth: 0`** so merge-base resolution and `HEAD~1` diffs work; shallow clones would otherwise break both ratchets.
> 
> On **pull requests**, the workflow explicitly fetches the base branch, resolves the merge-base (failing if empty), then runs `check-oo` with `--base-ref` and **`--require-base`** so a missing baseline cannot fail open, followed by `check-coupling`.
> 
> On **pushes to `main`**, it re-runs the same checks against **`HEAD~1`** as a post-merge tripwire for bad squashes or direct pushes to `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df32444439a0bca04eb54fa253c7f839ee3bf032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->