### PR TITLE
chore(vox-6r6o): gitignore ephemeral ethos session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,16 @@ MagicMock/
 # registry-wide lock; this covers the one ethos takes on an individual mission.
 .punt-labs/ethos/missions/*/.lock
 
+# Per-mission verbatim activity logs written into the durable tree. Same class
+# as sessions/**/audit.jsonl above — runtime churn, not a durable record.
+.punt-labs/ethos/missions/**/log-*.jsonl
+
+# Local-path root (vox-6r6o): ethos writes per-session runtime state under
+# .punt-labs/local/ (currently just ethos/, but the whole subtree is machine-
+# local churn — no vox source lives here). Specific sessions/ patterns above
+# stay for clarity; this blanket ignore keeps future ethos-local artifacts out.
+.punt-labs/local/
+
 # Ethos's flock on a vendored identity file, taken while it rewrites one.
 # Same convention as SiblingLock below, but written by ethos, not by vox.
 .punt-labs/ethos/identities/*.lock


### PR DESCRIPTION
## Summary

**Partially closes bead vox-6r6o (P2)** — extends `.gitignore` to preemptively cover the ephemeral session artifacts ethos writes per session. This eliminates the future log-spam vector but does NOT resolve the current-tree untracked durable mission records — those need an ethos-side coordination fix (see follow-up).

## What changed

- **`.gitignore`** — added two patterns under the existing Vendored ethos block:
  - `.punt-labs/ethos/missions/**/log-*.jsonl` — per-session verbatim activity logs. Already ignored by the block's stated intent (comment says "verbatim per-session activity logs (sessions/**/audit.jsonl)") but the current pattern didn't cover this newer `missions/*/log-*.jsonl` path.
  - `.punt-labs/local/` — the ephemeral local-scoped subtree.

## Scope note (why this PR is partial)

`git status --short | grep ethos` count: **9 files before, 9 after** — the newly-ignored patterns don't have files in the tree today; the change is preemptive against future session logs.

The 9 files still leaking are all **durable mission records** ethos WANTS tracked: `.punt-labs/ethos/missions/m-*/contract.yaml`, `results.yaml`, `reflections.yaml`, `delegations/`. Nothing commits them today, so they accrue as untracked forever. Ignoring them would erase the mission history ethos was designed to keep — wrong shape.

**Follow-up bead** filed for the durable-records side (ethos seal hook coordination); this PR closes the ephemera-only slice of vox-6r6o.

Unrelated leaks in the tree (out of scope for vox-6r6o): `.beads/dolt*`, `docs/conversation-mode-prd.pdf`.

## Test plan

- [x] `make check` green (4123 tests, ratchets clean) — gitignore-only change.

## Partially closes

Partially closes vox-6r6o on merge. The residual durable-records issue is a follow-up bead against the ethos-side coordination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gitignore-only change with no application, auth, or data-handling logic. Durable mission files remain unignored by design.
> 
> **Overview**
> Preemptively ignores ethos runtime churn so future session logs do not dirty the tree.
> 
> Adds `.punt-labs/ethos/missions/**/log-*.jsonl` for per-mission activity logs in the durable tree, and a blanket `.punt-labs/local/` ignore for machine-local ethos state. Durable mission records (`contract.yaml`, `results.yaml`, etc.) stay unignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78673058fdc98d34fbd4300d0e5e645af6f3cb66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->