### PR TITLE
chore(vox-tdy5): bump markdownlint-cli2-action to v24.2.0 (tag SHA, not mystery-past-v22)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,6 @@ jobs:
     # markdownlint across all tracked .md files
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: DavidAnson/markdownlint-cli2-action@4580e1612f6407034edd6c0e4e316d725920867b # v24.2.0
+      - uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           globs: "**/*.md"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,6 @@ jobs:
     # markdownlint across all tracked .md files
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: DavidAnson/markdownlint-cli2-action@2256fe35224a451507c8848ec825a4212e9eeb00 # v22
+      - uses: DavidAnson/markdownlint-cli2-action@4580e1612f6407034edd6c0e4e316d725920867b # v24.2.0
         with:
           globs: "**/*.md"


### PR DESCRIPTION
## Summary

Closes bead **vox-tdy5 (P3)** — the `markdownlint-cli2-action` pin was a `2256fe35…` SHA labelled `# v22`, but that SHA is a later "Update/freshen CONTRIBUTING.md" commit past the v22 tag (v22 actually points at `07035fd0…`). Meanwhile upstream shipped v23 and v24. This bump switches to the actual v24.2.0 commit SHA with a truthful annotation.

## What changed

- **`.github/workflows/docs.yml`** — SHA `2256fe35…` → `21c1be1b93ad9ed58fa840aacc3f279cde2a72ff` (the commit SHA the annotated v24.2.0 tag dereferences to) and annotation `# v22` → `# v24.2.0`.

### SHA lookup note (learned in review)

v24.2.0 is an ANNOTATED tag. `gh api /repos/.../git/refs/tags/v24.2.0 --jq '.object.sha'` returns the tag OBJECT SHA (`4580e161…`) — not the commit SHA. GitHub Actions needs the COMMIT SHA. Use `gh api /repos/.../commits/v24.2.0 --jq .sha` (auto-dereferences) or `gh api /repos/.../git/tags/<tag-sha> --jq '.object.sha'` to follow the tag. Bugbot caught the wrong SHA in the first push; corrected in `82fe961`.

`dependabot.yml` intentionally not touched — github-actions ecosystem is already enabled and dependabot will now bump from a truthful v24.2.0 baseline.

## Test plan

- [x] `make check` green — ruff, mypy, pyright, shellcheck, markdownlint (v24 behavior), 4150 pytest, ratchets.

## Closes

Closes vox-tdy5 on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single GitHub Action pin bump in the docs lint workflow; no application or security logic.
> 
> **Overview**
> Pins `markdownlint-cli2-action` in `docs.yml` to the real v24.2.0 commit SHA (`21c1be1b…`) instead of a mislabeled post-v22 SHA.
> 
> Lint job behavior is unchanged aside from using the current action release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa18deba68d95c3420f022d9067a421b52dd5d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->