### PR TITLE
docs(workflow): three nested loops in WORKFLOW.md + @-imports in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,23 @@ Text-to-speech CLI, MCP server, and Claude Code plugin. Supports ElevenLabs (pre
 - **MCP server**: `vox-server`
 - **Python**: 3.13+, managed with `uv`
 
+## Mandatory Reading
+
+Source-of-truth documents, `@`-imported so they load into context at session
+start. Read them before writing code.
+
+@docs/WORKFLOW.md
+@../punt-kit/standards/architecture.md
+@../punt-kit/standards/oo.md
+@../punt-kit/standards/python.md
+
+`WORKFLOW.md` is the three-loop development process (backlog → PR → mission),
+with pseudocode and an entry/exit Z schema at each level. The
+`punt-kit/standards` imports are the org's canonical engine-and-clients
+architecture, object-oriented stance, and Python standard (including the OO
+ratchet vox already runs) — cross-repo (external) imports, so the first load
+may ask for approval.
+
 ## Architecture
 
 ### How synthesis works
@@ -95,34 +112,9 @@ Bootstrap (first time only): run `make update-oo` to create the initial baseline
 
 ## Development Loop
 
-Two nested loops govern all code changes.
+The development workflow is **three nested loops** — the **backlog loop** (what to work on and in what order), the **PR loop** (one rollback-coherent merge), and the **mission loop** (one delegated piece of work) — defined authoritatively in **[`docs/WORKFLOW.md`](docs/WORKFLOW.md)**, `@`-imported above so it loads at session start. Read it before any code change; the pseudocode and the entry/exit Z schemas at each level are the source of truth for how work moves.
 
-### Inner loop — one mission
-
-Execute after every agent delegation that produces code changes. Do not start the next mission until this loop is complete — starting without local review is a procedural violation.
-
-1. **Delegate** to the right ethos specialist. One mission = one focused task. Never batch multiple steps. Do not use bare `Agent()` for implementation work (review-cycle fixes are the only exception).
-2. **`make check`** — must pass before proceeding. Zero exceptions.
-3. **`make install`** — builds the wheel and installs it locally. `make check` passing is not installation. **After installing, restart `voxd`** — the running daemon loads code at startup and will serve the old version until restarted. Tests that exercise MCP tools, hooks, or the synthesis pipeline are testing the old code if the daemon is stale. Restart with `vox daemon restart` (or kill and relaunch manually).
-4. **`make test`** against the installed artifact — not from source. If no test covers the changed code, write one before marking this step complete.
-5. **Exercise manually** — before running, write expected output for each case. After running, compare actual to expected; differences are bugs. Cover: one invalid or malformed input, one case where a dependency is unavailable or returns an error, one boundary condition. Paste the actual output. **For audio paths, run the canonical flight in [`docs/testing/manual-tests.md`](docs/testing/manual-tests.md) and ask the operator after each audible step — log inspection alone is not sufficient because vox produces audio that only the human can judge.**
-6. **`/feature-dev:code-reviewer`** on the mission diff.
-7. **`/pr-review-toolkit:silent-failure-hunter`** on the mission diff.
-8. **Fix every finding.** To dismiss one: document (a) the exact finding, (b) the specific reason it does not apply, (c) the code reference. "Pre-existing", "by design", "intentional", and "expected" are not reasons.
-9. **Re-run both agents.** Exit the fix loop on the first round that produces no findings.
-10. **Commit.**
-
-### Outer loop — one PR (one rollback-coherent unit)
-
-After all missions for the feature complete and each has passed its inner loop:
-
-1. **`make check`** on the full accumulated diff.
-2. **Both local review agents** on the complete diff — cross-mission issues only appear at this level.
-3. **Fix all findings** using the same documentation standard as the inner loop.
-4. **Human IDE review** of the full diff — the only human review in the process. Resolve all findings before proceeding.
-5. **`make install`** then restart `voxd` (`vox daemon restart`), then run the complete user-facing workflow end-to-end, including at least one path through a provider. Paste actual output and verify the changed code was exercised.
-6. **Re-run agents** until clean.
-7. **Open PR.** A PR opened before step 6 is clean is a procedural violation.
+The vox-specific precision that used to live here now lives in `WORKFLOW.md`, intact: `make check` green before every commit; `make install` + `vox daemon restart` before exercising any MCP/hook/synthesis path, because the daemon serves old code until restarted; `make test` against the installed artifact; the two local review agents (`code-reviewer` and `silent-failure-hunter`) iterated to a zero-findings round; and the **audio demo confirmed by ear** — the canonical flight in [`docs/testing/manual-tests.md`](docs/testing/manual-tests.md), asking the operator after each audible step, because vox produces audio only a human can judge. The stateful-audio formal-modeling gate is [Formal Modeling (z-spec)](#formal-modeling-z-spec) below; the merge mechanics and recap-email discipline are in the org workflow (`../CLAUDE.md`).
 
 ### PR boundaries
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,491 @@
+# Development Workflow
+
+All work in this repository runs as three nested loops. The outermost loop
+owns the backlog: what is worth doing and in what order. The middle loop owns
+one pull request: a single shippable, revertible change. The innermost loop
+owns one mission: a single delegated piece of work inside that change.
+
+```text
+Level 1 — Backlog loop   one iteration = one work batch     (beads)
+  Level 2 — PR loop      one iteration = one pull request
+    Level 3 — Mission    one iteration = one delegated mission
+                         (design, code, test — a do-while)
+```
+
+Each level hands work down and receives finished results back. Escalation of
+scope only goes up: a mission that uncovers a bigger problem grows its PR; a
+PR that uncovers a new line of work files a bead for the backlog loop. Defects
+move the other way — anything found while a PR is open is fixed in that PR,
+never sent back to the backlog.
+
+The pseudocode at each level gives the control flow; a small Z schema at each
+level gives the doorway conditions — what must be true to enter an iteration
+and what must be true to leave it. The state those schemas observe:
+
+```text
+LoopState
+  signals       : ℙ SIGNAL  -- issues, alerts, messages not yet triaged
+  open          : ℙ BEAD    -- open beads: the single work funnel
+  validated     : ℙ BEAD    -- re-proven against current main
+  claimed       : ℙ BEAD    -- the current batch
+  closed        : ℙ BEAD    -- beads completed by a merged PR
+  activeWorkers : ℙ WORKER  -- sub-agents editing the shared worktree
+  testCount     : ℕ         -- tests collected by the suite
+  ------------------------------------------------------------------
+  validated ⊆ open
+  claimed   ⊆ validated
+  open ∩ closed = ∅         -- a bead is open or closed, never both
+```
+
+A bead's lifecycle is a walk through these sets: `open → validated → claimed
+→ closed`. Steps that were performed ("the recap was sent") appear as named
+predicates over declared terms, never as bare primed flags.
+
+## Roles
+
+The operator owns requirements and design direction, rules on genuine design
+forks, and confirms the audio demo by ear. Claude runs everything else: the
+backlog, the missions, the review cycles, and the merges. Review of code is
+done by agents — the local review agents plus Copilot and Bugbot on the PR.
+There is no human review gate. The operator reads code in the IDE, but that
+inspection is separate, feeds design discussion only, and nothing in these
+loops waits on it.
+
+## Level 1 — The backlog loop
+
+The backlog loop keeps the bead tracker true and decides what to work on
+next. Beads are the single funnel: every piece of work, whatever its origin,
+is a bead before it is anything else. One iteration selects and completes one
+batch of work. The loop runs at session start and again whenever the current
+batch is done.
+
+```text
+function backlog_loop():
+
+    # 1. INTAKE — every signal becomes a bead or is disposed at the door
+    for signal in [github_issues, dependabot_alerts, biff_messages,
+                   operator_requests, new_scope_found_while_working]:
+                   # a defect inside an open PR's unit is fixed in that PR,
+                   # never filed — only genuinely NEW scope arrives here
+        if duplicate(signal):  close_at_door(signal, link_existing_bead)
+        elif invalid(signal):  close_at_door(signal, stated_reason)
+        else:                  bd_create(signal, labels, link_back_to_source)
+
+    # 2. VALIDATE — a bead must be true before it is workable
+    for bead in candidates(bd_ready):
+        confirm it is still real against current main
+        confirm nothing merged or decided has superseded it
+        confirm it is one rollback-coherent unit (split or merge if not)
+        confirm its blocked-by links reflect reality
+        otherwise: fix the bead, or close it with the reason
+
+    # 3. ASSESS — automatic ordering; escalate only on a genuine fork
+    order = sort(validated, by:
+        security severity                  # open HIGH/CRITICAL first, always
+        > broken user journeys             # audio paths users actually hit
+        > active epic continuity           # finish what is started
+        > debt that blocks throughput      # decomposition, OO ratchet paydown
+        > features)                        # then features
+    if the ordering hits a fork the charter cannot resolve:
+        ask the operator for a focus ruling
+    else:
+        proceed without asking
+
+    # 4. SELECT AND EXECUTE
+    batch = claim a realistic set from the top of the order
+    for unit in rollback_coherent_units(batch):
+        pr_loop(unit)                      # Level 2
+
+    # 5. CLOSE OUT
+    close GitHub issues resolved by the merged PRs, linking each PR
+    send the batch recap via beadle-email  # to jim@punt-labs.com; covers what
+                                           # the per-merge recaps do not: intake
+                                           # dispositions, beads closed at
+                                           # validation, order changes
+    return to intake — new signals have accrued while working
+```
+
+Entry and exit for one batch iteration:
+
+```text
+EnterBatch ≙ [ LoopState ]                -- no precondition: the backlog loop
+                                          -- is a do-while(true); intake always
+                                          -- has standing to run
+
+ExitBatch ≙ [ Δ LoopState |
+  intakeDisposed(signals)                 -- every signal observed at this
+                                          --   iteration's intake became a bead
+                                          --   or was closed at the door with a
+                                          --   reason; new signals keep accruing,
+                                          --   so the live queue is never empty
+  ∧ claimed′ = ∅ ∧ claimed ⊆ closed′      -- the batch drained: every claimed
+                                          --   bead closed by a merged PR
+  ∧ resolvedIssuesClosed(mergedPRs)       -- GitHub issues answered with their PR
+  ∧ batchRecapSent(claimed) ]
+```
+
+### Intake
+
+Work arrives from five places: GitHub issues, Dependabot security alerts,
+biff messages from agents in other repositories, requests from the operator,
+and new lines of work discovered while building. That last source carries a
+boundary: a defect found inside the unit of an open PR is fixed in that PR and
+never becomes a bead; only genuinely new scope — discovered outside any open
+PR, or clearly a separate rollback unit — enters at intake. At intake, each
+signal is either turned into a bead or closed at the door with a stated reason
+— duplicate of an existing bead, or invalid.
+
+Security alerts map severity to priority: a critical or high alert becomes a
+P1 bead and goes to the front of the order. Security work does not wait.
+
+Intake must not depend on remembering to look. A recurring poll (via the
+`/loop` skill) or a session-start sweep checks the GitHub issue list and the
+Dependabot alert list, so an alert filed overnight is a bead by the time the
+first batch is selected. Start every session with `/loop 2m /biff:read` so
+messages from other repos surface too.
+
+### Validation
+
+The codebase moves; beads rot. Before a bead is workable, confirm it is still
+real: reproduce the bug or re-check the premise against current main, confirm
+no merged PR or design decision has superseded it, confirm it describes one
+rollback-coherent unit, and confirm its dependency links are correct. A stale
+bead is closed with the reason. A bloated bead is split. Validation covers the
+candidates for the coming batch, not the whole backlog every time.
+
+### Assessment
+
+Ordering is automatic in the steady state. The sort is:
+
+1. **Security severity.** Open high or critical alerts outrank everything.
+2. **Broken user journeys.** A bug on an audio path users actually hit — a
+   provider that will not authenticate, a hook that plays the wrong chime, a
+   record that never writes its file — beats new work.
+3. **Active epic continuity.** An epic in flight keeps its claim until it is
+   done. Interleaving epics is how a backlog churns without shipping.
+4. **Debt that blocks throughput.** OO-ratchet paydown, module decomposition,
+   test infrastructure that makes the next ten changes cheaper.
+5. **Features.** New providers, voices, music, applet surface.
+
+The operator is asked for a focus ruling only when the ordering hits a genuine
+fork the rules cannot resolve: two epics competing to be active, a strategic
+pivot, or a shift in the debt-versus-feature balance. Direction belongs to the
+operator; sequencing inside a settled direction does not require asking.
+
+## Level 2 — The PR loop
+
+One iteration of the PR loop produces one merged pull request. It is entered
+when the backlog loop hands down a unit of work sized for throughput, and it
+runs the missions (Level 3) needed to build that unit.
+
+### Sizing: throughput, not purity
+
+Nobody reads these diffs. Agents review them, and they squash-merge. So the
+size of a PR is an economic decision, not a hygiene one:
+
+- **The floor is transaction cost.** Every PR pays a roughly fixed overhead —
+  branch, full-diff review rounds, the audio demo, CI, remote review cycles,
+  the merge gate, the recap. A PR too small pays that overhead for too little.
+- **The ceiling is reviewer effectiveness.** The reviewers are agents, and
+  past a certain diff size their quality drops. A PR too large buys throughput
+  at the cost of review quality.
+- **The typical right size** is several small beads batched together, or one
+  coherent slice of a larger bead. A bead too large to slice into one PR is
+  mis-filed: decompose it into an epic whose child beads fit the band.
+- **Rollback coherence still binds.** Whatever merges must revert together
+  sensibly. That is the one structural constraint. "Purity," "one concern per
+  PR," and "keep the diff small" are not criteria — a docs fix, an OO-ratchet
+  paydown, or an adjacent bug fix riding along is welcome, and an improvement
+  is never held back or split out for tidiness.
+
+```text
+function pr_loop(unit):
+
+    # A. BUILD — missions, one at a time
+    branch from main
+    if unit is architectural (daemon/client protocol, new provider,
+                              hook-classification, stateful audio subsystem):
+        design mission first, with no prescribed write-set
+        leader reviews the design end-to-end and STRIKES any migration,
+            compat, shim, or version-bridge element before it reaches code
+        substantive issues go to the operator as concrete decisions
+            (each with a recommendation), one ASK per issue
+        implementation waits for the operator's ratification
+    for mission in unit:
+        mission_loop(mission)             # Level 3
+        # bug fixes are TDD: a failing test reproduces the defect first
+        # coverage rises with every mission
+        # stateful-audio work is model-checked before implementation
+
+    # B. FULL-DIFF VERIFICATION (local, before any PR exists)
+    make check                            # full gate on the accumulated diff
+    repeat:
+        findings = code_reviewer + silent_failure_hunter on the full diff
+        fix every finding in this PR      # no deferrals
+    until a round produces zero findings
+
+    # C. AUDIO DEMO — confirmed by ear, the one human gate
+    make install; vox daemon restart      # the daemon serves old code until
+                                          #   restarted; a stale daemon demos
+                                          #   the old build
+    write down the expected outcome, then drive the real entry point
+        (mic tool, CLI command, hook fire)
+    capture machine evidence: mic:status, vox doctor, and grep of vox.log
+    run the canonical flight in docs/testing/manual-tests.md and ask the
+        operator after EACH audible step — a log cannot judge whether the
+        audio sounded right; only the operator's ear can
+
+    # D. SHIP
+    bd close the bead(s)
+    push; create the PR (description carries the verification playbook)
+    request Copilot review once, on open
+    schedule a background poll with /loop   # never gh pr checks --watch,
+                                            # never foreground sleep loops
+
+function poll_tick(pr):
+    state = current reviews, threads, checks   # prefix gh with
+                                               #   env -u GH_TOKEN
+                                               #   -u GITHUB_PERSONAL_ACCESS_TOKEN
+    for finding in unaddressed(state):    # handled now, never on a later tick
+        delegate the fix to a bare agent  # or reply with the concrete reason
+                                          # the finding does not apply
+        make check; commit; push          # each push restarts the gate
+        resolve the thread ONLY after a landed commit closes it, one by one,
+            never in bulk — the leader resolves, not the agent
+    if merge_gate(state): merge (squash, --delete-branch); close_out()
+
+function merge_gate(state) -> bool:
+    return docs, lint, and test green on the latest commit
+       and Copilot has reviewed the latest commit   # it re-reviews on push
+       and (Bugbot has reviewed the latest commit
+            or Bugbot never reviewed this PR and more than six minutes
+               have passed since CI went green)
+       and zero unresolved review threads
+       and the latest review round had zero material findings
+    # When this returns true: merge EXPLICITLY. No --auto. No --admin.
+    # Do not ask, do not wait.
+
+function close_out():
+    cancel the poll loop
+    delete the branch; checkout main; pull
+    send the merge recap via beadle-email # to jim@punt-labs.com, every merge,
+                                          # unprompted — a permanent record in
+                                          # the 8-part recap structure
+    start the next unit immediately       # no stopping to report
+```
+
+Entry and exit for one PR iteration. `merge_gate` in the pseudocode is the
+pre-merge subset of these conditions; `ExitPR` describes the state after
+close-out completes.
+
+```text
+EnterPR ≙ [ LoopState; unit : ℙ BEAD |
+  unit ⊆ claimed
+  ∧ rollbackCoherent(unit)                -- reverts together sensibly
+  ∧ inThroughputBand(unit)                -- above transaction cost,
+                                          --   below reviewer degradation
+  ∧ (architectural(unit) ⇒ designRatified(unit)) ]  -- operator has ruled
+
+ExitPR ≙ [ Δ LoopState; pr : PR |
+  merged(pr)
+  ∧ localFindings(pr) = ∅                 -- held BEFORE the PR opened
+  ∧ demoConfirmedByEar(pr)                -- held BEFORE the PR opened
+  ∧ ciGreen(head(pr))                     -- docs + lint + test
+  ∧ reviewedByBots(head(pr))              -- Copilot + Bugbot on the latest
+                                          --   commit, per the merge_gate rules
+  ∧ unresolvedThreads(pr) = ∅
+  ∧ materialFindings(latestRound(pr)) = ∅
+  ∧ beadsOf(pr) ⊆ closed′
+  ∧ mergeRecapSent(pr) ]
+```
+
+### Local review before the PR
+
+Full-diff local review is where issues die cheaply. A local round costs
+seconds; a remote review cycle costs minutes to hours. Both `code-reviewer`
+and `silent-failure-hunter` run on the full diff — silent-failure-hunter
+matters especially in vox, where a swallowed provider error becomes silence
+the user cannot diagnose. Every finding is fixed in this PR. A dismissal
+requires the exact finding, the specific reason it does not apply, and the
+code reference. Opening a PR with unresolved local findings is a procedural
+violation.
+
+### The audio demo gate
+
+`make check` passing means the code compiles and the tests pass. It does not
+mean the feature works — and for vox it cannot, because vox produces audio
+that only a human can judge. Before any PR opens, the feature is driven
+through its real entry point — a `mic` tool call, a CLI command, a hook fire —
+with the expected outcome written down first, after `make install` and
+`vox daemon restart` so the running daemon is the just-built code. Machine
+evidence comes from `mic:status`, `vox doctor`, and a grep of `vox.log`. Then
+the operator confirms what no introspection API can attest: that the audio
+sounded right — clean, the correct voice, the music ducked, the chime fired.
+Run the canonical flight in [`docs/testing/manual-tests.md`](testing/manual-tests.md)
+and ask after each audible step, immediately, because audio impressions decay
+within seconds. This is the one human gate in the loops, and it is a demo, not
+a diff.
+
+## Level 3 — The mission loop (design, code, test)
+
+One iteration is one delegated mission: a single piece of design,
+implementation, test, or review work executed by a specialist sub-agent under
+an ethos mission contract. The next mission does not start until this loop
+completes on the current one.
+
+The mission loop is a do-while: the work runs at least once, and the
+review-and-fix cycle repeats until a round comes back clean.
+
+```text
+function mission_loop(mission):
+    contract = write_contract(mission)   # problem, invariants, quality bar,
+                                         # commit discipline — never a
+                                         # write-set for design work; cite the
+                                         # OO rules with an example for
+                                         # protocol/data work
+    dispatch(contract)                   # mission create + background spawn;
+                                         # verify the worker is running
+    do:
+        worker designs / codes / tests   # tests lead; TDD for bug fixes;
+                                         # stateful-audio work is model-checked
+                                         # BEFORE implementation
+        worker commits locally           # each commit passes make check
+        result   = worker submits
+        findings = evaluator review      # a DISTINCT specialist
+                 + leader verification   # make install; vox daemon restart;
+                                         # make test on the installed artifact;
+                                         # drive the real entry point;
+                                         # review agents on the mission diff
+        if findings: reflect(findings)   # another round, same mission
+    while findings remain
+    close(mission)
+```
+
+Entry and exit for one mission iteration:
+
+```text
+EnterMission ≙ [ LoopState; m : MISSION |
+  contracted(m)                           -- problem, invariants, quality bar
+  ∧ workerRunning(m)                      -- dispatch is two operations; a
+                                          --   contract alone is orphaned work
+  ∧ activeWorkers = {workerOf(m)}         -- one worker at a time in a shared
+                                          --   worktree
+  ∧ (statefulAudioClass(m) ⇒ modelChecked(m)) ]  -- z-spec before code
+
+ExitMission ≙ [ Δ LoopState; m : MISSION |
+  verdict(m) = accept                     -- from an evaluator ≠ worker
+  ∧ findings(m) = ∅                       -- the do-while ran dry
+  ∧ (∀ c : commitsOf(m) • checkGreen(c))  -- every commit passed make check
+  ∧ testCount′ ≥ testCount                -- coverage never decreases
+  ∧ ooRatchetHeld(m)                      -- no metric regressed; ≥ 1 improved
+  ∧ missionClosed(m) ]
+```
+
+`statefulAudioClass(m)` holds when the mission changes a stateful subsystem
+with three or more modes and transitions between them, or an invariant that
+must hold across transitions — the music playlist (`off → generating-first →
+playing-filling → rotating`), the vibe/signal accumulation, the daemon
+playback lifecycle, a concurrent-writer discipline (the `vox.log` rotation
+lock). It does NOT hold for pure I/O helpers, provider SDK wrappers, text
+normalization, or single-function fixes with no state. When it holds, the
+model (`docs/<feature>.tex`) is `fuzz`-clean and, for higher-stakes
+invariants, ProB-model-checked, BEFORE the implementation mission dispatches.
+
+### Who does what
+
+The leader runs the workflow; the specialists produce the work. The boundary
+is strict in both directions.
+
+**The leader owns the workflow.** The backlog, the mission contract,
+dispatch, monitoring, the local review agents (run on each mission's diff and
+on the full diff), the audio demo, and every git and GitHub operation:
+branches, pushes, opening the PR, driving remote review, resolving threads,
+merging, and closing out. The leader does not write production code. The only
+files the leader authors directly are the doc set — `CHANGELOG.md`,
+`CLAUDE.md`, `DESIGN.md`, `README.md`, this `WORKFLOW.md`, design docs, and
+plan files — and those still ship through PRs.
+
+**The worker owns the work.** The thinking and the code inside its mission —
+the design decisions its contract leaves open, the tests, the implementation,
+and local commits on the current branch. A worker never creates branches,
+never pushes, never opens PRs, and never touches review threads. Putting
+workflow operations into a worker's prompt is a contract defect.
+
+**The evaluator** — always a different specialist from the worker, and never
+bound to the same role — reviews the worker's result inside the mission before
+the leader accepts it. The pairings live in `CLAUDE.md`.
+
+**Remote review findings are the one delegation that is not a mission.** When
+Copilot or Bugbot report on the PR, the leader reads each finding and hands
+the mechanical fix to a bare `Agent()`, then pushes and resolves the thread
+itself.
+
+### The lifecycle
+
+1. **Contract.** The leader writes the mission contract: the problem, the
+   invariants, the quality bar, and the commit discipline — one commit per
+   logical step, each passing `make check`, never more than thirty minutes of
+   work uncommitted. A design mission's contract never prescribes a write-set;
+   the specialist decides what to create, split, or extract. For protocol or
+   data work the contract cites the OO rules (`../.claude/rules/python-*.md`)
+   with a BEFORE/AFTER example, because sub-agents revert to procedural habits
+   when the prompt is not explicit.
+2. **Dispatch is two operations.** `ethos mission create` writes the contract;
+   a separate `Agent(subagent_type=<worker>, run_in_background=true)` spawn
+   starts the worker. Verify the worker is actually running — a contract with
+   no agent behind it is orphaned work.
+3. **The worker executes.** Tests lead: a bug fix starts from a failing test
+   that reproduces the defect, and the fix is done when it passes; a feature
+   ships its tests with the code; the test count never goes down. Stateful-
+   audio work gets its model-check before implementation. Every commit passes
+   `make check` — zero exceptions, zero unauthorized suppressions.
+4. **The leader monitors by the filesystem, never by git activity.** A worker
+   editing files is working, even with zero commits — analysis and reading are
+   invisible. Progress is judged by whether the working tree is changing and
+   advancing. An empty commit log is never a reason to intervene, commit by
+   proxy, or stop the agent. A genuine stall — no file changes over a long
+   window and no response to a status message — is the only cause for taking
+   over. Monitoring is silent: concrete facts or action, no narration of the
+   wait.
+5. **Result and evaluation.** The worker submits its result; a distinct
+   evaluator reviews it; reflect-and-advance rounds continue until the
+   evaluator accepts.
+6. **The leader verifies and closes.** Check the result against the contract:
+   `make install`, `vox daemon restart`, `make test` against the installed
+   artifact, and exercise the change through its real entry point with the
+   expected output written first — one invalid input, one missing/erroring
+   dependency, one boundary. Run the applicable local review agents on the
+   mission diff and fix every finding; a dismissal requires the exact finding,
+   the specific reason it does not apply, and the code reference. If the result
+   raises a design question, it goes to the operator as a concrete decision —
+   with a recommendation — before any dependent mission dispatches. Then close
+   the mission.
+
+## Invariants
+
+1. **Beads are the single funnel.** Every piece of work is a bead before it
+   is anything else; external queues (issues, alerts) drain into it at intake.
+2. **A satisfied merge gate means merge now.** The gate is the only path to a
+   merge, and nothing waits once it passes. Merge is always explicit — never
+   `--auto`, never `--admin`.
+3. **Findings never wait.** Review feedback is handled the moment it arrives,
+   not on the next poll tick and never in a follow-up PR. Threads are resolved
+   only against a landed commit, one by one, never in bulk.
+4. **Every push restarts the merge gate.** Fresh CI and fresh reviews on the
+   new commit, with the single Bugbot exception stated in the gate.
+5. **Defects flow inward, scope flows outward.** A defect found while a PR is
+   open is fixed in that PR. Only genuinely new lines of work become beads.
+6. **The operator gates the audio demo and direction, never diffs or
+   sequencing.**
+7. **Close-out is inside the loop.** The recap email, branch hygiene, and
+   starting the next unit are steps of the loop, not afterthoughts.
+8. **No migration, compat, shim, or version-bridge code.** Punt Labs products
+   have no installed base to migrate; the leader strikes any such element at
+   design review, before it reaches implementation.
+9. **The daemon is the audio host.** `voxd` owns playback, the cache, the
+   music program, and the recordings on disk; clients are thin controllers.
+   Work that touches audio, audio files, or daemon-owned state routes through
+   the daemon so it behaves the same whether the daemon is local or remote.
+10. **Never touch `vox.md` / `vox.local.md` directly.** The daemon writes
+    them; all state is reachable through the `mic` tools. Racing the files
+    corrupts state.


### PR DESCRIPTION
## Summary

Brings vox's configuration into line with lux's model: the development workflow becomes **three nested loops** in a dedicated `docs/WORKFLOW.md`, and `CLAUDE.md` `@`-imports it (plus the punt-kit standards) instead of restating a simpler two-loop version inline.

- **New `docs/WORKFLOW.md`** — Level 1 backlog loop, Level 2 PR loop, Level 3 mission loop. Each level has pseudocode for the control flow and a small **Z schema** (`EnterBatch`/`ExitBatch`, `EnterPR`/`ExitPR`, `EnterMission`/`ExitMission`) over a shared `LoopState`, plus roles and 10 invariants.
- **`CLAUDE.md` restructured** — new `## Mandatory Reading` block `@`-imports `docs/WORKFLOW.md`, `../punt-kit/standards/{architecture,oo,python}.md`. The inline `## Development Loop` (the old inner/outer loops) collapses to a pointer; every step it held moved into WORKFLOW.md.

## vox's precision is preserved, not lost

Folded into WORKFLOW.md verbatim in intent: `make check` before every commit; `make install` + `vox daemon restart` (the daemon serves old code until restarted); `make test` against the installed artifact; the two local review agents (`code-reviewer` + `silent-failure-hunter`); the **audio demo confirmed by ear** (`docs/testing/manual-tests.md`, ask after each audible step); the **stateful-audio formal-modeling gate** as the `EnterMission` predicate `statefulAudioClass(m) ⇒ modelChecked(m)`; the **no-migration/compat/shim** strike at design review; the explicit merge gate (docs+lint+test green, fresh Copilot on HEAD, no `--auto`, no `--admin`); and the recap-email discipline. Two invariants make the daemon-is-audio-host boundary and the never-touch-`vox.md` rule explicit.

## Notes

- Mirrors lux's `docs/WORKFLOW.md` (not lux's older inline CLAUDE.md loop text, which is mid-fix).
- One behavior shift toward the lux model: the demo (by ear) is the operator's gate; there is no separate human diff-review step. Flag if you want the old human-IDE-review gate kept.

Docs-only. markdownlint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only restructuring of agent workflow; the main behavioral note is removing the mandatory human IDE PR review step.
> 
> **Overview**
> Moves vox’s development process from **two inline loops** in `CLAUDE.md` to a **three-level model** (backlog → PR → mission) documented in new **`docs/WORKFLOW.md`**, aligned with lux and punt-kit.
> 
> `CLAUDE.md` gains **Mandatory Reading** with `@`-imports for `WORKFLOW.md` and `../punt-kit/standards/{architecture,oo,python}.md`. The long inner/outer loop sections are replaced by a short pointer; vox-specific rules (`make install` + daemon restart, installed-artifact tests, review agents, ear-confirmed manual audio flight) are consolidated into the new doc rather than dropped.
> 
> **`WORKFLOW.md`** adds pseudocode and Z-style **Enter/Exit** schemas per level, bead intake/validation/ordering, PR sizing and **merge_gate** (explicit squash merge, poll-driven remote review), mission do-while with leader/worker/evaluator roles, and ten invariants (daemon-as-audio-host, no direct `vox.md` edits, no migration shims).
> 
> **Process change:** the old outer-loop **human IDE diff-review gate** is removed; the operator’s blocking gate is **audio demo by ear** only (IDE reading is optional design input). Docs-only; no runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dee06bb22aa8dcabb4d5c7dbe3d2ac22df89d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->