### PR TITLE
ci: exempt release/* and post-release/* PRs from the OO ratchet gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,9 +69,15 @@ jobs:
       # OO ratchet on main after a merge: HEAD~1 is the squash's merge-base, so
       # the ratchet re-runs on merged reality — the tripwire that catches a red
       # main from a bad squash or a direct push (S1 push:[main] + §5 runbook).
+      # This step is REGRESSION-ONLY: must-improve is already enforced on the PR,
+      # so re-requiring it here would turn main red after every metric-neutral
+      # squash — most visibly a release commit that changes only __version__.
+      # --allow-no-improvement waives only the must-improve gate; regressions,
+      # baseline lock-in, and completeness stay enforced. check-coupling and
+      # check-suppressions are regression-only by construction.
       - name: OO ratchet (main — post-merge tripwire)
         if: github.event_name == 'push'
         run: |
-          make check-oo OO_BASE="--base-ref HEAD~1 --require-base"
+          make check-oo OO_BASE="--base-ref HEAD~1 --require-base --allow-no-improvement"
           make check-coupling COUPLING_BASE="--base-ref HEAD~1 --require-base"
           make check-suppressions SUPPRESSION_BASE="--base-ref HEAD~1 --require-base"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,13 @@ jobs:
       # merge-base (S1/S2). --require-base AND the explicit fetch are both
       # mandatory — with either missing, an unfetched/unresolvable base would
       # fail open and let a regression pass. See docs/oo-ratchet-improvements.md.
+      # release/* and post-release/* PRs are mechanical version bumps (punt
+      # release): their only scored Python change is __version__, which improves
+      # no OO metric, so the "at least one metric improved" gate structurally
+      # fails them. Exempt those head branches from the ratchet step only —
+      # ruff/format/mypy/pyright/shellcheck still run and pass on a version bump.
       - name: OO ratchet (PR — merge-base compare)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/') && !startsWith(github.head_ref, 'post-release/')
         run: |
           git fetch --no-tags origin "${{ github.base_ref }}"
           BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,13 +34,23 @@ jobs:
       # merge-base (S1/S2). --require-base AND the explicit fetch are both
       # mandatory — with either missing, an unfetched/unresolvable base would
       # fail open and let a regression pass. See docs/oo-ratchet-improvements.md.
-      # release/* and post-release/* PRs are mechanical version bumps (punt
-      # release): their only scored Python change is __version__, which improves
-      # no OO metric, so the "at least one metric improved" gate structurally
-      # fails them. Exempt those head branches from the ratchet step only —
-      # ruff/format/mypy/pyright/shellcheck still run and pass on a version bump.
+      # A mechanical version bump (release/* and post-release/* PRs from punt
+      # release) changes only __version__ in src/punt_vox/__init__.py, which
+      # improves no OO metric, so check-oo's "at least one metric improved" gate
+      # structurally fails it. For those head branches we pass
+      # --allow-no-improvement, which waives ONLY the must-improve requirement —
+      # a regression is still rejected and baseline completeness/lock-in still
+      # enforced. This is safe even though github.head_ref is attacker-controlled
+      # on fork PRs: the flag removes only the must-improve nicety, and
+      # check-coupling / check-suppressions (regression-only gates) run
+      # unconditionally below, so a fork PR named release/* gains nothing
+      # exploitable. head_ref reaches the shell via the HEAD_REF env var and is
+      # matched with `case`, never interpolated into the command, to avoid
+      # script injection.
       - name: OO ratchet (PR — merge-base compare)
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/') && !startsWith(github.head_ref, 'post-release/')
+        if: github.event_name == 'pull_request'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           git fetch --no-tags origin "${{ github.base_ref }}"
           BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
@@ -48,7 +58,12 @@ jobs:
             echo "FATAL: cannot resolve merge-base with origin/${{ github.base_ref }}" >&2
             exit 1
           fi
-          make check-oo OO_BASE="--base-ref ${BASE} --require-base"
+          OO_ARGS="--base-ref ${BASE} --require-base"
+          case "${HEAD_REF}" in
+            release/*|post-release/*)
+              OO_ARGS="${OO_ARGS} --allow-no-improvement" ;;
+          esac
+          make check-oo OO_BASE="${OO_ARGS}"
           make check-coupling COUPLING_BASE="--base-ref ${BASE} --require-base"
           make check-suppressions SUPPRESSION_BASE="--base-ref ${BASE} --require-base"
       # OO ratchet on main after a merge: HEAD~1 is the squash's merge-base, so

--- a/tests/test_oo_ratchet.py
+++ b/tests/test_oo_ratchet.py
@@ -62,6 +62,12 @@ class Widget:
 
 BROKEN = "def oops(:\n    pass\n"
 
+# Byte-different from GOOD but metric-identical: same line count, same
+# complexity, only a string literal differs. Models a mechanical version bump
+# (e.g. __version__ = "1.0.0" -> "1.0.1") that touches a scored file yet
+# improves no metric.
+GOOD_VARIANT = GOOD.replace('return "pos"', 'return "neg"')
+
 
 class GitFixture:
     """A throwaway git repo for exercising the ratchet end to end."""
@@ -197,6 +203,90 @@ class TestBaseCompare:
         outcome = fx.ratchet().check(fx.scorer(), base_ref=None, require_base=True)
         assert outcome.exit_code == 0
         assert fx.root  # b.py's main-only regression did not fail the PR
+
+
+class TestAllowNoImprovement:
+    """--allow-no-improvement waives only the must-improve gate.
+
+    Regressions, baseline lock-in, and completeness stay enforced. This is the
+    gate mechanical version-bump PRs (release/* and post-release/*) need: they
+    touch a scored file (__version__) but improve no metric.
+    """
+
+    def test_flag_passes_no_improvement_no_regression(self, fx: GitFixture) -> None:
+        # A metric-neutral change (version bump) touches the file but neither
+        # improves nor regresses: the flag lets it pass.
+        fx.write("sub/w.py", GOOD)
+        fx.snapshot("sub")
+        base = fx.commit("base")
+        fx.write("sub/w.py", GOOD_VARIANT)
+        fx.snapshot("sub")  # in-tree baseline == current, locked
+        fx.commit("metric-neutral change")
+        outcome = fx.ratchet().check(
+            fx.scorer(), base_ref=base, require_base=True, allow_no_improvement=True
+        )
+        assert outcome.exit_code == 0
+        assert any("must-improve gate waived" in line for line in outcome.lines)
+
+    def test_flag_still_fails_regression(self, fx: GitFixture) -> None:
+        # The flag never launders a regression.
+        fx.write("sub/w.py", GOOD)
+        fx.snapshot("sub")
+        base = fx.commit("base")
+        fx.write("sub/w.py", WORSE)
+        fx.snapshot("sub")
+        fx.commit("regress")
+        outcome = fx.ratchet().check(
+            fx.scorer(), base_ref=base, require_base=True, allow_no_improvement=True
+        )
+        assert outcome.exit_code == 1
+        assert any("regression" in line for line in outcome.lines)
+
+    def test_default_still_fails_no_improvement(self, fx: GitFixture) -> None:
+        # Without the flag, a metric-neutral change fails the must-improve gate
+        # exactly as before -- the default is unchanged.
+        fx.write("sub/w.py", GOOD)
+        fx.snapshot("sub")
+        base = fx.commit("base")
+        fx.write("sub/w.py", GOOD_VARIANT)
+        fx.snapshot("sub")
+        fx.commit("metric-neutral change")
+        outcome = fx.ratchet().check(fx.scorer(), base_ref=base, require_base=True)
+        assert outcome.exit_code == 1
+        assert any("no metric improved" in line for line in outcome.lines)
+
+    def test_flag_still_enforces_lock_in(self, fx: GitFixture) -> None:
+        # A stale in-tree baseline (out of date vs current) still fails under the
+        # flag: lock-in is orthogonal to the must-improve gate.
+        fx.write("sub/w.py", GOOD)
+        fx.snapshot("sub")
+        base = fx.commit("base")
+        fx.write("sub/w.py", GOOD_VARIANT)
+        current = Baseline.metrics_by_file(fx.scorer().results)["sub/w.py"]
+        fx.write_baseline(
+            {"sub/w.py": {**current, "module_size": current["module_size"] + 5}}
+        )
+        fx.commit("touch but leave baseline stale")
+        outcome = fx.ratchet().check(
+            fx.scorer(), base_ref=base, require_base=True, allow_no_improvement=True
+        )
+        assert outcome.exit_code == 1
+        assert any("baseline out of date" in line for line in outcome.lines)
+
+    def test_flag_still_requires_baseline_entry(self, fx: GitFixture) -> None:
+        # A touched file absent from the in-tree baseline still fails under the
+        # flag: completeness is orthogonal to the must-improve gate.
+        fx.write("sub/w.py", GOOD)
+        fx.snapshot("sub")
+        base = fx.commit("base")
+        fx.write("sub/w.py", GOOD_VARIANT)
+        fx.write_baseline({})  # drop the file's in-tree entry
+        fx.commit("touch but empty in-tree baseline")
+        outcome = fx.ratchet().check(
+            fx.scorer(), base_ref=base, require_base=True, allow_no_improvement=True
+        )
+        assert outcome.exit_code == 1
+        assert any("not in baseline" in line for line in outcome.lines)
 
 
 class TestEmptyBaseBaseline:

--- a/tests/test_oo_ratchet.py
+++ b/tests/test_oo_ratchet.py
@@ -65,7 +65,10 @@ BROKEN = "def oops(:\n    pass\n"
 # Byte-different from GOOD but metric-identical: same line count, same
 # complexity, only a string literal differs. Models a mechanical version bump
 # (e.g. __version__ = "1.0.0" -> "1.0.1") that touches a scored file yet
-# improves no metric.
+# improves no metric. Guard the substring so a drift in GOOD fails loudly here
+# instead of silently no-op'ing .replace() (GOOD_VARIANT == GOOD would stop
+# exercising the metric-neutral case).
+assert 'return "pos"' in GOOD, "GOOD fixture drifted; GOOD_VARIANT target missing"
 GOOD_VARIANT = GOOD.replace('return "pos"', 'return "neg"')
 
 

--- a/tools/oo_ratchet/cli.py
+++ b/tools/oo_ratchet/cli.py
@@ -33,6 +33,7 @@ class Options:
     justify: str
     base_ref: str | None
     require_base: bool
+    allow_no_improvement: bool
     allow_ci_write: bool
     source: str | None
 
@@ -55,6 +56,7 @@ class Options:
             justify=ns.justify or "",
             base_ref=ns.base_ref,
             require_base=bool(ns.require_base),
+            allow_no_improvement=bool(ns.allow_no_improvement),
             allow_ci_write=bool(ns.allow_ci_write),
             source=ns.source,
         )
@@ -86,6 +88,13 @@ class Options:
         parser.add_argument("--base-ref", metavar="REF", help="comparison base commit")
         parser.add_argument(
             "--require-base", action="store_true", help="fail if base unresolvable"
+        )
+        # Waive only the must-improve gate (mechanical version-bump PRs improve
+        # no metric); regressions and baseline lock-in are still enforced.
+        parser.add_argument(
+            "--allow-no-improvement",
+            action="store_true",
+            help="waive the must-improve gate; still reject regressions",
         )
         parser.add_argument(
             "--allow-ci-write", action="store_true", help="permit writes under CI"
@@ -132,7 +141,10 @@ class Cli:
         writer = BaselineWriter(self._root, self._git)
         if opts.check:
             return ratchet.check(
-                scorer, base_ref=opts.base_ref, require_base=opts.require_base
+                scorer,
+                base_ref=opts.base_ref,
+                require_base=opts.require_base,
+                allow_no_improvement=opts.allow_no_improvement,
             )
         if opts.rebaseline:
             return writer.rebaseline(

--- a/tools/oo_ratchet/ratchet.py
+++ b/tools/oo_ratchet/ratchet.py
@@ -39,9 +39,20 @@ class Ratchet:
         return self
 
     def check(
-        self, scorer: Scorer, *, base_ref: str | None, require_base: bool
+        self,
+        scorer: Scorer,
+        *,
+        base_ref: str | None,
+        require_base: bool,
+        allow_no_improvement: bool = False,
     ) -> Outcome:
-        """Compare touched files at HEAD against the base baseline."""
+        """Compare touched files at HEAD against the base baseline.
+
+        ``allow_no_improvement`` waives only the must-improve gate — a change
+        that pays down no debt still passes — while regressions, baseline
+        lock-in, and completeness stay enforced. It exists for mechanical
+        version-bump PRs whose only scored change improves no metric.
+        """
         base = self._git.resolve_base(base_ref)
         if base is None:
             return self._no_base(require_base=require_base)
@@ -72,7 +83,12 @@ class Ratchet:
             touched, current, base_baseline, diff.renames, waivable
         )
         lock_fail, missing = self._integrity(touched, current)
-        return self._verdict(Review(reviews), lock_fail, missing)
+        return self._verdict(
+            Review(reviews),
+            lock_fail,
+            missing,
+            allow_no_improvement=allow_no_improvement,
+        )
 
     def _no_base(self, *, require_base: bool) -> Outcome:
         """Decide the verdict when no comparison base can be resolved.
@@ -201,7 +217,12 @@ class Ratchet:
         )
 
     def _verdict(
-        self, review: Review, lock_fail: list[str], missing: list[str]
+        self,
+        review: Review,
+        lock_fail: list[str],
+        missing: list[str],
+        *,
+        allow_no_improvement: bool,
     ) -> Outcome:
         lines = self._render_rows(review)
         failed = False
@@ -221,12 +242,15 @@ class Ratchet:
             lines.append("FAIL: regression detected")
             lines.extend(f"  {path}: {metric}" for path, metric in review.regressions)
             failed = True
-        if not review.improvement_satisfied:
+        if not allow_no_improvement and not review.improvement_satisfied:
             lines.append("FAIL: no metric improved on any touched file")
             failed = True
         if failed:
             return Outcome(1, tuple(lines))
-        lines.append("PASS: at least one metric improved, no regressions")
+        if allow_no_improvement and not review.improvement_satisfied:
+            lines.append("PASS: no regressions (must-improve gate waived)")
+        else:
+            lines.append("PASS: at least one metric improved, no regressions")
         return Outcome(0, tuple(lines))
 
     @staticmethod


### PR DESCRIPTION
## Problem

The OO ratchet CI gate blocks mechanical release PRs. `.github/workflows/lint.yml`'s merge-base ratchet step runs `check-oo`, which requires "at least one metric improved on any touched file." A `punt release` PR (branch `release/*`) is a mechanical version bump — its only scored-Python change is `__version__` in `src/punt_vox/__init__.py`, which improves no OO metric — so the gate structurally fails it. This blocked release PR #327 (v4.12.1).

## Approach — a per-tool waiver, not a branch-name step skip

An earlier revision skipped the whole ratchet step for `release/*` branches. That was wrong (flagged in review): `github.head_ref` is attacker-controlled on a public repo, so a fork PR named `release/*` would bypass **all three** ratchets on arbitrary source. The current design instead:

- **`check-coupling` and `check-suppressions` run unconditionally** on every PR — they're regression-only and pass a version bump fine.
- **`check-oo` gains `--allow-no-improvement`** (`tools/oo_ratchet`): it waives *only* the must-improve requirement while **still failing on any regression, baseline lock-in violation, or completeness gap**.
- The workflow appends `--allow-no-improvement` to `check-oo` **only** when the head branch is `release/*`/`post-release/*`, matched via a `case` on the `HEAD_REF` env var (never interpolated into the command — no script injection). Because the flag removes only the must-improve nicety and coupling/suppressions still run, an attacker-named fork branch gains nothing exploitable.
- The **post-merge `push` tripwire** on `main` carries `--allow-no-improvement` unconditionally — its job is to catch regressions from a bad squash or direct push, not to redundantly require improvement (which would turn `main` red on every release squash-merge).

## Tests

`TestAllowNoImprovement` in `tests/test_oo_ratchet.py`: the flag passes a no-improvement/no-regression change; the flag **still fails a regression**; the default (no flag) still fails no-improvement; lock-in and completeness still enforced under the flag.

`make check` green; `actionlint` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and ratchet behavior change is narrowly scoped to waiving must-improve; regression and baseline integrity gates stay enforced, with tests and documented fork-PR safety rationale.
> 
> **Overview**
> Mechanical **release** and **post-release** PRs only bump `__version__`, which touches a scored file but improves no OO metric, so the existing must-improve gate blocked them. This adds **`--allow-no-improvement`** to the OO ratchet: it waives **only** that gate while **still** failing regressions, stale baselines, and missing baseline entries.
> 
> **CI** appends the flag to `check-oo` when the PR head branch matches `release/*` or `post-release/*` (via `case` on `HEAD_REF`, not command injection). Coupling and suppression checks still run unchanged on every PR. The **main post-merge** `check-oo` step always passes the flag so metric-neutral squash merges (e.g. releases) do not turn `main` red while the step remains a regression tripwire.
> 
> **Tests** add `TestAllowNoImprovement` with a metric-neutral `GOOD_VARIANT` fixture covering pass, regression, default behavior, lock-in, and completeness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73256bbd2e5e6ca23141a277d0c4eef5e436e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->