### PR TITLE
docs(remote): fix README guide link + document record/play UX on a remote daemon

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1530,7 +1530,7 @@ Four env vars — three client-side, one server-side:
 - `VOXD_TOKEN` (client): auth token, default from `serve.token` file
 - `VOXD_BIND` (server): bind address via `typer.Option(envvar="VOXD_BIND")`, default `127.0.0.1`
 
-Resolution: explicit arg > env var > file > default. Two deployment models: direct network (same LAN) and SSH tunnel (different networks). Token auth is the security boundary. Access logs redact tokens. Users configure via `.envrc`. See `docs/remote-setup.md` for the setup guide.
+Resolution: explicit arg > env var > file > default. Two deployment models: direct network (same LAN) and SSH tunnel (different networks). Token auth is the security boundary. Access logs redact tokens. Users configure via `.envrc`. See `docs/guide-remote-setup.md` for the setup guide.
 
 ## DES-038: LaunchAgent over LaunchDaemon — Eliminate macOS Background Throttling
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Every failure raises a `VoxError` subclass, and `health()` / `program_*` return 
 
 ## Remote Audio
 
-Run Claude Code on a headless server or cloud VM and hear audio on your local machine — point the client at your local voxd with `VOXD_HOST`/`VOXD_PORT`/`VOXD_TOKEN`. See [docs/guide-remote-setup.md](docs/guide-remote-setup.md) for the walkthrough (direct network and SSH tunnel).
+Run Claude Code on a headless server or cloud VM and hear audio on your local machine — point the client at your local voxd by setting `VOXD_HOST`/`VOXD_PORT`/`VOXD_TOKEN` on the remote host (they are client-side). See [docs/guide-remote-setup.md](docs/guide-remote-setup.md) for the walkthrough (direct network and SSH tunnel).
 
 ## Background Music
 

--- a/README.md
+++ b/README.md
@@ -206,9 +206,7 @@ Every failure raises a `VoxError` subclass, and `health()` / `program_*` return 
 
 ## Remote Audio
 
-Run Claude Code on a headless server or cloud VM and hear audio on your local machine. Set `VOXD_HOST`, `VOXD_PORT`, and `VOXD_TOKEN` on the remote host to point at your local voxd, or use an SSH tunnel for network-boundary crossings.
-
-See [docs/remote-setup.md](docs/remote-setup.md) for the full walkthrough (direct network and SSH tunnel approaches).
+Run Claude Code on a headless server or cloud VM and hear audio on your local machine — point the client at your local voxd with `VOXD_HOST`/`VOXD_PORT`/`VOXD_TOKEN`. See [docs/guide-remote-setup.md](docs/guide-remote-setup.md) for the walkthrough (direct network and SSH tunnel).
 
 ## Background Music
 

--- a/docs/architecture.tex
+++ b/docs/architecture.tex
@@ -375,7 +375,7 @@ Resolution is \texttt{explicit arg > env var > file > default}.  Two
 deployment models are supported: direct network (same LAN) and SSH
 tunnel (different networks).  The token is the security boundary and is
 redacted from access logs; there is no TLS on \texttt{voxd} itself.  See
-\texttt{docs/remote-setup.md}.
+\texttt{docs/guide-remote-setup.md}.
 
 \subsection{System Paths}
 

--- a/docs/guide-remote-setup.md
+++ b/docs/guide-remote-setup.md
@@ -9,6 +9,28 @@ You SSH from machine A (with speakers) to machine B (headless server,
 cloud VM, or second workstation). You run Claude Code on B. When Claude
 finishes a task, you want to hear it on A.
 
+## What plays where
+
+This setup is for **playback that voxd drives**: `vox say`, task
+notifications, chimes, and `/music` all play on the daemon host (machine A) —
+that is the whole point, so you hear your agent on the machine with speakers.
+
+Two commands behave differently, and it is worth knowing before you rely on
+them:
+
+- **`vox record` writes the file on the daemon host (machine A), not on B.**
+  voxd — not the client — writes the recording, so the `.mp3` lands on A's
+  disk. The output path is resolved on B and then used *literally on A*, so
+  recording against a remote daemon works cleanly only when that absolute path
+  also exists on A (for example, matching home directories). Pass an explicit
+  `-o /abs/path` that is valid on machine A. Smoothing this cross-host path
+  handling is planned.
+- **`vox play <file>` plays on the machine you run it from, not through the
+  daemon.** Run on B, it plays on B — and a headless host has no audio — so it
+  does *not* play a recording back on A. To hear a saved file on A, play it on
+  A directly. Routing an existing file through the daemon for playback is
+  planned.
+
 ## Quick decision
 
 - **Same LAN** (both machines on your home/office network) → Direct network (simpler, persistent)

--- a/docs/guide-remote-setup.md
+++ b/docs/guide-remote-setup.md
@@ -20,11 +20,13 @@ them:
 
 - **`vox record` writes the file on the daemon host (machine A), not on B.**
   voxd — not the client — writes the recording, so the `.mp3` lands on A's
-  disk. The output path is resolved on B and then used *literally on A*, so
-  recording against a remote daemon works cleanly only when that absolute path
-  also exists on A (for example, matching home directories). Pass an explicit
-  `-o /abs/path` that is valid on machine A. Smoothing this cross-host path
-  handling is planned.
+  disk. Both the output directory (always sent) and an explicit `-o` path are
+  resolved on B and then used *literally on A*, so recording against a remote
+  daemon works cleanly only when that absolute path also exists on A (for
+  example, matching home directories). Until the recording destination is
+  constrained daemon-side (in progress), keep voxd on a trusted network or
+  behind the SSH tunnel below — the token lets a client influence where the
+  daemon writes. Cross-host path handling is being hardened.
 - **`vox play <file>` plays on the machine you run it from, not through the
   daemon.** Run on B, it plays on B — and a headless host has no audio — so it
   does *not* play a recording back on A. To hear a saved file on A, play it on


### PR DESCRIPTION
## Summary

The README's Remote Audio link pointed at `docs/remote-setup.md` — the file is `docs/guide-remote-setup.md`, so the link 404s. Fixed, and trimmed the README section to a one-line mention plus the link (remote setup detail belongs in the guide, not the README).

The guide covered `vox say`/notifications only and said nothing about `vox record` or `vox play` — the exact commands whose behavior on a remote daemon just changed (vox-tnum, #351) and is easy to misread. Added a short "What plays where" section stating the current UX honestly:

- **`vox record`** writes the file on the **daemon host (A)**, not the client (B). The output path is resolved on B and used literally on A, so it works cleanly only when that absolute path also exists on A — pass an `-o /abs/path` valid on A. (Smoothing cross-host path handling is planned — vox-eoq9.)
- **`vox play <file>`** plays on the machine you run it from, not through the daemon — on a headless B it won't play a recording back on A. Routing playback through the daemon is planned (vox-ovb7).

This sets expectations accurately rather than implying the remote record→play loop is seamless (it isn't yet — that's the daemon-is-audio-host epic, vox-dvri).

Docs-only. markdownlint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and link fixes only; no runtime or API changes.
> 
> **Overview**
> **Docs-only** fix for the Remote Audio guide path and clearer remote-daemon behavior.
> 
> The README and **DESIGN.md** / **architecture.tex** links pointed at `docs/remote-setup.md`; they now target **`docs/guide-remote-setup.md`**. The README **Remote Audio** blurb is shortened to one line plus that link and notes that **`VOXD_HOST` / `VOXD_PORT` / `VOXD_TOKEN` are client-side** on the remote host.
> 
> **`docs/guide-remote-setup.md`** adds **“What plays where”**: daemon-driven playback (`vox say`, notifications, `/music`) happens on machine A; **`vox record`** writes on the **daemon host** with paths resolved on the client but applied literally on A; **`vox play`** plays only on the machine where you run it, not through voxd.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bc61fa5c1ca4471f3598adb3f555db143b1a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->