### PR TITLE
chore: ethos enable (v4.2.0 convergence)

### DIFF
--- a/.punt-labs/ethos/.vendored-manifest
+++ b/.punt-labs/ethos/.vendored-manifest
@@ -1,0 +1,2 @@
+.punt-labs/ethos/CLAUDE.md
+.punt-labs/ethos/.vendored-manifest

--- a/.punt-labs/ethos/CLAUDE.md
+++ b/.punt-labs/ethos/CLAUDE.md
@@ -1,0 +1,48 @@
+# Ethos
+
+How an agent drives ethos — not how to develop ethos itself. Ethos binds a
+name, voice, email, GitHub handle, writing style, personality, and talents
+into one identity that other tools read.
+
+## Who am I
+
+- `ethos whoami` — resolve your identity from the session, git config, or OS
+  user.
+- `ethos iam <persona>` — declare a persona for the current session.
+
+Session hooks inject your persona into context at start and after
+compaction. Ethos generates `.claude/agents/<handle>.md` from team data at
+SessionStart; restart Claude Code to regenerate them after a team change.
+
+## Delegation (missions)
+
+- `ethos mission dispatch --worker <h> --evaluator <h> --write-set <paths> --criteria <text>`
+  — write a mission contract. Dispatch writes the contract; a separate
+  agent spawn does the work.
+- `ethos mission show|log|results <id>` — inspect a mission.
+- `ethos mission close <id>` — close a passing mission.
+- `ethos mission pipeline list|show|instantiate <name>` — drive multi-stage
+  work from a template.
+
+Commit one logical step at a time; the write-set is enforced at runtime, so
+an edit outside it fails the mission.
+
+## Audit
+
+- `ethos audit show --delegation <id>` — reconstruct a delegation's trail.
+- `ethos audit seal` runs at pre-commit when ethos is enabled here; the
+  sealed chunks travel in the same commit as the work.
+- `ethos audit quarantine` — the recovery path for a corrupt chunk.
+
+## Session
+
+- `ethos session` — the current roster.
+- `ethos session purge` — clear stale sessions.
+
+## Gotchas
+
+- Never run `make install` from inside Claude Code — the running binary
+  cannot overwrite itself. Ask a human to run it from a shell.
+- Agent types are discovered at SessionStart; restart after adding one.
+- `ethos doctor` checks the seal hook only when ethos is enabled here — a
+  dormant or never-enabled repo passes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,3 +246,4 @@ Release scripts: `scripts/release-plugin.sh` (swap `vox-dev` → `vox`), `script
 - `docs/architecture.tex` → `docs/architecture.pdf` — system architecture
 - `prfaq.tex` → `prfaq.pdf` — product direction
 - `docs/vox-notify.tex` — Z specification for notification system
+@.punt-labs/ethos/CLAUDE.md


### PR DESCRIPTION
Part of the punt-labs/ethos v4.2.0 rollout (DES-059). vox's .punt-labs/ethos is inline (verified mode), so it can enable now.

`ethos enable` deposited/added exactly four tracked paths:
- .punt-labs/ethos/CLAUDE.md (vendored)
- .punt-labs/ethos/.vendored-manifest
- .punt-labs/ethos/enabled (marker)
- CLAUDE.md — one `@.punt-labs/ethos/CLAUDE.md` import line

It also re-chained the marker-gated git hooks (pre-commit, commit-msg) — those live in .git/hooks and aren't tracked. Committed only the four paths (no `git add -A`; runtime dirt excluded).

Verified: `ethos doctor` → 'Audit seal hook PASS chained seal section active'.

Precedent: ethos#361, public-website#268.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Claude context wiring only; no runtime Python changes in the diff. Local git hook re-chaining is outside tracked files.
> 
> **Overview**
> **Enables ethos in vox** as part of the punt-labs/ethos v4.2.0 rollout (inline/verified vendoring), so session tooling can treat this repo as ethos-active (including marker-gated pre-commit audit sealing described in the vendored guide).
> 
> **Adds tracked vendored ethos docs** under `.punt-labs/ethos/`: a short **Ethos** `CLAUDE.md` (whoami/iam, missions, audit, session, gotchas) and a `.vendored-manifest` that pins which ethos paths are vendored.
> 
> **Wires the guide into the main agent context** by appending `@.punt-labs/ethos/CLAUDE.md` to the root `CLAUDE.md` **Key Documents** section, so Claude Code pulls the ethos operator cheat sheet at session start alongside the existing `@` imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 575d4983469fb42fb5d80e7334800782f980314c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->