### PR TITLE
fix(tests): raise flaky _poll_until timeout for backgrounded panel spawn

### DIFF
--- a/tests/test_hook_gate.py
+++ b/tests/test_hook_gate.py
@@ -93,10 +93,20 @@ def _mark_enabled(repo: Path) -> None:
     marker.write_text("", encoding="utf-8")
 
 
-def _poll_until(predicate: Callable[[], bool], *, timeout: float = 2.0) -> None:
+def _poll_until(predicate: Callable[[], bool], *, timeout: float = 10.0) -> None:
     """Poll *predicate* until it's true -- the spawn is backgrounded
-    (``nohup ... &``), so its effects land some milliseconds after the hook
-    process itself has already exited."""
+    (``nohup ... & disown``), so its effects land some time after the hook
+    process itself has already exited, with no parent left to bound the wait.
+
+    10s, not 2s: a 15-run isolated rerun of this poll (no concurrent
+    load) still missed a 2s deadline once, so 2s is not a safe bound for
+    OS scheduling of an already-disowned background process even at
+    rest. The predicate resolves in milliseconds on the happy path --
+    this loop returns as soon as it's true -- so a generous ceiling costs
+    nothing when the spawn is prompt and only matters on the rare slow
+    tail. 10s matches this file's own tolerance for hook subprocess
+    timing elsewhere (``subprocess.run(..., timeout=30)`` below).
+    """
     deadline = time.monotonic() + timeout
     while not predicate():
         if time.monotonic() > deadline:


### PR DESCRIPTION
## Summary
- `tests/test_hook_gate.py::TestPanelSpawn` intermittently failed with "timed out waiting for the backgrounded panel spawn"
- Confirmed genuinely flaky via 15 isolated reruns (no concurrent load) before touching anything -- not attributable to machine load, contrary to the initial hypothesis
- Root cause: `session-start.sh` backgrounds the panel spawn with `nohup ... & disown`; its parent bash exits immediately, so the sentinel-file write depends on OS scheduling of an already-orphaned process with no real bound on tail latency. `_poll_until`'s hard-coded 2.0s deadline was too tight for that operation class -- the file already tolerates `timeout=30` elsewhere for hook subprocess calls.
- Raised the default `timeout` in `_poll_until` from 2.0s to 10.0s, with the rationale documented in the docstring. No production code changed -- the defect was in the test's timing assumption, not in `session-start.sh` or the panel-spawn logic itself.

Filed and closed via bead `vox-yoga`.

## Test plan
- [x] 20/20 clean reruns of `TestPanelSpawn` after the fix
- [x] Full `make check` green: 4335 tests passed, lint/type/OO/coupling/suppression gates all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout change with no production, security, or data-handling impact.
> 
> **Overview**
> Raises `_poll_until`'s default timeout from 2s to 10s in `tests/test_hook_gate.py` so `TestPanelSpawn` no longer flakes waiting on the disowned `vox-panel` spawn.
> 
> The helper still returns as soon as the sentinel appears; only the rare slow tail of OS scheduling for `nohup ... & disown` needed a looser ceiling. Production hook/spawn logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66567640e1902cdcf0a1a06d66fac765b09a221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->