### PR TITLE
chore(docs): purge dev-process citations from doc comments (vox-n3t1)

### DIFF
--- a/.oo-baseline.json
+++ b/.oo-baseline.json
@@ -1032,7 +1032,7 @@
     "avg_params": 0.5,
     "max_complexity": 2.0,
     "avg_complexity": 1.33,
-    "module_size": 80.0,
+    "module_size": 79.0,
     "classes_per_module": 3.0,
     "class_to_func_ratio": 1.0,
     "init_violations": 0.0,

--- a/src/punt_vox/__main__.py
+++ b/src/punt_vox/__main__.py
@@ -342,7 +342,7 @@ def say(  # pyright: ignore[reportUnusedFunction]
     # individual readers (``_read_api_key_file``, ``_read_api_key_stdin``)
     # still reject their own empty content with their own BadParameter
     # messages, so there is no silent fall-through for paths where
-    # emptiness is actually a user error. Cursor Bugbot on PR #175.
+    # emptiness is actually a user error.
     if api_key == "":
         api_key = None
 

--- a/src/punt_vox/cache.py
+++ b/src/punt_vox/cache.py
@@ -5,20 +5,20 @@ repeated hook invocations with the same quip phrase skip the TTS API
 entirely.  Content-addressed by hash.
 
 This module serves the **anonymous** cache only — calls that use the
-ambient provider credential from ``keys.env``. Per-call provider
-credential overrides (single-user multi-key billing isolation)
-bypass this module entirely at the voxd call site: see the cache
-guards in ``SynthesisPipeline.synthesize_to_file`` in
-``src/punt_vox/voxd/synthesis.py``. That design keeps all sensitive
-credential material out of any digest this module computes. CodeQL's
+ambient provider credential from ``keys.env``. A per-call provider
+credential override (single-user multi-key billing isolation) skips the
+cache lookup and store — no ``cache_get``/``cache_put`` — at the voxd call
+site (``SynthesisPipeline.synthesize_to_file`` in
+``src/punt_vox/voxd/synthesis.py``). A ``CacheKey`` may still be built, but
+its parts are (text, voice, provider) only, so no credential material ever
+enters a digest this module computes. CodeQL's
 ``py/weak-sensitive-data-hashing`` rule (correctly) flags any regular
 cryptographic hash — MD5, SHA-1, SHA-256, and friends — as inappropriate
-for hashing password-class input, and the only lint-clean alternatives
-are password KDFs (Argon2, scrypt, bcrypt, PBKDF2 with high iteration
-counts) whose per-call cost is unacceptable for a cache filename
-computation.
+for hashing password-class input, and the only lint-clean alternatives are
+password KDFs (Argon2, scrypt, bcrypt, PBKDF2 with high iteration counts)
+whose per-call cost is unacceptable for a cache filename computation.
 
-The bypass also closes a correctness hazard: a per-call billing scope
+Skipping the cache also closes a correctness hazard: a per-call billing scope
 that accepts cached bytes from another scope violates the whole point of
 the isolation. Scripts that want cache hits for repeated quips should use
 ``keys.env`` (the anonymous path); scripts that want billing attribution

--- a/src/punt_vox/cache.py
+++ b/src/punt_vox/cache.py
@@ -8,7 +8,8 @@ This module serves the **anonymous** cache only — calls that use the
 ambient provider credential from ``keys.env``. Per-call provider
 credential overrides (single-user multi-key billing isolation)
 bypass this module entirely at the voxd call site: see the cache
-guards in ``_synthesize_to_file`` in ``src/punt_vox/voxd.py``. That
+guards in ``SynthesisPipeline.synthesize_to_file`` in
+``src/punt_vox/voxd/synthesis.py``. That
 design keeps all sensitive credential material out of any digest this
 module computes. CodeQL's ``py/weak-sensitive-data-hashing`` rule
 (correctly) flags any regular cryptographic hash — MD5, SHA-1,
@@ -18,11 +19,10 @@ input, and the only lint-clean alternatives are password KDFs
 per-call cost is unacceptable for a cache filename computation.
 
 The bypass also closes a correctness hazard: a per-call billing scope
-that accepts cached bytes from another scope violates the whole point
-of the isolation. Scripts
-that want cache hits for repeated quips should use ``keys.env`` (the
-anonymous path); scripts that want billing attribution should accept
-that every call re-synthesizes.
+that accepts cached bytes from another scope violates the whole point of
+the isolation. Scripts that want cache hits for repeated quips should use
+``keys.env`` (the anonymous path); scripts that want billing attribution
+should accept that every call re-synthesizes.
 
 No dependencies on other vox modules — this is a standalone cache layer.
 """

--- a/src/punt_vox/cache.py
+++ b/src/punt_vox/cache.py
@@ -9,14 +9,14 @@ ambient provider credential from ``keys.env``. Per-call provider
 credential overrides (single-user multi-key billing isolation)
 bypass this module entirely at the voxd call site: see the cache
 guards in ``SynthesisPipeline.synthesize_to_file`` in
-``src/punt_vox/voxd/synthesis.py``. That
-design keeps all sensitive credential material out of any digest this
-module computes. CodeQL's ``py/weak-sensitive-data-hashing`` rule
-(correctly) flags any regular cryptographic hash — MD5, SHA-1,
-SHA-256, and friends — as inappropriate for hashing password-class
-input, and the only lint-clean alternatives are password KDFs
-(Argon2, scrypt, bcrypt, PBKDF2 with high iteration counts) whose
-per-call cost is unacceptable for a cache filename computation.
+``src/punt_vox/voxd/synthesis.py``. That design keeps all sensitive
+credential material out of any digest this module computes. CodeQL's
+``py/weak-sensitive-data-hashing`` rule (correctly) flags any regular
+cryptographic hash — MD5, SHA-1, SHA-256, and friends — as inappropriate
+for hashing password-class input, and the only lint-clean alternatives
+are password KDFs (Argon2, scrypt, bcrypt, PBKDF2 with high iteration
+counts) whose per-call cost is unacceptable for a cache filename
+computation.
 
 The bypass also closes a correctness hazard: a per-call billing scope
 that accepts cached bytes from another scope violates the whole point of

--- a/src/punt_vox/cache.py
+++ b/src/punt_vox/cache.py
@@ -6,7 +6,7 @@ entirely.  Content-addressed by hash.
 
 This module serves the **anonymous** cache only — calls that use the
 ambient provider credential from ``keys.env``. Per-call provider
-credential overrides (vox-a3e single-user multi-key billing isolation)
+credential overrides (single-user multi-key billing isolation)
 bypass this module entirely at the voxd call site: see the cache
 guards in ``_synthesize_to_file`` in ``src/punt_vox/voxd.py``. That
 design keeps all sensitive credential material out of any digest this
@@ -17,9 +17,9 @@ input, and the only lint-clean alternatives are password KDFs
 (Argon2, scrypt, bcrypt, PBKDF2 with high iteration counts) whose
 per-call cost is unacceptable for a cache filename computation.
 
-The bypass also closes a correctness hazard an earlier draft of PR
-#175 had: a per-call billing scope that accepts cached bytes from
-another scope is violating the whole point of the isolation. Scripts
+The bypass also closes a correctness hazard: a per-call billing scope
+that accepts cached bytes from another scope violates the whole point
+of the isolation. Scripts
 that want cache hits for repeated quips should use ``keys.env`` (the
 anonymous path); scripts that want billing attribution should accept
 that every call re-synthesizes.

--- a/src/punt_vox/config.py
+++ b/src/punt_vox/config.py
@@ -43,7 +43,7 @@ DURABLE_KEYS: frozenset[str] = frozenset(
 
 # The whole vibe cluster is session state, not a durable preference. Keeping
 # vibe_mode in the tracked vox.md let any git checkout/stash resurrect a stale
-# "manual" mode while the gitignored mood lingered (vox-73m5). Mode, mood, tags,
+# "manual" mode while the gitignored mood lingered. Mode, mood, tags,
 # and the nudge cadence counter now live together in the ephemeral vox.local.md.
 EPHEMERAL_KEYS: frozenset[str] = frozenset(
     {
@@ -177,7 +177,7 @@ class ConfigStore:
         Each file contributes only the keys it owns: durable prefs from
         ``vox.md``, session state from ``vox.local.md``.  Filtering both
         sides keeps the split drift-proof -- a stale ``vibe_mode`` left in a
-        committed ``vox.md`` is ignored rather than resurrected (vox-73m5).
+        committed ``vox.md`` is ignored rather than resurrected.
         """
         fields: dict[str, str] = {}
 

--- a/src/punt_vox/hooks.py
+++ b/src/punt_vox/hooks.py
@@ -87,7 +87,7 @@ def _read_hook_input() -> dict[str, object]:
     """Read JSON hook payload from stdin (non-blocking).
 
     Uses ``select`` + ``os.read`` to avoid blocking forever when
-    Claude Code does not close the stdin pipe.  See biff DES-027.
+    Claude Code does not close the stdin pipe.
     """
     try:
         fd = sys.stdin.fileno()

--- a/src/punt_vox/types_programs/format.py
+++ b/src/punt_vox/types_programs/format.py
@@ -14,7 +14,7 @@ MAX_RETRY: Final = 5
 class Format(StrEnum):
     """One of the three Program formats (Z free type ``Format``).
 
-    Only ``PLAYLIST`` is realised in Phase 1; ``PODCAST`` and ``AUDIOBOOK`` are
+    Only ``PLAYLIST`` is realised today; ``PODCAST`` and ``AUDIOBOOK`` are
     named so that ``pool_size`` and the operations branching on it are total
     from the start. The string values are the wire/JSON form.
     """

--- a/src/punt_vox/types_programs/identifiers.py
+++ b/src/punt_vox/types_programs/identifiers.py
@@ -1,8 +1,8 @@
 """Identity, reference, and diagnostic value objects for the Programs domain.
 
-Holds the Program name, the resolved ``playlist:2`` :class:`PartRef` (finding
-#7), and the Z ``[REASON]`` diagnostic -- the addressing and diagnostic
-vocabulary shared across the domain.
+Holds the Program name, the resolved ``playlist:2`` :class:`PartRef`, and the
+Z ``[REASON]`` diagnostic -- the addressing and diagnostic vocabulary shared
+across the domain.
 """
 
 from __future__ import annotations
@@ -112,7 +112,7 @@ class PartRef:
 
     The ``index`` addresses the Program's Parts ordered by intrinsic index;
     resolving it to a ``Part`` -- and reporting an out-of-range index -- is a
-    surface concern the CLI owns before any transition runs (finding #7), not
+    surface concern the CLI owns before any transition runs, not
     modelled state.
     """
 

--- a/src/punt_vox/types_programs/mode.py
+++ b/src/punt_vox/types_programs/mode.py
@@ -27,7 +27,7 @@ class Mode(StrEnum):
     """The six-state Program machine (Z free type ``Mode``).
 
     The first four are the original playlist modes;
-    ``RETRYING`` and ``FAILED`` are the resilience states of ``vox-ig52``. The
+    ``RETRYING`` and ``FAILED`` are the resilience states. The
     modes are format-general -- a finite format reads ``PLAYING_ROTATING`` as
     "every Part generated, playing sequentially".
     """

--- a/src/punt_vox/types_programs/status_views.py
+++ b/src/punt_vox/types_programs/status_views.py
@@ -1,11 +1,10 @@
-"""The format-neutral sub-views of a Program's runtime status (design section 5).
+"""The format-neutral sub-views of a Program's runtime status.
 
 Three small value objects project the parts of a :class:`ProgramState` a client
 watches -- what is playing, how generation is faring, and which Parts failed
 permanently. Every field is format-agnostic: "Part N of M" reads the same for a
-playlist track, a podcast segment, or an audiobook chapter, so Phases 2--3
-populate the identical shape with no field change. Each round-trips through JSON
-so the value crosses the ``voxd`` wire to any client (PY-EH-8 on deserialize).
+playlist track, podcast segment, or audiobook chapter. Each round-trips through
+JSON so the value crosses the ``voxd`` wire to any client (PY-EH-8 on deserialize).
 """
 
 from __future__ import annotations
@@ -55,7 +54,7 @@ class NowPlaying:
 @final
 @dataclass(frozen=True, slots=True)
 class GenerationStatus:
-    """The program-level generation/error surface (design finding #5).
+    """The program-level generation/error surface.
 
     ``last_error`` is the *program-level* advisory error (set while retrying or
     failed, ``None`` when healthy) -- distinct from the per-Part failures in
@@ -87,7 +86,7 @@ class GenerationStatus:
 @final
 @dataclass(frozen=True, slots=True)
 class FailedPartView:
-    """One permanently-failed Part while the Program plays on (design finding #5)."""
+    """One permanently-failed Part while the Program plays on."""
 
     index: int  # the intrinsic index of a Part that hit a permanent error
     reason: str  # the human-readable failure diagnostic

--- a/src/punt_vox/voxd/health.py
+++ b/src/punt_vox/voxd/health.py
@@ -93,7 +93,7 @@ class DaemonHealth:
         The ``pid`` field is used by ``vox daemon restart`` to confirm the
         daemon has come back up as a fresh process. The ``daemon_version``
         field is used by ``vox doctor`` to warn when the running daemon
-        does not match the wheel installed on disk (vox-nmb). Neither is
+        does not match the wheel installed on disk. Neither is
         exposed on the unauthenticated HTTP ``/health`` route -- version
         info is a fingerprinting aid for targeted exploitation, and the
         minimal payload stays minimal.

--- a/src/punt_vox/voxd/programs/__init__.py
+++ b/src/punt_vox/voxd/programs/__init__.py
@@ -1,10 +1,10 @@
 """The audio Programs domain -- a format-general playlist/podcast/audiobook model.
 
-Phase 1 realises the *playlist* format of ``docs/audio-programs.tex``: a named,
-ordered collection of ready :class:`Part` audio that plays, advances, and
+This package realises the *playlist* format of ``docs/audio-programs.tex``: a
+named, ordered collection of ready :class:`Part` audio that plays, advances, and
 rotates for free once generated. The domain is pure -- no I/O, no daemon, no
 session -- so every state, transition, and invariant is unit-testable against
-the Z model. See ``docs/audio-programs-phase1-design.md`` for the code map.
+the Z model.
 """
 
 from __future__ import annotations

--- a/src/punt_vox/voxd/programs/music_producer.py
+++ b/src/punt_vox/voxd/programs/music_producer.py
@@ -1,10 +1,10 @@
 """The playlist Producer: ElevenLabs music generation with varied track lengths.
 
-``MusicProducer`` is the Phase-1 ``Producer``. It wraps an injected
+``MusicProducer`` is the playlist ``Producer``. It wraps an injected
 ``MusicProvider`` (the existing ``ElevenLabsMusicProvider`` in production, a fake
 in tests) and maps the provider's failures onto the two ``Producer`` error
-types. It folds in vox-y3om: instead of the hard-wired 120s, a ``LengthPolicy``
-samples a realistic, slightly-randomized length per Part.
+types. It also varies track length: instead of the hard-wired 120s, a
+``LengthPolicy`` samples a realistic, slightly-randomized length per Part.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ _PERMANENT_STATUS: Final = frozenset({400, 401, 403, 404, 422})
 
 @final
 class LengthPolicy:
-    """Sample a realistic, slightly-randomized Part length in milliseconds (vox-y3om).
+    """Sample a realistic, slightly-randomized Part length in milliseconds.
 
     Draws a uniform length in the closed range ``[min_ms, max_ms]``; the
     playlist default is 90--210s. Replaces the hard-wired 120s so a pool of

--- a/src/punt_vox/voxd/programs/part.py
+++ b/src/punt_vox/voxd/programs/part.py
@@ -2,7 +2,7 @@
 
 Realises the Z ``[PART]`` basic type together with the ``PartStatus`` free type
 and the ``failedParts : PART \\pfun REASON`` finite map. The resolved surface
-reference behind ``playlist:2`` (finding #7) lives in ``identifiers`` as
+reference behind ``playlist:2`` lives in ``identifiers`` as
 :class:`PartRef`.
 """
 
@@ -20,10 +20,10 @@ __all__ = ["FrozenParts", "Part", "PartStatus"]
 class PartStatus(StrEnum):
     """The lifecycle status of a stored Part (Z free type ``PartStatus``).
 
-    Phase 1 ever writes only ``READY`` and ``FAILED`` (finding #9: atomic
-    delivery hides ``PENDING``/``GENERATING``); the two in-flight statuses are
-    declared now so the spoken formats promote them to stored per-Part state
-    without a signature change.
+    Only ``READY`` and ``FAILED`` are ever written -- atomic delivery hides
+    ``PENDING``/``GENERATING``; the two in-flight statuses are declared now so
+    the spoken formats promote them to stored per-Part state without a
+    signature change.
     """
 
     PENDING = "pending"
@@ -37,7 +37,7 @@ class Part:
 
     ``identity`` is the opaque content-addressed identifier (the saved-audio
     file token); ``index`` is the 1-based manifest position assigned once at
-    record time and never reused (MAJOR-1) -- the stable basis for ``playlist:2``
+    record time and never reused -- the stable basis for ``playlist:2``
     addressing across daemon restarts and across processes. Identity is the
     ``identity`` alone: two Parts naming the same audio are equal, so a pool
     modelled as a ``frozenset[Part]`` dedups by audio, faithful to the Z ``pool``.

--- a/src/punt_vox/voxd/programs/playback_policy.py
+++ b/src/punt_vox/voxd/programs/playback_policy.py
@@ -1,10 +1,10 @@
-"""The playback-advance strategy seam (Z ``Rotate`` next-Part choice, finding #1).
+"""The playback-advance strategy seam (Z ``Rotate`` next-Part choice).
 
 The loop-versus-stop decision lives here, not in a new ``Mode``: a playlist
 policy never ends, while a finite format's policy signals end-of-list. Returning
 a discriminated ``AdvanceResult`` -- an ``Advance`` or the ``Complete`` singleton
--- rather than a bare ``Part | None`` lets Phase 2/3 add a finite-format policy
-with no change to this Protocol (MAJOR-2).
+-- rather than a bare ``Part | None`` lets a finite-format policy be added
+with no change to this Protocol.
 """
 
 from __future__ import annotations
@@ -28,8 +28,8 @@ class Advance:
 class Complete:
     """End-of-list signal: a finite format has no further Part to play.
 
-    Phase-1 playlist never reaches this -- a playlist has no end -- but the
-    shared result type carries it so a Phase-2/3 sequential policy can signal
+    A playlist never reaches this -- a playlist has no end -- but the
+    shared result type carries it so a sequential policy can signal
     end-of-list without changing the Protocol. Use the ``COMPLETE`` singleton.
     """
 

--- a/src/punt_vox/voxd/programs/playback_source.py
+++ b/src/punt_vox/voxd/programs/playback_source.py
@@ -3,8 +3,8 @@
 The daemon plays exactly one source at a time, and that source is a union: a
 generate-mode :class:`Program` or a consume-only :class:`SelectionPlayback`. Both
 satisfy this narrowed structural interface, so the single-writer channel and the
-playback loop drive either without narrowing on the concrete type (risk R1). The
-protocol carries no ``filling`` and no ``locate`` (findings #1, #2): path
+playback loop drive either without narrowing on the concrete type. The
+protocol carries no ``filling`` and no ``locate``: path
 resolution is the persistence seam's job, and "wants generation" is the one
 generation signal the fill reconciler reads.
 """

--- a/src/punt_vox/voxd/programs/producer.py
+++ b/src/punt_vox/voxd/programs/producer.py
@@ -5,7 +5,7 @@ the format-specific generation call (ElevenLabs music, later dialogue and
 narration). It raises one of two error types so the fill loop routes cleanly to
 the right Program transition: a permanent error (bad prompt / ToS / missing key)
 becomes ``ProducerBadInputError``; a transient one (429 / quota / 5xx / timeout)
-becomes ``ProducerTransientError`` (findings #4/#5).
+becomes ``ProducerTransientError``.
 """
 
 from __future__ import annotations

--- a/src/punt_vox/voxd/programs/retry_machine.py
+++ b/src/punt_vox/voxd/programs/retry_machine.py
@@ -1,13 +1,13 @@
 """The transient-error backoff sub-machine -- the Z ``retrying``/``failed`` transitions.
 
 :class:`RetryMachine` wraps one :class:`ProgramState` and computes the successor
-for each transient-error transition (the resilience states carried over from
-``vox-ig52``). It never mutates: every method re-validates the successor through
+for each transient-error transition -- the retrying and failed resilience
+states. It never mutates: every method re-validates the successor through
 :meth:`ProgramState.with_updates` and returns it for the single writer to store.
 
 The empty-pool guard on :meth:`retry_exhausted` and the non-empty self-loop of
-:meth:`retry_capped` are what confine hard-failure to the empty-pool case
-(finding #4): a Program with a non-empty pool tolerates transient errors
+:meth:`retry_capped` are what confine hard-failure to the empty-pool case:
+a Program with a non-empty pool tolerates transient errors
 indefinitely, recovering via :meth:`recover` while playback continues.
 """
 
@@ -97,7 +97,7 @@ class RetryMachine:
     def retry_capped(self, reason: Reason) -> ProgramState:
         """Tolerate a transient at the cap on a non-empty pool (Z ``RetryCapped``).
 
-        A non-empty pool never hard-fails (finding #4): at the cap a further
+        A non-empty pool never hard-fails: at the cap a further
         transient error neither exhausts (that needs an empty pool) nor climbs
         (``retry_fails`` guards below the cap), so the retry self-loops with
         ``attempts`` pinned and playback untouched -- it "plays on and keeps

--- a/src/punt_vox/voxd/programs/rotate_policy.py
+++ b/src/punt_vox/voxd/programs/rotate_policy.py
@@ -1,10 +1,10 @@
-"""The playlist advance strategy -- ``RotatePolicy`` (finding #1).
+"""The playlist advance strategy -- ``RotatePolicy``.
 
-Realises the Phase-1 playlist ``PlaybackPolicy``: shuffle-advance the pool,
+Realises the playlist ``PlaybackPolicy``: shuffle-advance the pool,
 avoiding an immediate repeat when more than one Part is ready, and replaying the
 sole Part when only one is. It is today's ``TrackPool.pick_next`` promoted to a
 strategy. A playlist has no end, so it never returns ``COMPLETE``; a finite
-format (podcast/audiobook) supplies its own sequential policy in a later phase.
+format (podcast/audiobook) supplies its own sequential policy.
 """
 
 from __future__ import annotations

--- a/src/punt_vox/voxd/programs/state.py
+++ b/src/punt_vox/voxd/programs/state.py
@@ -26,7 +26,7 @@ class _Unset:
     """Sentinel for "carry this field forward" in :meth:`ProgramState.with_updates`.
 
     Distinct from ``None`` because ``None`` is a legal value for the optional
-    fields (it clears them), so it cannot also mean "unchanged" (MAJOR-3).
+    fields (it clears them), so it cannot also mean "unchanged".
     """
 
     __slots__ = ()
@@ -159,7 +159,7 @@ class ProgramState:
 
     @property
     def ordered_pool(self) -> tuple[Part, ...]:
-        """Return the ready Parts sorted by intrinsic index (stable, MAJOR-1)."""
+        """Return the ready Parts sorted by intrinsic index (stable)."""
         return tuple(sorted(self._pool, key=lambda part: part.index))
 
     @property
@@ -204,7 +204,7 @@ class ProgramState:
 
         The shared spine of the six disjunctive transitions. Callers override
         ``filling`` afterwards where the model requires it -- ``StartFromDisk``
-        keeps the fill inactive (finding #2), ``Recover`` forces it on.
+        keeps the fill inactive, ``Recover`` forces it on.
         """
         if not pool:
             return Activation(mode=Mode.GENERATING_FIRST, filling=True, playing=None)
@@ -228,7 +228,7 @@ class ProgramState:
         """Return a re-validated successor with the named fields replaced.
 
         Every parameter carries its field's exact type, so each call site is
-        type-checked (MAJOR-3); ``format`` is never a parameter because it is
+        type-checked; ``format`` is never a parameter because it is
         invariant across all transitions. Unnamed fields carry forward.
         """
         return ProgramState(

--- a/src/punt_vox/voxd/programs/status_handler.py
+++ b/src/punt_vox/voxd/programs/status_handler.py
@@ -2,9 +2,9 @@
 
 Reads the daemon's live :class:`ProgramStatus` on every call and returns it,
 never a cached copy: a client asking "what is playing?" gets exactly what the
-daemon holds, so no server-side shadow can drift. Reading a
-log is not a strategy for a client -- both failure surfaces (program-level and
-per-Part) cross the wire here.
+daemon holds, so no server-side shadow can drift. Reading a log is not a
+strategy for a client -- both failure surfaces (program-level and per-Part)
+cross the wire here.
 """
 
 from __future__ import annotations

--- a/src/punt_vox/voxd/programs/status_handler.py
+++ b/src/punt_vox/voxd/programs/status_handler.py
@@ -2,7 +2,7 @@
 
 Reads the daemon's live :class:`ProgramStatus` on every call and returns it,
 never a cached copy: a client asking "what is playing?" gets exactly what the
-daemon holds, so no server-side shadow can drift (vox-73m5 / vox-ig52). Reading a
+daemon holds, so no server-side shadow can drift. Reading a
 log is not a strategy for a client -- both failure surfaces (program-level and
 per-Part) cross the wire here.
 """

--- a/src/punt_vox/voxd/synthesis.py
+++ b/src/punt_vox/voxd/synthesis.py
@@ -273,8 +273,8 @@ class SynthesisPipeline:
         raises on failure. ``cached=True`` marks an on-disk cache hit (no
         TTS call); ``cached=False`` marks fresh audio -- the observability
         signal forwarded to callers. A per-call ``api_key`` bypasses the
-        cache on lookup and store (billing isolation); the
-        anonymous path uses the MD5-keyed cache. See ``punt_vox.cache``.
+        cache on lookup and store (billing isolation); the anonymous path
+        uses the MD5-keyed cache. See ``punt_vox.cache``.
         """
         voice = spec.voice
         provider_name = spec.provider or ""

--- a/src/punt_vox/voxd/synthesis.py
+++ b/src/punt_vox/voxd/synthesis.py
@@ -273,7 +273,7 @@ class SynthesisPipeline:
         raises on failure. ``cached=True`` marks an on-disk cache hit (no
         TTS call); ``cached=False`` marks fresh audio -- the observability
         signal forwarded to callers. A per-call ``api_key`` bypasses the
-        cache on lookup and store (vox-a3e billing isolation); the
+        cache on lookup and store (billing isolation); the
         anonymous path uses the MD5-keyed cache. See ``punt_vox.cache``.
         """
         voice = spec.voice


### PR DESCRIPTION
## What

Removes development-process citations (bead IDs, PR numbers, phase refs, review-finding labels, `MAJOR-N`/`risk R1` tags) from docstrings and comments across `src/punt_vox/` — the remainder PR #302 did not sweep. Comments/docstrings document the non-obvious WHY of the code, never the project's history (agent-engineering §8 / PY-DOC-2). Substance is preserved in every case; only the rotting cross-ref is struck (and several lines read better for it, e.g. "carried over from vox-ig52" → "the retrying and failed resilience states").

## Scope

20 files swept, ~30 citations removed: `vox-73m5`/`vox-ig52`/`vox-a3e`/`vox-nmb`, `PR #175`, `Phase 1/2/3`, `finding #1/#2/#4/#5/#7/#9`, `MAJOR-1/-2/-3`, `risk R1`, `DES-027`. Kept true false-positives (`vox-side artifact`, `not vox-specific` — hyphenated words, not bead IDs).

The 6 logging-subsystem files (`log_handlers.py`, `logging_config.py`, `voxd/config.py`, `crash_logging.py`, `vibe_trace.py`, `log_sanitize.py`) are intentionally left for the vox-fdmm logging-rework stream's own citation sweep (they're mid-rewrite there) — so the whole-tree goal is still met, just split across the two PRs.

## Verification

`make check` green (2669 tests; check-oo `status_views.py` module_size improved 80→79, coupling/suppressions unchanged). Post-sweep grep for process citations across the swept files returns zero hits. No runtime change — docstrings/comments only.

Closes vox-n3t1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and docstring edits only; behavior and APIs are unchanged.
> 
> **Overview**
> Strips **development-process citations** from docstrings and comments across ~20 files under `src/punt_vox/`, continuing a doc-hygiene sweep. Removed references include bead IDs (`vox-73m5`, `vox-a3e`, `vox-ig52`, `vox-nmb`), PR numbers, phase labels (`Phase 1/2/3`), review tags (`finding #N`, `MAJOR-N`, `risk R1`, `DES-027`), while keeping the explanatory **why** (e.g. cache bypass for billing isolation, ephemeral vibe config split).
> 
> In a few places the edits **reword** comments for clarity—`cache.py` now points at `SynthesisPipeline.synthesize_to_file` instead of an old `_synthesize_to_file` path—and **`.oo-baseline.json`** updates `status_views.py` `module_size` 80→79 after a one-line module docstring trim. **No executable code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea7efeb123e0d8961dc8541872b2339b04b46863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->