### PR TITLE
fix(vox-yzme): LCOM counts public field usage (broaden the filter)

### DIFF
--- a/tests/tools/test_coupling_metrics.py
+++ b/tests/tools/test_coupling_metrics.py
@@ -71,6 +71,34 @@ def test_private_field_cohesion_still_counted() -> None:
     assert metrics["max_lcom"] == 0.0
 
 
+def test_shared_helper_calls_do_not_fake_cohesion() -> None:
+    """A shared ``self.helper()`` call is method dispatch, not shared state.
+
+    LCOM measures data cohesion; the call target ``helper`` is not a field.
+    Two methods that both call ``self.helper()`` but touch no common
+    ``self.<field>`` are data-disjoint and must score LCOM 1.0.
+    """
+    metrics = _score(
+        """
+        class Split:
+            a: int = 1
+            b: int = 2
+
+            def helper(self) -> None:
+                pass
+
+            def reads_a(self) -> int:
+                self.helper()
+                return self.a
+
+            def reads_b(self) -> int:
+                self.helper()
+                return self.b
+        """
+    )
+    assert metrics["max_lcom"] == 1.0
+
+
 def test_disjoint_methods_score_incohesive() -> None:
     """Two methods that touch no shared ``self`` attribute score LCOM 1.0."""
     metrics = _score(

--- a/tests/tools/test_coupling_metrics.py
+++ b/tests/tools/test_coupling_metrics.py
@@ -1,0 +1,89 @@
+"""Unit tests for the per-module LCOM computation in the coupling scorer."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+
+from tools.coupling.imports import ImportResolver
+from tools.coupling.metrics import ModuleCouplingMetrics
+
+
+def _score(source: str) -> dict[str, float | int | str]:
+    tree = ast.parse(textwrap.dedent(source))
+    resolver = ImportResolver("mod", frozenset({"mod"}), "pkg")
+    return ModuleCouplingMetrics("mod.py", tree, resolver).compute()
+
+
+def test_frozen_dataclass_public_fields_score_cohesive() -> None:
+    """A frozen dataclass value object whose methods share public fields is cohesive.
+
+    Regression for vox-yzme: LCOM previously counted only ``_``-prefixed
+    ``self`` references, so a ``SelectionRequest``-shaped value object read
+    as if every method touched disjoint state and scored the maximal 1.0.
+    """
+    metrics = _score(
+        """
+        from dataclasses import dataclass
+        from typing import final
+
+        @final
+        @dataclass(frozen=True, slots=True)
+        class Selection:
+            style: str | None = None
+            vibe: str | None = None
+            name: str | None = None
+
+            def is_empty(self) -> bool:
+                return self.style is None and self.vibe is None and self.name is None
+
+            def matches(self, other: "Selection") -> bool:
+                return (
+                    self.style == other.style
+                    and self.vibe == other.vibe
+                    and self.name == other.name
+                )
+
+            def with_style(self, style: str) -> "Selection":
+                return Selection(style, self.vibe, self.name)
+        """
+    )
+    assert metrics["max_lcom"] == 0.0
+
+
+def test_private_field_cohesion_still_counted() -> None:
+    """Underscore-prefixed fields keep counting as shared state."""
+    metrics = _score(
+        """
+        class Box:
+            def __new__(cls, value: int) -> "Box":
+                self = super().__new__(cls)
+                self._value = value
+                return self
+
+            def get(self) -> int:
+                return self._value
+
+            def doubled(self) -> int:
+                return self._value * 2
+        """
+    )
+    assert metrics["max_lcom"] == 0.0
+
+
+def test_disjoint_methods_score_incohesive() -> None:
+    """Two methods that touch no shared ``self`` attribute score LCOM 1.0."""
+    metrics = _score(
+        """
+        class Split:
+            a: int = 1
+            b: int = 2
+
+            def reads_a(self) -> int:
+                return self.a
+
+            def reads_b(self) -> int:
+                return self.b
+        """
+    )
+    assert metrics["max_lcom"] == 1.0

--- a/tools/coupling/metrics.py
+++ b/tools/coupling/metrics.py
@@ -124,16 +124,24 @@ class ModuleCouplingMetrics:
 
     @staticmethod
     def _method_self_attrs(method: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
-        # Count every ``self.<name>`` reference, public or private. Restricting to
-        # ``_``-prefixed names under-reads cohesion on frozen dataclass value
-        # objects whose fields are public by contract (PY-CC-6) -- their methods
-        # share state through those fields and would otherwise score LCOM 1.0.
+        # LCOM measures DATA cohesion -- fields shared between methods. Count
+        # every ``self.<name>`` field read/write, public or private (an
+        # underscore-only filter under-reads frozen dataclass value objects
+        # whose fields are public by contract, PY-CC-6), but exclude
+        # ``self.helper()`` call targets: sharing a helper method is method
+        # dispatch, not shared state.
+        call_targets = {
+            node.func
+            for node in ast.walk(method)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
         return {
             node.attr
             for node in ast.walk(method)
             if isinstance(node, ast.Attribute)
             and isinstance(node.value, ast.Name)
             and node.value.id == "self"
+            and node not in call_targets
         }
 
     @staticmethod

--- a/tools/coupling/metrics.py
+++ b/tools/coupling/metrics.py
@@ -124,13 +124,16 @@ class ModuleCouplingMetrics:
 
     @staticmethod
     def _method_self_attrs(method: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+        # Count every ``self.<name>`` reference, public or private. Restricting to
+        # ``_``-prefixed names under-reads cohesion on frozen dataclass value
+        # objects whose fields are public by contract (PY-CC-6) -- their methods
+        # share state through those fields and would otherwise score LCOM 1.0.
         return {
             node.attr
             for node in ast.walk(method)
             if isinstance(node, ast.Attribute)
             and isinstance(node.value, ast.Name)
             and node.value.id == "self"
-            and node.attr.startswith("_")
         }
 
     @staticmethod


### PR DESCRIPTION
## Summary

Closes bead **vox-yzme (P3)** — the LCOM ratchet in `tools/coupling/metrics.py` previously counted only `_`-prefixed instance attributes when measuring method-attribute sharing. Frozen dataclass value objects with PUBLIC fields (canonical example: `SelectionRequest` in `types_programs/control.py` with fields `style/vibe/name/id`) whose methods operate cohesively on those public fields scored a false-positive high LCOM. This forced spurious scoped `--relax` waivers on genuinely-cohesive value objects (done for control.py in vox-q1z4).

## Fix

**Option (a): broaden the filter.** Removed the `startswith("_")` restriction in `ModuleCouplingMetrics._method_self_attrs` so LCOM counts every `self.<name>` reference, public or private.

Chose broaden-filter over frozen-dataclass exemption because it's simpler (no special-case detection) and symmetric (public and private state count the same, matching what the metric intuitively measures — method-pair state sharing).

## What changed

- **`tools/coupling/metrics.py`** — one-line filter change + a why-comment.
- **`tests/tools/test_coupling_metrics.py`** (new) — three cases: the SelectionRequest-shape regression, private-field cohesion still counted, disjoint public fields scoring 1.0.

## Verification

- `SelectionRequest` now scores `max_lcom=0.0` (was 1.0) in `src/punt_vox/types_programs/control.py`. Baselines are floors on lower-is-better metrics, so the entry in `.oo-coupling-baseline.json` (currently `max_lcom=1.0`) stays as a floor; any subsequent touch to that file will pull the baseline down naturally. No src/ rewrite needed for this scoped tool fix.
- Ratchet impact on this PR: none — `make check-coupling` reports "No scored Python files touched" (only `tools/` and `tests/` changed). Since a superset of attributes can only grow method-pair intersections, LCOM values can only DECREASE under the new filter — no file can regress.
- `make check` — 4126 tests pass, ratchets clean.

## Closes

Closes vox-yzme on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal coupling-metric tweak plus unit tests; LCOM can only decrease, with no production or security impact.
> 
> **Overview**
> Fixes a false-high LCOM score for frozen dataclass value objects whose methods share **public** fields.
> 
> `_method_self_attrs` no longer ignores non-`_` `self` attributes, so public field sharing counts as cohesion. Call targets like `self.helper()` are still excluded so method dispatch is not treated as shared state.
> 
> Adds unit tests covering the Selection-shaped regression, private-field cohesion, disjoint public fields, and shared helper calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be71c62a73b0f469d170b2a327f935062bd917e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->