### PR TITLE
docs(vox-efa6): voxd Music Player design + PlayerView Z model

### DIFF
--- a/.punt-labs/ethos/missions/m-2026-07-29-010/log-b7904b4e-3f31-4167-a02e-fd695912658a-1785304174157628000-1785304174157628000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-07-29-010/log-b7904b4e-3f31-4167-a02e-fd695912658a-1785304174157628000-1785304174157628000.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-07-29T05:49:34.157628Z","event":"create","actor":"claude","details":{"evaluator":"bwk","ticket":"","worker":"rmh"}}

--- a/.punt-labs/ethos/missions/m-2026-07-29-010/log-b7904b4e-3f31-4167-a02e-fd695912658a-1785304761499392000-1785305100870858000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-07-29-010/log-b7904b4e-3f31-4167-a02e-fd695912658a-1785304761499392000-1785305100870858000.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-07-29T05:59:21.499392Z","event":"result","actor":"rmh","details":{"confidence":0.86,"evidence_entries":5,"files_changed":2,"round":1,"verdict":"pass"}}
+{"ts":"2026-07-29T06:05:00.870858Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/docs/vox-music-player.md
+++ b/docs/vox-music-player.md
@@ -1,0 +1,351 @@
+# The voxd Music Player
+
+A headless app inside `voxd` that drives a lux scene: browse vox's saved album
+catalog, play or stop a saved album, GNOME-Music-plain. vox is the speakers,
+lux is the display, and the two are co-located on the user's machine. The player
+adds no new audio machinery — it is a **projection of voxd's one active source
+onto a lux scene, plus a command translator back**. Richer transport
+(pause/next/prev/queue) layers on later with no architectural change.
+
+This document is the design; the write-set it produces is the input to a later
+implementation mission. The cross-repo architecture is **settled with the lux
+agent** and is restated in §2 for grounding, not reopened.
+
+## 1. What already exists, and what is actually new
+
+The temptation is to read "play / stop / now-playing state model" as new
+playback machinery. It is not. `voxd` already owns exactly-one-active-source and
+every playback primitive the player needs:
+
+| Player action | Existing voxd primitive |
+|---------------|-------------------------|
+| play a saved album | `ProgramService.replay_album(album_id)` — a single-album `SelectionPlayback` |
+| stop | `ProgramService.off()` |
+| now-playing | `ProgramService.status()` → `ProgramStatus.radio(..., NowPlaying(index, of))` |
+| browse the catalog | `ProgramService.catalog_albums()` → `tuple[Album, ...]` |
+| auto-advance within the album | `SelectionPlayback.rotate()` (the loop drives it on track-end) |
+| refuse deleting a playing album | `active_backing_locators()` guards `MusicRemove` |
+
+The single-active-source invariant already holds: `ActiveContext.current` is zero
+or one source, and the `audio-programs.tex` model proves the Radio/off/rotate
+transitions the player rides. So the player does **not** re-implement playback.
+
+The genuinely new work is three things, none of them a playback state machine:
+
+1. **A lux scene projection** — turn `(albums, now-playing)` into a scene and
+   `PUT /scenes/vox.music`, re-pushing whenever voxd's state changes.
+2. **An inbound command leg** — receive `music.play {album_id}` / `music.stop`
+   from in-scene buttons over lux's pub-sub, and translate each to the primitive
+   above.
+3. **A voxd-internal change signal** — a small PubSub seam on `ProgramService`
+   so the projection re-pushes on every state change (a play from any surface,
+   an auto-advance, a catalog edit), keeping the scene truthful.
+
+This scoping is the design's first substantive claim, called out for the leader
+in §8.
+
+## 2. Architecture (settled cross-repo — restated, not reopened)
+
+vox is one engine (`voxd`) fronted by thin clients. The Music Player is a new
+**app inside `voxd`**: the daemon is the audio host and now also the lux app
+host. Per invariant 9 of `WORKFLOW.md`, work that touches audio and daemon-owned
+state routes through the daemon, so the player and its lux connection live in
+`voxd`, not in a client.
+
+The lux boundary, as agreed with the lux agent (`claude:tty21`):
+
+- **voxd holds lux's public `LuxRestClient`** — never `DisplayClient`.
+  `DisplayClient` is lux's Hub-internal renderer client (guard-enforced, being
+  deprecated for apps): a `DisplayClient` player renders but every click
+  dispatches into a void, which the lux z-spec already flagged. `LuxRestClient`
+  is the public, validated, typed surface; raw REST is forbidden (Jim's ruling —
+  validation and typing).
+- **Identity is `kind=app`, automatic via `LuxRestClient`.**
+- **Send leg (push):** `PUT /scenes/vox.music` with the album-list scene,
+  re-pushed on every state change.
+- **Receive leg (pub-sub):** in-scene Play/Stop `ButtonElement`s whose Hub-side
+  handlers publish `music.play {album_id}` / `music.stop`; voxd subscribes via
+  the persistent `LuxRestClient` extension over WebSocket (luxd serves WS
+  alongside REST on one port).
+
+```text
+        voxd (audio host + lux app host)
+  ┌──────────────────────────────────────────────┐
+  │  ProgramService  ── change signal ─▶ MusicPlayer
+  │  (catalog, replay_album, off,        │   │  │
+  │   status; one active source)         │   │  │
+  │        ▲                             │   │  ▼
+  │        │ replay_album / off          │   │  AlbumListScene (pure projection)
+  │        └─────────────────────────────┘   │  │
+  │                                          │  ▼
+  │                        LuxScenePublisher ─┼─▶ PUT /scenes/vox.music ─▶ luxd
+  │                        LuxSubscription  ◀─┼── music.play / music.stop  (Hub)
+  └──────────────────────────────────────────┘
+                   (public LuxRestClient — one WS+REST port)
+```
+
+The `MusicPlayer` is the only component that talks to both `ProgramService` and
+lux. Everything the scene shows is derived from `ProgramService`; everything a
+click does is a call into `ProgramService`. There is no player-owned playback
+state to drift out of sync.
+
+## 3. vox-side decomposition
+
+A new package, `src/punt_vox/voxd/music_player/`, holds the app. One concern per
+module (PY-IC-6, PY-OO-2); the facade is the only public name (PY-DP-10). The
+`ProgramService` change signal is a small addition to the existing programs
+package.
+
+### 3.1 New package `voxd/music_player/`
+
+| Module | Class | Responsibility |
+|--------|-------|----------------|
+| `__init__.py` | — | `__all__ = ["MusicPlayer"]` — the facade is the package's public API |
+| `player.py` | `MusicPlayer` | The app/facade. Holds the `ProgramService` seam and the lux publisher; registers as a change listener; projects state → scene → push; (phase 2) dispatches inbound events → service calls |
+| `player_view.py` | `PlayerView` | Frozen value: `mode ∈ {idle, playing}`, the playing `album_id`, and the `NowPlaying` cursor. Built from `ProgramStatus`. The object the Z model pins |
+| `scene.py` | `AlbumListScene` | Pure projection `(albums, view) → Scene`. No I/O. Builds the lux element tree (per-album row + Play button, a Stop control, a now-playing marquee) from the public `LuxRestClient` element builders |
+| `lux_scene_publisher.py` | `LuxScenePublisher` | Thin transport over `LuxRestClient`: `push(scene)` → `PUT /scenes/vox.music`. No business logic |
+
+Phase 2 adds the receive leg to the same package:
+
+| Module | Class | Responsibility |
+|--------|-------|----------------|
+| `player_events.py` | `PlayAlbum`, `StopMusic` | The inbound command objects — a discriminated union, each with `apply(service)` (Command pattern, PY-DP-8 / PY-OO-6), so the coordinator dispatches by message, not an `if`-ladder |
+| `lux_subscription.py` | `LuxSubscription` | The persistent WS subscribe loop over the `LuxRestClient` extension: decode `music.play` / `music.stop` into `PlayerEvent`s, and own the ~30s menu-callback lease renewed by contact. **Gated on lux's not-yet-pinned subscribe API** (§7) |
+
+### 3.2 Change signal on `ProgramService` (voxd-internal, not lux-gated)
+
+The scene must re-push whenever voxd's state changes — a play or stop from any
+surface (CLI, MCP, or the lux button), an auto-advance on track-end, or a
+catalog edit (`music new` / `music remove`). `ProgramService` today exposes state
+only by read-per-call `status()`; it fires no notification.
+
+Add a publish-subscribe seam (PY-DP-8), the minimum that keeps the projection
+truthful:
+
+- `ChangeListener` — a single-method Protocol (PY-DP-11, PY-TS-6):
+  `notify_changed() -> None`.
+- `ProgramService.on_change(listener: ChangeListener) -> None` — register.
+- `ProgramService._notify_change() -> None` — fired after each applied command
+  (in the `ControlChannel` single-writer, so notification is serialized with the
+  state it reports) and after each auto-advance in the playback loop, and after a
+  catalog mutation (`new` / `remove`).
+
+`MusicPlayer` registers one listener; `notify_changed()` reads `status()` +
+`catalog_albums()`, builds the `PlayerView` and `AlbumListScene`, and pushes.
+This lives in phase 1 — it is a daemon-internal concern, independent of lux's
+gated PRs, and a read-only scene is worthless if it lies.
+
+### 3.3 Wiring (composition root)
+
+The daemon composition root (`voxd/daemon.py`, via `voxd/programs/wiring.py`)
+constructs `MusicPlayer(service, LuxScenePublisher(LuxRestClient(...)))`, calls
+`service.on_change(player)`, and in `_lifespan`:
+
+- **phase 1:** push the initial scene once the lux connection is up;
+- **phase 2:** run `LuxSubscription` as a background task alongside the existing
+  playback/control tasks, cancelled on shutdown like its siblings.
+
+The `LuxRestClient` is injected at the composition root (as the ElevenLabs
+producer already is), so tests drive the player with a fake lux client and a fake
+`ProgramService` seam.
+
+## 4. The playback / player state model
+
+The player owns no playback state; it owns a **view** derived from the one active
+source, plus the invariants the contract asks to pin. The view is a two-mode
+machine over the catalog:
+
+```text
+PlayerView
+  mode        : {idle, playing}
+  album       : optional ALBUM        -- the album playing (≤ 1)
+  nowPlaying  : optional (index, of)  -- the track cursor within that album
+
+  invariants
+    I1  at most one album playing        -- #album ≤ 1
+    I2  now-playing present iff playing  -- mode = playing ⟺ #album = 1 ⟺ #nowPlaying = 1
+    I3  a played album is catalogued     -- album ⊆ catalogued ids
+```
+
+The transitions are the projection of the already-proven Radio machine
+(`audio-programs.tex`) onto the view:
+
+| Player transition | Underlying primitive | View result |
+|-------------------|----------------------|-------------|
+| `PlayerPlay(album)` from idle | `replay_album` → `StartRadio` | `playing`, `album = {id}`, cursor at track 1 of M |
+| `PlayerPlay(album')` while playing | `replay_album` → `SwitchSelection` | `playing`, `album = {id'}` — the old album is displaced, never two playing (I1) |
+| `PlayerTrackEnd` | loop drives `SelectionPlayback.rotate` → `RadioRotate` | `playing`, same album, cursor advances |
+| `PlayerStop` | `off` → `RadioOff` | `idle`, `album = ∅`, `nowPlaying = ∅` (I2) |
+| album removed while playing | refused by `active_backing_locators` guard | no view change — a playing album cannot be removed |
+
+The three invariants are exactly the contract's "at most one album playing;
+now-playing present iff playing; stop returns to idle." They are consequences of
+the single-active-source model, not new runtime checks: I1 because the channel
+holds one source; I2 because `RadioOff` empties the cursor and `StartRadio`
+fills it; I3 because the `System` invariant already contains a Radio selection in
+the catalogued albums.
+
+**One shared audio slot.** Because there is one audio device and one active
+source, playing a saved album and running the generative program (`mic:music
+on`) are mutually exclusive: `PlayerPlay` displaces a running program (it is a
+`SwitchSelection`/`SwitchProgram` retarget), and starting a program blanks the
+player's now-playing. This is the only coherent design with one device and is
+why the player is a view over the one source, not a second player. Called out
+for the leader in §8.
+
+## 5. Two-phase split
+
+Each phase is independently shippable and rollback-coherent.
+
+### Phase 1 — catalog + album-list scene (push only)
+
+**Starts when** lux's public `LuxRestClient` export merges (PR-3; the lux agent
+pings us). Everything here is stable in lux today.
+
+Deliverables:
+
+- The `music_player` package modules `player.py` (push side only),
+  `player_view.py`, `scene.py`, `lux_scene_publisher.py`.
+- The `ProgramService` change-signal PubSub (§3.2) — voxd-internal, not
+  lux-gated.
+- Wiring: construct the player, register the listener, push the initial scene.
+
+Result: a live `vox.music` scene showing the saved-album catalog and the current
+now-playing, re-pushed on every state change. The scene may render Play/Stop
+`ButtonElement`s whose Hub-side handlers publish `music.play` / `music.stop`, but
+voxd is not yet subscribed, so a click is inert until phase 2. (If the public
+`LuxRestClient` in PR-3 does not yet expose the button-publishes-event element,
+the controls render in phase 2 with the receive leg; the album list and
+now-playing do not depend on it.)
+
+### Phase 2 — interactive
+
+**Gated on** lux's menu model and persistent-extension (subscribe) PRs.
+
+Deliverables:
+
+- `player_events.py` (the `PlayAlbum` / `StopMusic` command objects) and
+  `lux_subscription.py` (the WS subscribe loop).
+- `MusicPlayer` dispatch: decode an inbound event, call `event.apply(service)`
+  (`replay_album` / `off`); the change signal then re-pushes the scene.
+- The **"Music" menu callback** — a session-callback with a ~30s lease renewed by
+  contact — that opens the scene from lux's menu.
+- Wiring: run `LuxSubscription` as a daemon background task.
+
+Result: clicking Play plays that album; clicking Stop stops; the scene reflects
+the change because the same change signal re-pushes.
+
+## 6. Stateful-audio z-spec gate
+
+`WORKFLOW.md` requires a `fuzz`-clean Z model, before the matching
+implementation, for a stateful subsystem with 3+ modes and invariants across
+transitions. Assessment, part by part:
+
+- **Phase-1 scene projection — no new model.** It is a deterministic function
+  `(catalog, active source) → scene`, re-pushed on change. That is a projection
+  (formatting-class), which the gate's carve-out excludes. It introduces no
+  audio-state transition beyond what `audio-programs.tex` already proves.
+- **Phase-2 playback transitions — already proven.** `PlayerPlay` / `PlayerStop`
+  / `PlayerTrackEnd` are `StartRadio` / `RadioOff` / `RadioRotate` on a
+  single-album selection, and the "cannot remove a playing album" property is
+  the `MusicRemove` derivation — all `fuzz`-clean and ProB-checked in
+  `audio-programs.tex`. Re-modeling them would duplicate a proven model.
+- **The player-view invariants — modeled now.** The new, stable content worth
+  pinning is `PlayerView` and its three invariants (I1–I3 of §4) across the
+  player transitions. `docs/vox-music-player.tex` states them as a small
+  self-contained machine and proves each transition preserves them. This is the
+  required model for the stable playback state machine, and it is independent of
+  the lux API (a transition's trigger — a click or a CLI call — is immaterial to
+  the model).
+- **The connection / subscribe / lease lifecycle — deferred.** The phase-2 WS
+  connection state (`disconnected → connected → subscribed → lease-renewed`) and
+  the menu-callback lease do have 3+ modes and invariants (at most one live
+  subscription; a click received while disconnected is dropped; the lease
+  expires unless renewed by contact). But its transitions depend on lux's
+  **not-yet-pinned** subscribe/lease API, so it cannot be modeled precisely now.
+  It is flagged pending the lux API pin and modeled in a follow-on amendment to
+  `vox-music-player.tex` before the phase-2 subscribe loop is implemented.
+
+So: `docs/vox-music-player.tex` ships now with the `PlayerView` machine
+(`fuzz -t` clean); the connection/lease lifecycle is a named, pending addition.
+
+## 7. Dependencies and gating
+
+| Deliverable | Gated on |
+|-------------|----------|
+| Phase 1 (scene projection, push, change signal) | lux public `LuxRestClient` export (PR-3) |
+| Phase-1 in-scene buttons | PR-3 exposing a button-publishes-event element (else defer to phase 2) |
+| Phase 2 (subscribe loop, dispatch) | lux persistent-extension (subscribe) PR |
+| Phase 2 "Music" menu entry | lux menu-model PR |
+| Phase-2 connection/lease Z model | lux subscribe/lease API pinned |
+
+## 8. Decisions for the leader
+
+Three items for the leader to ratify or escalate before the implementation
+mission dispatches.
+
+1. **Scope: the player is a projection, not new playback machinery.** The
+   playback primitives (`replay_album`, `off`, `status`, `catalog_albums`, the
+   remove-guard) already exist; the new work is the lux projection, the receive
+   leg, and a voxd-internal change signal. Recommend scoping the implementation
+   mission to those three, not a rebuild of play/stop/now-playing. *(This
+   corrects the contract's framing that the playback state model is "the real
+   substance.")*
+
+2. **One shared audio slot.** The player reuses the one active source, so playing
+   a saved album and running the generative program (`mic:music on`) are mutually
+   exclusive, and the lux Stop stops whichever is playing. Recommend accepting —
+   it is the only coherent design with one audio device. *(Design decision, not a
+   fork; confirm.)*
+
+3. **Z-spec scoping.** Model the `PlayerView` invariants now
+   (`vox-music-player.tex`, `fuzz`-clean); reuse `audio-programs.tex` for the
+   proven Radio transitions; defer the connection/subscribe/lease lifecycle model
+   until lux pins its subscribe API. Recommend ratifying this split. *(My call
+   under the delegated assessment; confirm or override.)*
+
+## 9. Write-set (the design's output)
+
+Phase 1:
+
+- New package `src/punt_vox/voxd/music_player/`: `__init__.py`, `player.py`,
+  `player_view.py`, `scene.py`, `lux_scene_publisher.py`.
+- `src/punt_vox/voxd/programs/service.py` (+ `control_channel.py` / the loop) —
+  the `ChangeListener` PubSub seam and `_notify_change()` firings.
+- `src/punt_vox/voxd/daemon.py` / `voxd/programs/wiring.py` — construct the
+  player, register the listener, push the initial scene.
+- `pyproject.toml` — the public lux client dependency.
+- Tests mirroring each new module; `ProgramService` change-signal tests; a
+  scene-projection test asserting the element tree for a known catalog + view.
+
+Phase 2:
+
+- `src/punt_vox/voxd/music_player/player_events.py`,
+  `src/punt_vox/voxd/music_player/lux_subscription.py`.
+- `MusicPlayer` dispatch and the menu-callback registration.
+- `daemon.py` — run the subscribe loop as a background task.
+- Tests: event decode/dispatch, the lease renewal, the subscribe-loop lifecycle.
+
+Docs:
+
+- `docs/vox-music-player.tex` — the `PlayerView` Z model (phase 1); the
+  connection/lease amendment (before phase-2 subscribe implementation).
+
+## 10. Rejected alternatives
+
+- **A second, independent player with its own playback state.** Rejected: one
+  audio device means one active source; a second player would contend for the
+  device and could play two things at once. The player is a view over the one
+  source.
+- **`DisplayClient` for the player.** Rejected (and settled): it renders but its
+  clicks dispatch into a void; the public `LuxRestClient` is the only surface
+  with a working receive leg.
+- **Raw REST to luxd.** Rejected per Jim's ruling — the public `LuxRestClient`
+  carries validation and typing; raw REST bypasses both.
+- **Re-model the playback transitions in `vox-music-player.tex`.** Rejected: the
+  Radio/off/rotate/remove machine is already `fuzz`-clean and ProB-checked in
+  `audio-programs.tex`; the new model pins only the player-view invariants.
+- **Poll `status()` on a timer to refresh the scene.** Rejected: a change-signal
+  PubSub re-pushes exactly when state changes, with no polling latency or wasted
+  pushes.

--- a/docs/vox-music-player.md
+++ b/docs/vox-music-player.md
@@ -110,7 +110,7 @@ Phase 2 adds the receive leg to the same package:
 
 | Module | Class | Responsibility |
 |--------|-------|----------------|
-| `player_events.py` | `PlayAlbum`, `StopMusic` | The inbound command objects — a discriminated union, each with `apply(service)` (Command pattern, PY-DP-8 / PY-OO-6), so the coordinator dispatches by message, not an `if`-ladder |
+| `player_events.py` | `PlayAlbum`, `StopMusic` | The inbound event objects — a discriminated union, each with `apply(service)` (polymorphic dispatch — oo.md *Polymorphism Over Conditionals*, PY-OO-6), so the coordinator dispatches by message, not an `if`-ladder |
 | `lux_subscription.py` | `LuxSubscription` | The persistent WS subscribe loop over the `LuxRestClient` extension: decode `music.play` / `music.stop` into `PlayerEvent`s, and own the ~30s menu-callback lease renewed by contact. **Gated on lux's not-yet-pinned subscribe API** (§7) |
 
 ### 3.2 Change signal on `ProgramService` (voxd-internal, not lux-gated)
@@ -132,7 +132,19 @@ truthful:
   catalog mutation (`new` / `remove`).
 
 `MusicPlayer` registers one listener; `notify_changed()` reads `status()` +
-`catalog_albums()`, builds the `PlayerView` and `AlbumListScene`, and pushes.
+`catalog_albums()` and builds the `PlayerView` and `AlbumListScene`.
+
+**The lux `PUT` must never run synchronously in the single-writer.**
+`_notify_change()` fires inside the `ControlChannel` single-writer, so a
+synchronous `PUT /scenes/vox.music` would let a slow or unreachable `luxd`
+stall the daemon's playback control loop — a dead display would freeze audio.
+`notify_changed()` therefore only *builds* the scene and hands it to an async
+publish task via a **latest-wins** channel (a one-slot mailbox that coalesces to
+the newest scene): the single-writer returns immediately, and `LuxScenePublisher`
+drains the mailbox on its own task, where a lux timeout or `HubUnavailable` is
+logged and dropped, never propagated back into audio control. Playback is never
+hostage to the display.
+
 This lives in phase 1 — it is a daemon-internal concern, independent of lux's
 gated PRs, and a read-only scene is worthless if it lies.
 

--- a/docs/vox-music-player.tex
+++ b/docs/vox-music-player.tex
@@ -157,8 +157,8 @@ The cursor starts at track~1 of \texttt{count?}. Because $count? \geq 1$, the
 after-state satisfies the cursor-validity invariant ($1 \leq 1 \leq of'$ and
 $of' \geq 1$), and because $target? \in catalogued$, \texttt{I3}
 ($album' \subseteq catalogued'$) holds. \texttt{PlayerPlay} is the single verb
-for both ``start'' and ``switch'', exactly as \texttt{StartRadio} $\defs$
-\texttt{SwitchSelection} in \texttt{audio-programs.tex}.
+for both ``start'' and ``switch'', exactly as \texttt{SwitchSelection} $\defs$
+\texttt{StartRadio} in \texttt{audio-programs.tex}.
 
 \subsection{PlayerTrackEnd --- auto-advance within the album}
 

--- a/docs/vox-music-player.tex
+++ b/docs/vox-music-player.tex
@@ -1,0 +1,282 @@
+%
+% vox-music-player.tex
+%
+% Z Specification for the voxd Music Player's view state machine.
+%
+% The player owns NO playback machinery. Its play/stop/advance transitions are
+% StartRadio / RadioOff / RadioRotate on a single-album selection, already
+% fuzz-clean and ProB-checked in docs/audio-programs.tex. This model pins the one
+% new, stable thing: the PlayerView --- the projection of voxd's single active
+% source onto a lux scene --- and its invariants across the player transitions:
+%
+%   I1  at most one album playing
+%   I2  now-playing present iff playing
+%   I3  a played album is catalogued (and a playing album cannot be removed)
+%
+% The phase-2 connection / subscribe / lease lifecycle depends on lux's
+% not-yet-pinned subscribe API and is deferred to an amendment (see section 6).
+%
+
+\documentclass[a4paper,10pt,fleqn]{article}
+\usepackage[margin=1in]{geometry}
+\usepackage{fuzz}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\begin{document}
+
+\title{The voxd Music Player: A Z Specification}
+\author{Formal model of the PlayerView state machine}
+\date{July 2026}
+\hypersetup{
+  pdftitle={The voxd Music Player: A Z Specification},
+  pdfauthor={Punt Labs},
+  pdfsubject={Z Specification},
+  pdfcreator={fuzz/probcli}
+}
+\maketitle
+
+\section{Introduction}
+
+The Music Player is a headless app inside \texttt{voxd} that projects the
+daemon's one active source onto a lux scene and translates in-scene clicks back
+into playback commands. It adds no playback machinery: playing a saved album is
+\texttt{ProgramService.replay\_album}, stopping is \texttt{off}, and advancing
+within the album is the playback loop driving \texttt{SelectionPlayback.rotate}.
+Those transitions --- \texttt{StartRadio}, \texttt{RadioOff},
+\texttt{RadioRotate}, and the \texttt{MusicRemove} refusal of a playing album ---
+are already modelled and \texttt{fuzz}-clean in \texttt{docs/audio-programs.tex}.
+
+This specification pins the one new, stable object: the \emph{PlayerView}, and
+the three invariants the design must preserve across every player transition.
+The phase-2 lux connection/subscribe/lease lifecycle depends on lux's
+not-yet-pinned subscribe API and is deferred (Section~\ref{sec:deferred}).
+
+\section{Basic Types and Modes}
+
+An \texttt{ALBUM} is an opaque catalog identifier --- the id \texttt{vox music
+list} prints and the scene's Play button carries. It is a catalog key, never a
+filesystem path; the model treats it as opaque, exactly as
+\texttt{audio-programs.tex} does.
+
+\begin{zed}
+  [ALBUM]
+\end{zed}
+
+The player is a two-mode machine: nothing playing, or one album playing.
+
+\begin{zed}
+  PlayerMode ::= idle | playing
+\end{zed}
+
+\section{State}
+\label{sec:state}
+
+The \texttt{PlayerView} carries the catalog of saved albums, the mode, the
+optional playing album (a set of at most one, mirroring the ``optional Part''
+cursor of \texttt{audio-programs.tex}), and the now-playing cursor
+\texttt{(index, of)} --- the 1-based track position and the album's track count,
+both zero when idle.
+
+The predicate carries every invariant. \texttt{I1} bounds the playing album to
+at most one. \texttt{I2} is the biconditional the design names ``now-playing
+present iff playing'': the mode is \texttt{playing} exactly when one album is
+playing, exactly when the cursor is live (\texttt{of} $\geq 1$). \texttt{I3}
+contains the playing album in the catalog. The cursor-validity conjuncts tie the
+index into $1 \upto of$ while playing and pin it to zero while idle.
+
+\begin{schema}{PlayerView}
+  catalogued : \power ALBUM \\
+  mode : PlayerMode \\
+  album : \power ALBUM \\
+  index : \nat \\
+  of : \nat
+  \where
+  \# album \leq 1 \\
+  album \subseteq catalogued \\
+  (mode = playing \iff \# album = 1) \\
+  (mode = idle \iff album = \emptyset) \\
+  (mode = playing \implies (1 \leq index \land index \leq of \land of \geq 1)) \\
+  (mode = idle \implies (index = 0 \land of = 0))
+\end{schema}
+
+The now-playing cursor is the \texttt{(index, of)} pair the status API reports as
+``Part $N$ of $M$''; \texttt{I2} makes ``present iff playing'' a fact of the state
+schema, not a runtime check. Because \texttt{PlayerMode} has only two
+inhabitants, $mode = idle$ and $mode = playing$ are complementary, so the two
+biconditionals are consistent: $album = \emptyset \iff \# album = 0 \iff mode
+\neq playing$.
+
+\section{Initialisation}
+
+The daemon starts with a (possibly empty) catalog and nothing playing.
+
+\begin{schema}{PlayerInit}
+  PlayerView' \\
+  cat0? : \power ALBUM
+  \where
+  catalogued' = cat0? \\
+  mode' = idle \\
+  album' = \emptyset \\
+  index' = 0 \\
+  of' = 0
+\end{schema}
+
+\section{Player Transitions}
+
+Each transition is the projection of an \texttt{audio-programs.tex} operation
+onto the view. They are gated on mode alone, never on a session --- any client
+(the lux button, the CLI, or an MCP tool) may drive any of them, which is why the
+scene must re-push on every state change regardless of origin.
+
+\subsection{PlayerPlay --- play a saved album}
+
+A client plays the album \texttt{target?}, whose ready-track count is
+\texttt{count?}. The album must be catalogued and non-empty ($count? \geq 1$):
+\texttt{replay\_album} refuses an unknown id and an album with no playable
+tracks. There is \emph{no} mode precondition: from \texttt{idle} this is
+\texttt{StartRadio}; while already \texttt{playing} it is
+\texttt{SwitchSelection}, displacing the old album. Either way the after-state
+has exactly one album playing, so \texttt{I1} holds and two albums never play at
+once.
+
+\begin{schema}{PlayerPlay}
+  \Delta PlayerView \\
+  target? : ALBUM \\
+  count? : \nat
+  \where
+  target? \in catalogued \\
+  count? \geq 1 \\
+  catalogued' = catalogued \\
+  mode' = playing \\
+  album' = \{ target? \} \\
+  index' = 1 \\
+  of' = count?
+\end{schema}
+
+The cursor starts at track~1 of \texttt{count?}. Because $count? \geq 1$, the
+after-state satisfies the cursor-validity invariant ($1 \leq 1 \leq of'$ and
+$of' \geq 1$), and because $target? \in catalogued$, \texttt{I3}
+($album' \subseteq catalogued'$) holds. \texttt{PlayerPlay} is the single verb
+for both ``start'' and ``switch'', exactly as \texttt{StartRadio} $\defs$
+\texttt{SwitchSelection} in \texttt{audio-programs.tex}.
+
+\subsection{PlayerTrackEnd --- auto-advance within the album}
+
+When the current track ends, the playback loop advances the cursor to another
+track of the same album, avoiding an immediate repeat when the album holds more
+than one and replaying when it holds exactly one. This is \texttt{RadioRotate}
+projected onto the cursor: the album and its count are unchanged, only the index
+moves.
+
+\begin{schema}{PlayerTrackEnd}
+  \Delta PlayerView
+  \where
+  mode = playing \\
+  catalogued' = catalogued \\
+  mode' = playing \\
+  album' = album \\
+  of' = of \\
+  1 \leq index' \land index' \leq of \\
+  (of \geq 2 \implies index' \neq index) \\
+  (of = 1 \implies index' = index)
+\end{schema}
+
+The automatic track-end advance and a user-driven \texttt{next}/\texttt{skip} are
+one transition, mirroring \texttt{RadioNext} $\defs$ \texttt{RadioRotate}. The
+mode, album, and count are all held, so \texttt{I1}, \texttt{I2}, and \texttt{I3}
+are trivially preserved; only the cursor moves, and it stays in range.
+
+\subsection{PlayerStop --- stop, return to idle}
+
+Stopping tears the source down and returns the view to \texttt{idle}: no album,
+no cursor. This is \texttt{RadioOff}. It is enabled while playing; a stop while
+already idle is a no-op the daemon need not model as a transition.
+
+\begin{schema}{PlayerStop}
+  \Delta PlayerView
+  \where
+  mode = playing \\
+  catalogued' = catalogued \\
+  mode' = idle \\
+  album' = \emptyset \\
+  index' = 0 \\
+  of' = 0
+\end{schema}
+
+The after-state is the \texttt{idle} shape: \texttt{I2} holds because emptying
+the album empties the cursor, discharging ``stop returns to idle''.
+
+\section{Catalog Transitions}
+
+The catalog changes under the player via \texttt{music new} and \texttt{music
+remove}. They are modelled here only for their interaction with the view ---
+specifically, that a playing album cannot be removed.
+
+\subsection{CatalogAdd --- a fresh album appears}
+
+\texttt{music new} files a fresh album. It grows the catalog and leaves playback
+untouched, so the scene re-pushes with a new row but the same now-playing.
+
+\begin{schema}{CatalogAdd}
+  \Delta PlayerView \\
+  new? : ALBUM
+  \where
+  new? \notin catalogued \\
+  catalogued' = catalogued \cup \{ new? \} \\
+  mode' = mode \\
+  album' = album \\
+  index' = index \\
+  of' = of
+\end{schema}
+
+Because the catalog only grows, $album \subseteq catalogued'$ still holds and
+\texttt{I3} is preserved with playback unchanged.
+
+\subsection{CatalogRemove --- delete a non-playing album}
+
+\texttt{music remove} deletes a catalogued album, but the playing album is
+refused --- the model image of the \texttt{active\_backing\_locators} guard and of
+\texttt{MusicRemove}'s precondition in \texttt{audio-programs.tex}. The
+precondition $gone? \notin album$ is exactly ``you cannot delete the album you
+are playing''.
+
+\begin{schema}{CatalogRemove}
+  \Delta PlayerView \\
+  gone? : ALBUM
+  \where
+  gone? \in catalogued \\
+  gone? \notin album \\
+  catalogued' = catalogued \setminus \{ gone? \} \\
+  mode' = mode \\
+  album' = album \\
+  index' = index \\
+  of' = of
+\end{schema}
+
+The guard is what preserves \texttt{I3} across a removal: with $gone? \notin
+album$ and $album \subseteq catalogued$, removing \texttt{gone?} leaves
+$album \subseteq catalogued'$. Deleting the playing album would break
+$album' \subseteq catalogued'$, so the invariant is not decoration --- it forces
+the guard rather than the guard being an ad-hoc check.
+
+\section{Deferred: the connection / subscribe / lease lifecycle}
+\label{sec:deferred}
+
+Phase~2 adds the receive leg: a persistent WebSocket subscription over the public
+\texttt{LuxRestClient} extension, decoding \texttt{music.play} / \texttt{music.stop}
+into the transitions above, and a ``Music'' menu callback held by a $\sim$30s
+lease renewed by contact. That lifecycle --- \texttt{disconnected} $\to$
+\texttt{connected} $\to$ \texttt{subscribed} $\to$ \texttt{lease-renewed}, with a
+click received while disconnected dropped and the lease expiring unless renewed
+--- is itself a stateful machine with invariants (at most one live subscription;
+no dispatch while disconnected). It is \emph{not} modelled here because its
+transitions depend on lux's subscribe/lease API, which is not yet pinned. When
+lux pins that API, this specification gains a \texttt{Connection} schema and its
+operations as an amendment, before the phase-2 subscribe loop is implemented.
+
+The separation is deliberate and mirrors the design: the \texttt{PlayerView} is
+stable today because a transition's \emph{trigger} --- a lux click or a CLI call
+--- is immaterial to the view's invariants. Only the plumbing that carries the
+trigger is unpinned.
+
+\end{document}


### PR DESCRIPTION
## What

Design for the **voxd Music Player** (bead `vox-efa6`) — a headless app inside `voxd` that drives a lux scene: browse vox's saved-album catalog, play/stop a saved album, GNOME-Music-plain. This PR is **design only** (`docs/vox-music-player.md` + the `PlayerView` Z model); implementation is gated on lux's PRs.

## The design

- **voxd holds lux's public `LuxRestClient`** — never `DisplayClient` (Hub-internal, being deprecated for apps; a DisplayClient player renders but every click dispatches into a void). `PUT /scenes/vox.music` + re-push; pub-sub receive leg (`music.play`/`music.stop`) over the persistent WebSocket extension. Settled cross-repo with the lux agent.
- **The player owns no new playback machinery.** voxd already has the primitives — `replay_album`, `off`, `status`, `catalog_albums`, the remove-guard, one-active-source. The genuinely new work is three things: the lux scene projection, the pub-sub receive leg, and a `ProgramService` change-signal (PubSub) that keeps the scene truthful.
- **Decomposition:** new `voxd/music_player/` package (`MusicPlayer` facade, `PlayerView` value, `AlbumListScene` pure projection, `LuxScenePublisher`; phase 2 adds `player_events` + `lux_subscription`) + a `ChangeListener` seam on `ProgramService`.
- **Two-phase split:** phase 1 = catalog + scene push + change-signal (gated on lux's public `LuxRestClient` export); phase 2 = interactive (menu callback + WS subscribe + dispatch, gated on lux's menu/extension PRs).
- **One shared audio slot:** album-play and the generative program are mutually exclusive (one device, one active source) — the one user-visible consequence.
- **Z model** (`docs/vox-music-player.tex`, `fuzz -t` clean): `PlayerView` invariants — I1 ≤1 album playing, I2 now-playing iff playing, I3 played album is catalogued. Radio transitions reused from `audio-programs.tex`; the connection/subscribe/lease lifecycle deferred pending lux's not-yet-pinned subscribe API.

## Review

Design mission (rmh), evaluated by **bwk → ACCEPT** — all six criteria pass, `.tex` verified `fuzz`-clean. Two refinements folded in before this PR:
1. Fixed a citation (`apply(service)` is polymorphic dispatch, not PY-DP-8 PubSub).
2. **The async re-push:** `_notify_change()` fires inside the `ControlChannel` single-writer, so the lux `PUT` must not run there — a slow/dead `luxd` would freeze playback. The push is handed to an async task via a latest-wins mailbox; a lux timeout is logged and dropped, never propagated into audio control.

## Scope

Design only — no code. The implementation mission dispatches when the lux PRs land. Closes `vox-efa6` at the design stage.