### PR TITLE
fix(claude): remove dead Write(path) deny rules (vox-vjyl)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -141,9 +141,7 @@
       "Bash(tftp:*)",
       "Bash(wget:*)",
       "Edit(.env)",
-      "Edit(.envrc)",
-      "Write(.env)",
-      "Write(.envrc)"
+      "Edit(.envrc)"
     ]
   }
 }

--- a/.punt-labs/ethos/missions/m-2026-08-09-030/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786297412710798000-1786297412710798000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-09-030/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786297412710798000-1786297412710798000.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-08-09T17:43:32.710798Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/.punt-labs/ethos/missions/m-2026-08-09-032/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786306876430154000-1786306950715986000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-09-032/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786306876430154000-1786306950715986000.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-08-09T20:21:16.430154Z","event":"reflect","actor":"gvr","details":{"converging":true,"recommendation":"stop","round":1,"signal_count":1}}
+{"ts":"2026-08-09T20:22:30.715986Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/.punt-labs/ethos/missions/m-2026-08-09-035/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786311128293216000-1786315176326957000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-09-035/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786311128293216000-1786315176326957000.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-08-09T21:32:08.293216Z","event":"create","actor":"claude","details":{"evaluator":"rop","ticket":"","worker":"mdm"}}
+{"ts":"2026-08-09T22:39:36.326957Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/.punt-labs/ethos/missions/m-2026-08-09-036/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786315252954340000-1786343340811085000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-09-036/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786315252954340000-1786343340811085000.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-08-09T22:40:52.95434Z","event":"create","actor":"claude","details":{"evaluator":"gvr","ticket":"","worker":"rmh"}}
+{"ts":"2026-08-10T06:29:00.792104Z","event":"result","actor":"rmh","details":{"confidence":1,"evidence_entries":2,"files_changed":0,"round":1,"verdict":"fail"}}
+{"ts":"2026-08-10T06:29:00.811085Z","event":"close","actor":"claude","details":{"round":1,"status":"failed","verdict":"fail"}}

--- a/.punt-labs/ethos/missions/m-2026-08-10-001/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786343380562673000-1786348189463165000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-10-001/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786343380562673000-1786348189463165000.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-08-10T06:29:40.562673Z","event":"create","actor":"claude","details":{"evaluator":"gvr","ticket":"","worker":"rmh"}}
+{"ts":"2026-08-10T07:49:49.447917Z","event":"result","actor":"rmh","details":{"confidence":0.85,"evidence_entries":5,"files_changed":5,"round":1,"verdict":"pass"}}
+{"ts":"2026-08-10T07:49:49.463165Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/.punt-labs/ethos/missions/m-2026-08-10-002/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786354197501021000-1786354197501021000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-10-002/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786354197501021000-1786354197501021000.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-08-10T09:29:57.501021Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/.punt-labs/ethos/missions/m-2026-08-10-003/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786354873224259000-1786362063182081000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-10-003/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786354873224259000-1786362063182081000.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-08-10T09:41:13.224259Z","event":"create","actor":"claude","details":{"evaluator":"gvr","ticket":"","worker":"rmh"}}
+{"ts":"2026-08-10T11:36:43.562659Z","event":"result","actor":"rmh","details":{"confidence":0.95,"evidence_entries":6,"files_changed":16,"round":1,"verdict":"pass"}}
+{"ts":"2026-08-10T11:41:03.182081Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}

--- a/.punt-labs/ethos/missions/m-2026-08-11-001/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786431259988398000-1786439100745467000.jsonl
+++ b/.punt-labs/ethos/missions/m-2026-08-11-001/log-e4d29846-455d-4428-856a-2c7f4ca48885-1786431259988398000-1786439100745467000.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-08-11T06:54:19.988398Z","event":"create","actor":"claude","details":{"evaluator":"gvr","ticket":"","worker":"rmh"}}
+{"ts":"2026-08-11T09:05:00.72422Z","event":"result","actor":"rmh","details":{"confidence":0.9,"evidence_entries":6,"files_changed":10,"round":1,"verdict":"pass"}}
+{"ts":"2026-08-11T09:05:00.745467Z","event":"close","actor":"claude","details":{"round":1,"status":"closed","verdict":"pass"}}


### PR DESCRIPTION
Closes vox-vjyl.

## What

Deletes two inert permission rules from the `deny` tier of `.claude/settings.json`:

```diff
       "Edit(.env)",
-      "Edit(.envrc)",
-      "Write(.env)",
-      "Write(.envrc)"
+      "Edit(.envrc)"
```

## Why

Claude Code routes every path-scoped file rule through `Edit(path)`, which covers `Write`, `Edit`, and `NotebookEdit`. A `Write(path)` rule matches nothing and prints a startup warning every session.

## Verification

Not asserted from the bead — measured. Captured from a real startup (`claude --debug -p`) **before**:

```
Permission deny rule (.claude/settings.json): Write(.env) is not matched by file
permission checks — only Edit(path) rules are. Use Edit(.env) instead
(Edit rules cover all file-editing tools).
Permission deny rule (.claude/settings.json): Write(.envrc) is not matched by ...
```

**After** the same command: both lines gone. Warnings attributable to `.claude/settings.json` went 2 → 0.

The warning text is also the authority for the safety claim — *"Edit rules cover all file-editing tools"* — so enforcement is unchanged. Independently confirmed every `Write()` had an `Edit()` twin **in the same tier** before deletion:

```
deny   Write(.env)     twin Edit(.env)     present=True
deny   Write(.envrc)   twin Edit(.envrc)   present=True
```

Post-edit checks: JSON re-validates via `json.load`; `grep '"Write('` returns nothing; `Edit(.env)` and `Edit(.envrc)` both confirmed still in the `deny` tier (19 rules).

`make check` green — 4053 passed; OO and coupling gates pass trivially (no Python touched); suppression ratchet **improved by 5** (213 → 208).

## Authorization

The Claude Code auto-mode self-modification classifier blocks agents from editing their own permission config without explicit in-transcript user authorization. This change was held — not worked around — until the operator authorized it directly, scoped to "dead `Write(.env)`, `Write(.envrc)`, `Write(.envrc.local)` rules where a matching `Edit()` rule exists in the same tier." A peer agent's authorization was offered earlier and declined as insufficient; that is the exact bypass the gate exists to prevent.

vox has no `Write(.envrc.local)`, so the authorized scope reduces to the two rules above.

## Note on diff size

The commit carries 8 ethos sealed-audit chunks alongside the one-file change. That is the `ethos audit seal` pre-commit hook working as designed — sealed chunks travel in the same commit as the work — not scope creep. The only intentional change is `.claude/settings.json`.

## Out of scope, already fixed upstream

`.claude/settings.local.json` carries the same defect on the **allow** side and still warns:

```
Permission allow rule (.claude/settings.local.json):
Write(/Users/jfreeman/Coding/punt-labs/**) is not matched by file permission checks
```

That file is local and gitignored, and it fell outside the authorized scope, so it is untouched and flagged rather than swept.

No action needed here: the root cause is already merged in **punt-kit#256** (`2ae1990`). `punt init` no longer seeds these rules and now removes them from *both* `settings.json` and `settings.local.json`, and `punt audit` flags them as a standing check across both files. vox's remainder is handled on the next punt-kit release.

One safety property worth recording, found by tty18 while building that fix: dead **allow** orphans (a `Write(x)` with no `Edit(x)` twin) are dropped and reported rather than rewritten, because rewriting one would *activate* a grant that has never been in effect. The same hazard exists mirrored on the deny side — rewriting a deny orphan would activate a block that has never been in effect. Deletion is safe on both sides; rewriting is not.

## Docs

No CHANGELOG or README entry — this is repo development configuration with no user-facing effect on the `punt-vox` package.
