### PR TITLE
chore: enable biff CI-failure notifications

### DIFF
--- a/.github/workflows/biff-notify.yml
+++ b/.github/workflows/biff-notify.yml
@@ -1,0 +1,29 @@
+name: Biff CI Notifications
+on:
+  workflow_run:
+    workflows: ["Lint", "Test", "Docs"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          sparse-checkout: .punt-labs/biff
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+      - env:
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: >-
+          uvx --from punt-biff biff --user github-actions wall
+          "CI failed: ${WORKFLOW_NAME} on ${BRANCH} — ${RUN_URL}"
+          --duration 2h


### PR DESCRIPTION
## What

Commits the two files generated by `/biff enable` so biff CI notifications take effect for the repo:

- **`.github/workflows/biff-notify.yml`** — on a `push`-triggered failure of the `Lint`, `Test`, or `Docs` workflow, broadcasts a biff `wall` message ("CI failed: …") for 2h.
- **`.punt-labs/biff/enabled`** — the marker that turns biff on for this repo.

## Fix applied

The generated workflow triggered on a workflow named `"Tests"`, but this repo's test workflow is named **`Test`** (singular) — as generated it would have missed every test-failure notification. Corrected to `"Test"`.

## Safety

- Untrusted `workflow_run` values (branch, workflow name, run URL) go through `env:` and are referenced as double-quoted shell vars (`${BRANCH}`), never interpolated as `${{ }}` in `run:` — no command injection.
- `push`-only trigger (not fork PRs), pinned action SHAs, `contents: read` permissions, 2-minute timeout.

Config only — no code, no version change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only configuration with read-only permissions and no application or runtime code changes.
> 
> **Overview**
> Turns on **biff** for this repo and adds a **`workflow_run`** workflow that posts a 2-hour `wall` message when **`Lint`**, **`Test`**, or **`Docs`** fail on a **`push`** (not fork PRs).
> 
> The workflow sparse-checkouts `.punt-labs/biff`, runs `uvx punt-biff`, and passes workflow name, branch, and run URL via `env:` into a quoted shell string to avoid injection. Action SHAs are pinned, permissions are `contents: read`, and the job times out after 2 minutes.
> 
> A **`.punt-labs/biff/enabled`** marker is added so biff is active for the repository. The monitored test workflow name is **`Test`** (singular), matching this repo’s existing CI workflow names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965fa4b60aa2887a711e39bb72a81f6e0e7f4f55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->