### PR TITLE
chore: sync vox.md durable preference state

### DIFF
--- a/.punt-labs/vox/vox.md
+++ b/.punt-labs/vox/vox.md
@@ -1,5 +1,5 @@
 ---
 notify: "y"
-speak: "y"
+speak: "n"
 voice: "benno"
 ---


### PR DESCRIPTION
## Summary

`voxd` rewrites `.punt-labs/vox/vox.md` live as session preferences (notify, speak, provider, voice) change. This session's work left a one-line drift uncommitted, which blocked the 4.17.0 release preflight (`punt release` requires a clean working tree). Committing the current state so the tree is clean.

No code changes — a single durable-preference-file sync, committed via git directly per the vox guide's own instruction that config state changes land through a PR, not manual file edits.

## Test plan

- [x] No source files touched — `make check` not expected to be affected
- [x] File change is a single line, opaque state sync, not hand-edited content
