### PR TITLE
chore(envrc): only export secrets when the lookup returns non-empty

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,12 @@
 # Git identity (user-specific — name, email, signing key vary per contributor)
+#
+# watch_file is required, not decorative: direnv keys its cache on .envrc's own
+# hash, so a file that .envrc merely sources is invisible to cache invalidation.
+# Without this line, adding or rotating a token in git-identity.env leaves every
+# repo running the stale environment until something happens to change .envrc's
+# mtime — and the failure presents as a bad credential, not as stale config.
 if [ -f "${HOME}/.punt-labs/git-identity.env" ]; then
+  watch_file "${HOME}/.punt-labs/git-identity.env"
   source "${HOME}/.punt-labs/git-identity.env"
 fi
 
@@ -9,30 +16,49 @@ export BEADS_DOLT_SERVER_PORT=3306
 export BEADS_DOLT_SERVER_USER="tacvb9o46xu04pa5"
 export BEADS_DOLT_SERVER_TLS=1
 
-# Secrets from platform-native secret store (service-name lookup only)
+# Secrets from platform-native secret store (service-name lookup only).
+#
+# Only export when the lookup returns a non-empty value. An unconditional
+# export "$(security find-...)" propagates a missing keychain entry as an
+# EXPORTED empty string, which then overrides any pre-existing value the
+# user set in ~/.zshrc / ~/.bashrc / a parent shell. Presents downstream
+# as an opaque 401 rather than "your secret store is empty."
+_puntlabs_export_if_set() {
+  # _puntlabs_export_if_set VARNAME VALUE
+  # Exports VARNAME=VALUE only when VALUE is non-empty.
+  if [ -n "$2" ]; then
+    export "$1=$2"
+  fi
+}
 case "$(uname -s)" in
   Darwin)
-    export BEADS_DOLT_PASSWORD="$(security find-generic-password -s 'BEADS_DOLT_PASSWORD' -w 2>/dev/null)"
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$(security find-generic-password -s 'github-pat' -w 2>/dev/null)"
-    export ANTHROPIC_API_KEY="$(security find-generic-password -s 'ANTHROPIC_API_KEY' -w 2>/dev/null)"
-    export OPENAI_API_KEY="$(security find-generic-password -s 'OPENAI_API_KEY' -w 2>/dev/null)"
-    export ELEVENLABS_API_KEY="$(security find-generic-password -s 'elevenlabs-api-key' -w 2>/dev/null)"
-    export RESEND_API_KEY="$(security find-generic-password -s 'RESEND_API_KEY' -w 2>/dev/null)"
+    _puntlabs_export_if_set BEADS_DOLT_PASSWORD          "$(security find-generic-password -s 'BEADS_DOLT_PASSWORD' -w 2>/dev/null)"
+    _puntlabs_export_if_set GITHUB_PERSONAL_ACCESS_TOKEN "$(security find-generic-password -s 'github-pat' -w 2>/dev/null)"
+    _puntlabs_export_if_set ANTHROPIC_API_KEY            "$(security find-generic-password -s 'ANTHROPIC_API_KEY' -w 2>/dev/null)"
+    _puntlabs_export_if_set OPENAI_API_KEY               "$(security find-generic-password -s 'OPENAI_API_KEY' -w 2>/dev/null)"
+    _puntlabs_export_if_set ELEVENLABS_API_KEY           "$(security find-generic-password -s 'elevenlabs-api-key' -w 2>/dev/null)"
+    _puntlabs_export_if_set RESEND_API_KEY               "$(security find-generic-password -s 'RESEND_API_KEY' -w 2>/dev/null)"
+    _puntlabs_export_if_set CONTEXT7_API_KEY             "$(security find-generic-password -s 'CONTEXT7_API_KEY' -w 2>/dev/null)"
     ;;
   Linux)
-    export BEADS_DOLT_PASSWORD="$(pass show beads/dolt-password 2>/dev/null)"
-    export GITHUB_PERSONAL_ACCESS_TOKEN="$(pass show github/personal-access-token 2>/dev/null)"
-    export ANTHROPIC_API_KEY="$(pass show anthropic/api-key 2>/dev/null)"
-    export OPENAI_API_KEY="$(pass show openai/api-key 2>/dev/null)"
-    export ELEVENLABS_API_KEY="$(pass show elevenlabs/api-key 2>/dev/null)"
-    export RESEND_API_KEY="$(pass show resend/api-key 2>/dev/null)"
+    _puntlabs_export_if_set BEADS_DOLT_PASSWORD          "$(pass show beads/dolt-password 2>/dev/null)"
+    _puntlabs_export_if_set GITHUB_PERSONAL_ACCESS_TOKEN "$(pass show github/personal-access-token 2>/dev/null)"
+    _puntlabs_export_if_set ANTHROPIC_API_KEY            "$(pass show anthropic/api-key 2>/dev/null)"
+    _puntlabs_export_if_set OPENAI_API_KEY               "$(pass show openai/api-key 2>/dev/null)"
+    _puntlabs_export_if_set ELEVENLABS_API_KEY           "$(pass show elevenlabs/api-key 2>/dev/null)"
+    _puntlabs_export_if_set RESEND_API_KEY               "$(pass show resend/api-key 2>/dev/null)"
+    _puntlabs_export_if_set CONTEXT7_API_KEY             "$(pass show context7/api-key 2>/dev/null)"
+    ;;
+  *)
+    # Unknown platform — leave secrets to the shell rc file or explicit export.
     ;;
 esac
+unset -f _puntlabs_export_if_set
 
 export DISABLE_TELEMETRY=1
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-unset  CLAUDE_CODE_ENABLE_TELEMETRY
+unset CLAUDE_CODE_ENABLE_TELEMETRY
 
 export TMPDIR="$PWD/.tmp"
 mkdir -p "$TMPDIR"


### PR DESCRIPTION
## Summary
Update `.envrc` to only export secrets when the lookup returns a non-empty value. Same fix as workspace PR #60.
## Test plan
- [x] Matches workspace canonical template verbatim
