### PR TITLE
chore: post-release v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ vox is usable in three ways, all driving the same `voxd` audio daemon --- so it 
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/2ed73ee/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh | sh
 ```
 
 Restart Claude Code, then:
@@ -50,10 +50,10 @@ Install the `vox` CLI without the Claude Code plugin — for a non-Claude harnes
 
 ```bash
 # Flag form
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/2ed73ee/install.sh | sh -s -- --no-plugin
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh | sh -s -- --no-plugin
 
 # Environment form (for argument-hostile contexts — CI templates, proxies)
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/2ed73ee/install.sh | VOX_NO_PLUGIN=1 sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh | VOX_NO_PLUGIN=1 sh
 ```
 
 `VOX_NO_PLUGIN` skips the plugin only when set to exactly `1`; any other value is ignored. The plugin also auto-skips when `claude` or `git` is absent.
@@ -73,7 +73,7 @@ vox doctor
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/2ed73ee/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "5.0.0",
+  "version": "4.17.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /recap",
-  "version": "4.17.0",
+  "version": "5.0.0",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only install URL pins plus plugin manifest rename for local dev; no changes to hooks, MCP, or runtime code.
> 
> **Overview**
> **Post-release housekeeping** after tagging **v5.0.0**: no product or daemon behavior changes.
> 
> The **README** now points every `curl …/install.sh` example (quick start, `--no-plugin`, `VOX_NO_PLUGIN=1`, and verify-before-run) at git ref **`67b5ac4`** instead of **`2ed73ee`**, so documented one-liners match the release commit.
> 
> In **`plugin/.claude-plugin/plugin.json`**, the marketplace **`name`** goes from **`vox`** back to **`vox-dev`**, matching the usual dev-tree state after `release-plugin.sh` ships **`vox`** on the tag (version remains **5.0.0**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2a68dc7a703a9baa7905fc2ac8f290df05c4451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->