### PR TITLE
chore(ci): biff-notify watches Release; bump setup-uv to v9.0.0

### DIFF
--- a/.github/workflows/biff-notify.yml
+++ b/.github/workflows/biff-notify.yml
@@ -1,7 +1,11 @@
 name: Biff CI Notifications
 on:
   workflow_run:
-    workflows: ["Lint", "Test", "Docs"]
+    # workflow_run matches a workflow's `name:` field, not the job id or the
+    # filename. `biff enable` renders this list from the target repo's own
+    # .github/workflows/*.yml and *.yaml name: fields, so a fixed list can't
+    # watch the wrong workflows in a repo whose names differ from biff's.
+    workflows: ["Docs", "Lint", "Release", "Test"]
     types: [completed]
 
 permissions:
@@ -18,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: .punt-labs/biff
-      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - env:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
## Summary

Two small edits to `.github/workflows/biff-notify.yml`:

- **Watched workflows.** Add `"Release"` so a failing release-pipeline run notifies alongside Lint, Test, and Docs. Also sort the list alphabetically. New comment explains why: `workflow_run.workflows` matches by the workflow's `name:` field (not filename or job id), and `biff enable` in a target repo renders this list from that repo's own `.github/workflows/*.yml` `name:` fields — a fixed list can't watch the wrong workflows in a repo whose names differ from biff's.
- **setup-uv.** Bump the pinned SHA from v5 to v9.0.0 (`c771a70e6277c0a99b617c7a806ffedaca235ff9`). No `with:` inputs used, so no interface change.

## Test plan

- [ ] CI: `lint`, `test`, `docs` all pass on the branch.
- [ ] Copilot + Bugbot review clean.
- [ ] Post-merge: verify a real Release-workflow **push-triggered** failure delivers a biff notification. The notify job gates on `github.event.workflow_run.event == 'push'`, so a manually-dispatched failure will NOT trigger — the exercise has to ride a real tag push. No way to reproduce this on the PR branch because the notify workflow runs on `workflow_run` events on the base branch.