### PR TITLE
fix(ci): bump gh-action-pypi-publish to v1.14.2, enable Dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  # Python (uv)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+
+  # GitHub Actions. Without this, SHA-pinned actions rot silently until a
+  # release fails — which is how the gh-action-pypi-publish pin went stale.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -94,4 +94,4 @@ jobs:
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## The next release of this repo would have failed

punt-kit hit this an hour ago releasing v0.12.0:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Toolchain drift, not anything anyone wrote. Hatchling now emits `Metadata-Version: 2.5`; the pinned publish action `ed0c539` is **v1.13.0**, whose bundled twine predates 2.5 support. Releases earlier in the year worked because hatchling emitted older metadata then — the world moved underneath a pinned action.

This repo pins the same SHA, so its next release fails the same way.

## The fix

`v1.14.2` (`dc37677`) ships Twine v7. Verified before pinning, from its release notes:

> Twine to v7 that we use internally (#416). This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI.

## The part that actually matters

`.github/dependabot.yml` with the `github-actions` ecosystem.

Measured across the fleet: **quarry was the only repo unaffected**, and only because it runs Dependabot on actions and picked up the bump automatically months ago. punt-kit, biff, vox and lux had no Dependabot config at all.

SHA-pinning actions is correct for supply-chain reasons and should stay. But pinning **without** automated bumping converts a security control into a time bomb that detonates only during a release — the worst possible moment to find out. Bumping four pins by hand treats this instance; Dependabot treats the class.

## Scope

Two files. No source changes, no behavior change outside CI.

Branched from `origin/main` in a git worktree, so nothing in the working tree was touched — there is in-flight work in this repo right now.

Refs pkit-lr8g.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes with no application or runtime behavior; the publish action update reduces release failure risk rather than introducing new product logic.
> 
> **Overview**
> **Prevents the next tag release from failing on PyPI upload** by moving `pypa/gh-action-pypi-publish` from the old v1.13.0 SHA to **v1.14.2** in both the TestPyPI and production publish steps in `release.yml`. The older pin bundles Twine that rejects Hatchling’s current `Metadata-Version: 2.5` artifacts.
> 
> **Adds `.github/dependabot.yml`** with weekly updates for **uv** (Python deps) and **github-actions**, so SHA-pinned workflow actions get bump PRs instead of rotting until a release breaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 768f78cb89ae1cde8af9e557a7095f9974177320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->