### PR TITLE
chore(vox-ndgf): pin uv_build to 0.12.5 (retire the range widen)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.9.14,<0.10.0"]
+requires = ["uv_build==0.12.5"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
## Summary

Closes bead **vox-ndgf (P3)** — pins `uv_build` from the range `>=0.9.14,<0.10.0` to an exact `==0.12.5`. Follow-up to closing Dependabot PR #417 which proposed a range widen we rejected as the wrong shape for our build backend (vox pins uv_build deliberately per DES-026 for sdist safety).

## What changed

- **`pyproject.toml`** — `[build-system].requires` from `uv_build>=0.9.14,<0.10.0` to `uv_build==0.12.5` (latest PyPI stable).

`dependabot.yml` not touched — the exact pin already forces Dependabot to raise each bump as a discrete version PR; no ecosystem-specific `versioning-strategy` was worth grafting on.

## Validation

- `uv sync` clean.
- `make check` — 4123 passed, all three ratchets clean.
- `uv build` — wheel + sdist produced.
- `uvx twine check dist/*` — both PASSED.

## Closes

Closes vox-ndgf on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line build-backend pin with no runtime or security surface. Packaging could break if 0.12.5 behaves differently from the old 0.9.x range, but that is limited to sdist/wheel builds.
> 
> **Overview**
> Pins `[build-system].requires` from `uv_build>=0.9.14,<0.10.0` to `uv_build==0.12.5` so the packaging backend is an exact version rather than a range widen.
> 
> This keeps Dependabot raising discrete version PRs for the backend and matches the existing sdist-safety pin policy. No other files change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d8adddc932f42102493fec2b85061e8d10e04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->