### PR TITLE
chore: post-release v4.13.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
   "version": "4.13.1",
   "author": {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ vox is usable in three ways, all driving the same `voxd` audio daemon --- so it 
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/956ea0b/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/39089a2/install.sh | sh
 ```
 
 Restart Claude Code, then:
@@ -59,7 +59,7 @@ vox doctor
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/956ea0b/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/39089a2/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and plugin metadata only; no changes to daemon, MCP, or install script logic.
> 
> **Overview**
> **Post-release housekeeping for v4.13.1** — switches the working tree back to the dev plugin identity and refreshes install links.
> 
> The Claude Code plugin **`name`** in `.claude-plugin/plugin.json` goes from **`vox`** to **`vox-dev`**, matching the repo’s dev/prod isolation (release prep swaps to `vox` on the tag; `restore-dev-plugin.sh` puts `vox-dev` back on `main`).
> 
> **README** Quick Start and “verify before running” **`curl`** examples now pin `install.sh` to GitHub commit **`39089a2`** instead of **`956ea0b`**. Plugin **version** remains **4.13.1**; no runtime or MCP behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d6250c2652b38e24cf8e81eba0b247de9197887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->