### PR TITLE
fix(gitignore): make .claude/settings.json genuinely trackable (pkit-rc97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,9 @@ htmlcov/
 .env
 lancedb/
 .mcp.json
-.claude/
+.claude/*
 !.claude/settings.json
+*/**/.claude/
 Lux.ini
 research/
 .biff.local


### PR DESCRIPTION
Closes pkit-rc97 for vox.

## What

```diff
-.claude/
+.claude/*
 !.claude/settings.json
+*/**/.claude/
```

## Why

A bare `.claude/` excludes the **directory**, and git cannot re-include a file whose parent directory is excluded — so `!.claude/settings.json` on the next line never took effect. `.claude/settings.json` is only in the index because it was added before the rule existed.

The failure is not theoretical. It bit this repo during #409, while staging an operator-authorized fix:

```
$ git add .claude/settings.json
The following paths are ignored by one of your .gitignore files:
.claude
```

An *untracked* file under `.claude/` would have been silently unstageable.

Excluding the directory's **contents** (`.claude/*`) lets the negation fire. `*/**/.claude/` keeps nested `.claude` directories — worktrees, vendored trees, pytest temp roots — excluded exactly as before.

## Verification — operational test, not a proxy

`git check-ignore` **cannot detect this bug**. It skips indexed paths, so it reports "not ignored" for a tracked file regardless of the rules:

```
$ git check-ignore -v .claude/settings.json          # tracked
exit 1  -> "not ignored"                             # FALSE PASS

$ git check-ignore -v --no-index .claude/settings.json
.gitignore:24:.claude/    .claude/settings.json      # the truth
exit 0
```

So the check that matters is the operation the rule exists to permit:

```
before:  git add --dry-run .claude/settings.json  ->  exit 1  (ignored)
after:   git add --dry-run .claude/settings.json  ->  exit 0
```

## No change in exposure

Verified by comparing both `.gitignore` versions against the same working tree:

| | untracked, non-ignored files |
|---|---|
| old `.gitignore` | 19 |
| new `.gitignore` | 19 |

Nothing new became trackable. Specifically still ignored:

- `.claude/settings.local.json` — `git check-ignore -q` exit 0
- nested `.claude/` trees — `.gitignore:24:.claude/*` matches `.claude/worktrees/foo/.claude/settings.json`
- `.punt-labs/ethos/sessions/` — exit 0

That last one matters more than it looks. vox publishes a marketplace plugin, and the marketplace **clones the tagged commit**, so the full tracked tree reaches users. `.punt-labs/ethos/sessions/` holds 351 audit files containing `tool_input` payloads; line 101 keeping them ignored is what puts them outside both shipping channels. This PR does not touch that line, and the check above confirms it still fires.

## Gates

`make check` green — 4053 passed; OO and coupling gates pass trivially (no Python touched); suppression ratchet improved by 5 (213 → 208).

## Docs

No CHANGELOG or README entry — repo development configuration, no user-facing effect on the `punt-vox` package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only `.gitignore` tweak with no runtime or package behavior changes.
> 
> **Overview**
> **Fixes `.gitignore` so `!.claude/settings.json` actually works.** The old rule ignored the whole `.claude/` directory, which prevents git from re-including any file inside it—so newly added `settings.json` could not be staged even though the negation line existed.
> 
> The change ignores **contents** via `.claude/*` instead of the directory, adds `*/**/.claude/` so nested `.claude` trees (worktrees, vendored copies) stay ignored, and leaves the existing `!.claude/settings.json` exception effective. No application code changes; intent is unchanged trackability for shared Claude settings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52e4adf5f514e55c78a19e3cb4c484ed530c91e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->