### PR TITLE
docs(vox-ry7l): TESTING.md marker taxonomy precision (4 gaps)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -243,7 +243,7 @@ and `make check`. A handful of unmarked tests still spawn real local
 subprocesses -- `test_core.py` invokes `ffmpeg` directly outside the
 cached-MP3-bytes fixture path, and `test_public_api.py` runs a `python -c`
 import-lightness probe -- but none reach the network or a credentialed API, so
-the tier's contract ("safe to run anywhere, no external dependency") holds. Tests that spawn a real *shell script* under test move to
+the tier's contract ("safe to run anywhere, no external service dependency") holds. Tests that spawn a real *shell script* under test move to
 Tier 3a; local `ffmpeg`/interpreter spawns from tests whose subject is
 in-process code stay here.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -240,11 +240,10 @@ unit-tested in-process.
 No marker, no external service dependency. This is the vast majority of the
 suite (~4,130 of ~4,340 tests) and runs on every `uv run pytest`, `make test`,
 and `make check`. A handful of unmarked tests still spawn real local
-subprocesses -- `test_core.py` and `test_public_api.py` call `ffmpeg` directly
-outside the cached-MP3-bytes fixture path, and `test_service_process.py`
-exercises the daemon-restart flow -- but none of them reach the network or a
-credentialed API, so the tier's contract ("safe to run anywhere, no external
-dependency") holds. Tests that spawn a real *shell script* under test move to
+subprocesses -- `test_core.py` invokes `ffmpeg` directly outside the
+cached-MP3-bytes fixture path, and `test_public_api.py` runs a `python -c`
+import-lightness probe -- but none reach the network or a credentialed API, so
+the tier's contract ("safe to run anywhere, no external dependency") holds. Tests that spawn a real *shell script* under test move to
 Tier 3a; local `ffmpeg`/interpreter spawns from tests whose subject is
 in-process code stay here.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -237,15 +237,22 @@ unit-tested in-process.
 
 ### Tier 1: Unit (default, unmarked)
 
-No marker, no external dependency, no real subprocess. This is the vast
-majority of the suite (~4,130 of ~4,340 tests) and runs on every
-`uv run pytest`, `make test`, and `make check`.
+No marker, no external service dependency. This is the vast majority of the
+suite (~4,130 of ~4,340 tests) and runs on every `uv run pytest`, `make test`,
+and `make check`. A handful of unmarked tests still spawn real local
+subprocesses -- `test_core.py` and `test_public_api.py` call `ffmpeg` directly
+outside the cached-MP3-bytes fixture path, and `test_service_process.py`
+exercises the daemon-restart flow -- but none of them reach the network or a
+credentialed API, so the tier's contract ("safe to run anywhere, no external
+dependency") holds. Tests that spawn a real *shell script* under test move to
+Tier 3a; local `ffmpeg`/interpreter spawns from tests whose subject is
+in-process code stay here.
 
 | What it covers | Representative files |
 |-----------------|----------------------|
 | Pure functions, domain types | `test_types*.py`, `test_normalize.py`, `test_resolve.py` |
 | Mocked-provider-boundary synthesis | `test_polly_provider.py`, `test_openai_provider.py`, `test_elevenlabs_provider.py`, `test_say_provider.py`, `test_espeak_provider.py`, `test_core.py` |
-| Real pydub/ffmpeg encode, mocked network | `test_chunked.py`, `test_core.py`, `test_public_api.py` (see [The MP3 Problem](#the-mp3-problem) -- the one real ffmpeg encode is cached once per session, not per test) |
+| Real pydub/ffmpeg encode, mocked network | `test_chunked.py`, `test_core.py`, `test_public_api.py` (see [The MP3 Problem](#the-mp3-problem) -- within the mocked-provider fixture path the one real ffmpeg encode is cached once per session, not per test; tests that call `ffmpeg` directly, outside that fixture path, pay their own per-invocation cost) |
 | WebSocket client/daemon wire protocol (in-process) | `test_client*.py`, `test_wire_reply.py`, `test_voxd_*.py` |
 | Hook dispatch logic (config/audio patched) | `test_hooks.py`, `test_hook_envelope.py`, `test_hook_payload.py`, `test_nudge_hook.py` |
 | Static shell-script assertions (no subprocess) | `test_hook_scripts.py` -- reads and greps the `.sh` files as text; does not execute them |
@@ -278,15 +285,16 @@ the fix is not to make them lie about git; it is to make them opt-in.
 
 ### Tier 3a: `subprocess` -- real shell/git subprocess spawns
 
-`@pytest.mark.subprocess` is applied to the three files that can only be
-honest by spawning a real process, because the thing under test is a shell
-script that cannot run in-process:
+`@pytest.mark.subprocess` is applied to the files that can only be honest by
+spawning a real process, because the thing under test is a shell script that
+cannot run in-process:
 
 | File | Tests | What it drives |
 |------|-------|-----------------|
 | `test_hook_gate.py` | 18 | Real `bash plugin/hooks/*.sh` invocations -- the per-repo enablement gate and the panel-spawn block |
 | `test_plugin_surface.py` | 8 | Real `bash scripts/check-plugin-surface.sh` invocations against fixture surfaces |
 | `test_install_script.py` | 13 | Real `sh install.sh` invocations under a sandboxed `PATH` of stub executables |
+| `test_suppress_output.py` | 27 | Real `bash plugin/hooks/suppress-output.sh` invocations -- the PostToolUse two-channel display contract (also requires `jq` on `PATH`; auto-skipped when absent) |
 
 `test_hook_scripts.py` looks like it belongs in this tier by name but does
 not: it makes static text assertions over the `.sh` files (`grep`-shaped

--- a/tests/test_oo_ratchet.py
+++ b/tests/test_oo_ratchet.py
@@ -25,7 +25,9 @@ from tools.oo_ratchet.writer import BaselineWriter
 # Every test drives a real ``git init``/``commit``/``checkout`` sequence plus a
 # real ``tools/oo_ratchet`` subprocess invocation per assertion -- genuinely
 # slow relative to the mocked-boundary suite (measured: this file plus its
-# three siblings, 153 tests, took 4m35s wall on a dev box; see TESTING.md).
+# three siblings, 153 tests, took 32s wall on a clean, uncontended run; see
+# TESTING.md, which also records the ~8x slowdown observed under CPU
+# contention from other agents sharing the dev box).
 pytestmark = pytest.mark.slow
 
 GOOD = '''from __future__ import annotations

--- a/tests/test_suppress_output.py
+++ b/tests/test_suppress_output.py
@@ -37,9 +37,12 @@ _HOOK = (
 # pinning the whole sentence.
 _STOP_MARK = "reply with no text, no summary, no narration. Stop."
 
-pytestmark = pytest.mark.skipif(
-    shutil.which("jq") is None, reason="suppress-output.sh requires jq"
-)
+pytestmark = [
+    pytest.mark.subprocess,
+    pytest.mark.skipif(
+        shutil.which("jq") is None, reason="suppress-output.sh requires jq"
+    ),
+]
 
 
 def _run_hook(


### PR DESCRIPTION
## Summary

Closes bead **vox-ry7l (P3)** — 4 wording-precision gaps in TESTING.md that Copilot flagged on PR #445 (merged as `ee571aa`) and were suppressed at the time as "previously missed" rather than opened as blocking threads.

## What changed

- **`TESTING.md`**
  - Narrowed the Tier 1 "no real subprocess" claim → "no external service dependency", explicitly noting that a few tests (`test_core.py`, `test_public_api.py`) spawn `ffmpeg`/`python -c` and stay unmarked.
  - Scoped the "real ffmpeg encode… not a repeated cost" claim to the mocked-provider fixture path only (which caches MP3 bytes); tests that call ffmpeg directly are outside that claim.
  - Added `test_suppress_output.py` (27 tests) to the Tier 3a `subprocess` table now that it carries the marker.
- **`tests/test_oo_ratchet.py`** — inline comment now cites 32s clean-run figure (matches TESTING.md's own investigation), with a pointer to the CPU-contention 4m35s measurement.
- **`tests/test_suppress_output.py`** — added `pytest.mark.subprocess` via `pytestmark` list (keeps the existing `jq` skipif). The taxonomy exists precisely for real-shell-script tests, and CI already runs `-m subprocess` as its second pytest step.

## Test plan

- [x] `make check` green — 4123 tests pass; `-m subprocess` still selects the marked set including the newly-marked file.

## Closes

Closes vox-ry7l on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and pytest marker placement only; no production logic or CI workflow changes. The new marker moves existing shell-hook tests into the already-run `-m subprocess` CI step.
> 
> **Overview**
> Tightens the TESTING.md pyramid so Tier 1 means *no external service*, not *no subprocess*, and documents the few unmarked local `ffmpeg`/`python -c` spawns plus the cached-vs-direct ffmpeg cost distinction.
> 
> Marks `test_suppress_output.py` as `subprocess` (keeping the `jq` skip) and lists those 27 tests in the Tier 3a table. Aligns the ratchet-file comment with the documented 32s clean-run timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf392d043619e1bbed40ea8107d3a1738f01d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->