### PR TITLE
fix(hooks): unwritable HOME aborted session-start before deploying prod commands

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -53,16 +53,21 @@ fi
 # Skip *-dev.md files — dev commands use plugin namespace (vox-dev:say-dev)
 if [[ "$DEV_MODE" == "false" ]]; then
   DEPLOYED=()
-  for cmd_file in "$PLUGIN_ROOT/commands/"*.md; do
-    name="$(basename "$cmd_file")"
-    [[ "$name" == *-dev.md ]] && continue
-    dest="$COMMANDS_DIR/$name"
-    mkdir -p "$COMMANDS_DIR"
-    if [[ ! -f "$dest" ]] || ! diff -q "$cmd_file" "$dest" >/dev/null 2>&1; then
-      cp "$cmd_file" "$dest"
-      DEPLOYED+=("/${name%.md}")
-    fi
-  done
+  # A bare `mkdir -p` here would abort the whole hook under `set -e` if
+  # $HOME is unwritable -- same failure mode the panel log below guards
+  # against. Skip deployment silently rather than take session startup
+  # down with it.
+  if mkdir -p "$COMMANDS_DIR" 2>/dev/null; then
+    for cmd_file in "$PLUGIN_ROOT/commands/"*.md; do
+      name="$(basename "$cmd_file")"
+      [[ "$name" == *-dev.md ]] && continue
+      dest="$COMMANDS_DIR/$name"
+      if [[ ! -f "$dest" ]] || ! diff -q "$cmd_file" "$dest" >/dev/null 2>&1; then
+        cp "$cmd_file" "$dest"
+        DEPLOYED+=("/${name%.md}")
+      fi
+    done
+  fi
   if [[ ${#DEPLOYED[@]} -gt 0 ]]; then
     ACTIONS+=("Deployed commands: ${DEPLOYED[*]}")
   fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -36,16 +36,24 @@ ACTIONS=()
 if [[ "$DEV_MODE" == "false" ]]; then
   RETIRED=(say.md speak.md notify.md voice.md vox-on.md vox-off.md enable.md disable.md)
   CLEANED=()
+  FAILED_CLEAN=0
   for name in "${RETIRED[@]}"; do
     dest="$COMMANDS_DIR/$name"
     # `-f` passing doesn't guarantee $COMMANDS_DIR is writable -- an rm that
     # fails here must not take the rest of the hook down with it under `set -e`.
-    if [[ -f "$dest" ]] && rm "$dest" 2>/dev/null; then
-      CLEANED+=("/${name%.md}")
+    if [[ -f "$dest" ]]; then
+      if rm "$dest" 2>/dev/null; then
+        CLEANED+=("/${name%.md}")
+      else
+        FAILED_CLEAN=$((FAILED_CLEAN + 1))
+      fi
     fi
   done
   if [[ ${#CLEANED[@]} -gt 0 ]]; then
     ACTIONS+=("Cleaned retired commands: ${CLEANED[*]}")
+  fi
+  if [[ $FAILED_CLEAN -gt 0 ]]; then
+    ACTIONS+=("Failed to remove $FAILED_CLEAN retired command(s) from ~/.claude/commands")
   fi
 fi
 
@@ -54,29 +62,40 @@ fi
 # Skip *-dev.md files — dev commands use plugin namespace (vox-dev:say-dev)
 if [[ "$DEV_MODE" == "false" ]]; then
   DEPLOYED=()
+  FAILED_DEPLOY=0
   # A bare `mkdir -p` here would abort the whole hook under `set -e` if
   # $HOME is unwritable -- same failure mode the panel log below guards
   # against. `mkdir -p` returns 0 for an ALREADY-existing directory
   # regardless of its write permission, so the guard alone doesn't cover
   # an existing-but-now-unwritable $COMMANDS_DIR -- `cp` below is guarded
-  # too. Report the failure via ACTIONS (the settings.json block below
+  # too. Report every failure via ACTIONS (the settings.json block below
   # does the same on its identical failure class) instead of aborting or
   # skipping silently -- the agent's additionalContext is the only
-  # channel this hook has to say why commands never showed up.
+  # channel this hook has to say why commands never showed up. ACTIONS
+  # messages are ASCII literals for the no-jq heredoc fallback below, so
+  # this reports the fixed path "~/.claude/commands", never $COMMANDS_DIR
+  # (which could carry a quote or backslash from an unusual $HOME).
   if mkdir -p "$COMMANDS_DIR" 2>/dev/null; then
     for cmd_file in "$PLUGIN_ROOT/commands/"*.md; do
       name="$(basename "$cmd_file")"
       [[ "$name" == *-dev.md ]] && continue
       dest="$COMMANDS_DIR/$name"
       if [[ ! -f "$dest" ]] || ! diff -q "$cmd_file" "$dest" >/dev/null 2>&1; then
-        cp "$cmd_file" "$dest" 2>/dev/null && DEPLOYED+=("/${name%.md}")
+        if cp "$cmd_file" "$dest" 2>/dev/null; then
+          DEPLOYED+=("/${name%.md}")
+        else
+          FAILED_DEPLOY=$((FAILED_DEPLOY + 1))
+        fi
       fi
     done
   else
-    ACTIONS+=("Failed to create $COMMANDS_DIR — skipping command deployment")
+    ACTIONS+=("Failed to create ~/.claude/commands — skipping command deployment")
   fi
   if [[ ${#DEPLOYED[@]} -gt 0 ]]; then
     ACTIONS+=("Deployed commands: ${DEPLOYED[*]}")
+  fi
+  if [[ $FAILED_DEPLOY -gt 0 ]]; then
+    ACTIONS+=("Failed to deploy $FAILED_DEPLOY command(s) to ~/.claude/commands")
   fi
 fi
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -38,8 +38,9 @@ if [[ "$DEV_MODE" == "false" ]]; then
   CLEANED=()
   for name in "${RETIRED[@]}"; do
     dest="$COMMANDS_DIR/$name"
-    if [[ -f "$dest" ]]; then
-      rm "$dest"
+    # `-f` passing doesn't guarantee $COMMANDS_DIR is writable -- an rm that
+    # fails here must not take the rest of the hook down with it under `set -e`.
+    if [[ -f "$dest" ]] && rm "$dest" 2>/dev/null; then
       CLEANED+=("/${name%.md}")
     fi
   done
@@ -55,18 +56,24 @@ if [[ "$DEV_MODE" == "false" ]]; then
   DEPLOYED=()
   # A bare `mkdir -p` here would abort the whole hook under `set -e` if
   # $HOME is unwritable -- same failure mode the panel log below guards
-  # against. Skip deployment silently rather than take session startup
-  # down with it.
+  # against. `mkdir -p` returns 0 for an ALREADY-existing directory
+  # regardless of its write permission, so the guard alone doesn't cover
+  # an existing-but-now-unwritable $COMMANDS_DIR -- `cp` below is guarded
+  # too. Report the failure via ACTIONS (the settings.json block below
+  # does the same on its identical failure class) instead of aborting or
+  # skipping silently -- the agent's additionalContext is the only
+  # channel this hook has to say why commands never showed up.
   if mkdir -p "$COMMANDS_DIR" 2>/dev/null; then
     for cmd_file in "$PLUGIN_ROOT/commands/"*.md; do
       name="$(basename "$cmd_file")"
       [[ "$name" == *-dev.md ]] && continue
       dest="$COMMANDS_DIR/$name"
       if [[ ! -f "$dest" ]] || ! diff -q "$cmd_file" "$dest" >/dev/null 2>&1; then
-        cp "$cmd_file" "$dest"
-        DEPLOYED+=("/${name%.md}")
+        cp "$cmd_file" "$dest" 2>/dev/null && DEPLOYED+=("/${name%.md}")
       fi
     done
+  else
+    ACTIONS+=("Failed to create $COMMANDS_DIR — skipping command deployment")
   fi
   if [[ ${#DEPLOYED[@]} -gt 0 ]]; then
     ACTIONS+=("Deployed commands: ${DEPLOYED[*]}")


### PR DESCRIPTION
## Summary

Discovered while cutting the 4.17.0 release: `punt release`'s Phase 4 swaps `plugin.json` from `vox-dev` to `vox` for the release PR, which flips `DEV_MODE=false` in `hooks/session-start.sh` for the first time in CI (every other run — main, feature branches, local — uses the dev plugin name and skips this branch entirely). That exposed a real, latent bug: `test_unwritable_home_costs_the_log_not_the_hook` already asserted that an unwritable `$HOME` must not abort session startup, and it passed locally and in every prior CI run only because the code path it targets was never exercised.

**Root cause**: `hooks/session-start.sh` has `set -euo pipefail`. Inside the `DEV_MODE=false` "Deploy top-level commands" block, a bare `mkdir -p "$COMMANDS_DIR"` sat unguarded, inside a loop. Under `set -e`, a failed `mkdir` (unwritable `$HOME`) aborted the entire hook — on the very first line of command deployment, before the already-correctly-guarded panel-log and settings.json blocks further down ever ran.

**Fix, three parts** (first commit found the mkdir bug; local code-reviewer found the other two on the same diff):

1. Guard `mkdir -p "$COMMANDS_DIR"` with an `if`, matching the pattern already used for the settings.json creation a few lines below.
2. `mkdir -p` returns success for an *already-existing* directory regardless of its write permission — so the guard alone doesn't cover `$COMMANDS_DIR` existing from a prior session but now unwritable. Guarded the `cp` inside the loop too, and the `rm` in the sibling "clean up retired commands" block above (same `DEV_MODE=false` gate, same failure class, not covered by the specific failing test but the identical shape).
3. The failure was reported nowhere — `ACTIONS` (the hook's only channel to the calling agent, surfaced as `additionalContext`) stayed silent on the mkdir-failure path. Added the same `"Failed to create ... — skipping ..."` entry the settings.json block already uses for its identical failure, so this exact condition doesn't recur invisibly.

## Verification

- Reproduced the exact CI failure directly: built a scratch repo with a prod-named `plugin.json`, `chmod 500` on a fake `$HOME`, ran the real script. Before: `mkdir: Permission denied`, `rc=1` (matches CI). After: `rc=0` with the diagnostic message in `additionalContext`.
- Verified the second edge case (existing-but-unwritable `$COMMANDS_DIR`, which the first fix alone didn't cover) the same way — confirmed it reproduces the abort before the follow-up fix and resolves after.
- `shellcheck -x hooks/session-start.sh` clean.
- `make check` run to completion in an isolated `git worktree`, full output read (not tail-truncated): ruff, ruff-format, shellcheck, mypy (483 files), pyright, markdownlint, full pytest suite (3915 passed), all three ratchets — exit 0.
- Two local review rounds (code-reviewer + silent-failure-hunter) on the diff: first round found the two follow-on issues above, both fixed; not yet re-reviewed after the fix commit (will confirm clean before merge).

## Test plan

- [x] Reproduced the original bug directly against the unfixed script
- [x] Confirmed the fix resolves it, both for a fresh unwritable `$HOME` and an existing-but-unwritable `$COMMANDS_DIR`
- [x] `make check` green in isolated worktree
- [x] `shellcheck` clean
- [ ] Final local review round clean (in progress)
