### PR TITLE
feat(vox-uvgv): tier-3 e2e CI job — install wheel, drive CLI + MCP stdio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,32 @@ jobs:
       # this taxonomy existed; run them explicitly so marking them opt-in
       # locally does not silently drop them from CI coverage.
       - run: uv run pytest -m "slow or subprocess"
+
+  # Tier 5: drive the INSTALLED wheel -- the `vox` binary as a subprocess and
+  # the `vox mcp` server over stdio. This tier catches packaging faults (an
+  # entry point that does not resolve, a module missing from the wheel, an MCP
+  # server that fails to start over stdio) which the in-process pytest above
+  # cannot see. Kept in its own job so a packaging break does not mask a
+  # unit-test failure and vice versa.
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      # ffmpeg + espeak-ng match the unit job so `vox doctor` reports the same
+      # environment the packaged binary is expected to run against.
+      - run: sudo apt-get update && sudo apt-get install -y ffmpeg espeak-ng
+      - run: uv sync --frozen --all-extras
+      # `make install` builds the wheel and does `uv tool install --force
+      # dist/*.whl`; uv drops the console script in ${XDG_DATA_HOME:-~/.local}/
+      # bin, which is NOT on PATH in non-interactive Actions shells until we
+      # publish it. Adding it before the tests run means shutil.which("vox")
+      # in the e2e suite resolves the just-installed artifact, not a stale one.
+      - run: make install
+      - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - run: vox version
+      - run: make test-e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,13 +31,17 @@ jobs:
       # locally does not silently drop them from CI coverage.
       - run: uv run pytest -m "slow or subprocess"
 
-  # Tier 5: drive the INSTALLED wheel -- the `vox` binary as a subprocess and
-  # the `vox mcp` server over stdio. This tier catches packaging faults (an
-  # entry point that does not resolve, a module missing from the wheel, an MCP
-  # server that fails to start over stdio) which the in-process pytest above
-  # cannot see. Kept in its own job so a packaging break does not mask a
-  # unit-test failure and vice versa.
-  e2e:
+  # Packaging e2e: drive the INSTALLED wheel -- the `vox` binary as a
+  # subprocess and the `vox mcp` server over stdio. This job catches packaging
+  # faults (an entry point that does not resolve, a module missing from the
+  # wheel, an MCP server that fails to start over stdio) which the in-process
+  # pytest above cannot see. Kept in its own job so a packaging break does not
+  # mask a unit-test failure and vice versa.
+  #
+  # NOTE: distinct from the "Tier 5" designation in
+  # tests/conversation_mode/coverage-matrix.md, which names live-audio /
+  # human-judged testing. This is installed-wheel packaging smoke.
+  packaging-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -51,10 +55,12 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ffmpeg espeak-ng
       - run: uv sync --frozen --all-extras
       # `make install` builds the wheel and does `uv tool install --force
-      # dist/*.whl`; uv drops the console script in ${XDG_DATA_HOME:-~/.local}/
-      # bin, which is NOT on PATH in non-interactive Actions shells until we
-      # publish it. Adding it before the tests run means shutil.which("vox")
-      # in the e2e suite resolves the just-installed artifact, not a stale one.
+      # dist/*.whl`; uv drops the console script in `$HOME/.local/bin` by
+      # default. That directory is NOT on PATH in non-interactive Actions
+      # shells until we publish it, and the e2e tests resolve the binary at
+      # that path explicitly (see tests/e2e/test_installed_cli._vox) so a
+      # `uv run pytest` invocation cannot mask the wheel with the editable
+      # `.venv/bin/vox` shim.
       - run: make install
       - run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - run: vox version

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: help test lint type docs check check-oo update-oo check-coupling update-coupling check-suppressions update-suppressions report format build install clean depot metrics coverage prfaq clean-tex zspec zspec-test
+.PHONY: help test test-e2e lint type docs check check-oo update-oo check-coupling update-coupling check-suppressions update-suppressions report format build install clean depot metrics coverage prfaq clean-tex zspec zspec-test
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
 
 test: ## Run tests
 	uv run pytest
+
+test-e2e: ## Tier 5 -- drive the INSTALLED `vox` binary and `vox mcp` server (run `make install` first)
+	uv run pytest tests/e2e -v -m e2e
 
 lint: ## Lint and format check (Python + shell)
 	uv run ruff check .

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Show available targets
 test: ## Run tests
 	uv run pytest
 
-test-e2e: ## Tier 5 -- drive the INSTALLED `vox` binary and `vox mcp` server (run `make install` first)
+test-e2e: ## Packaging e2e -- drive the INSTALLED `vox` binary and `vox mcp` server (run `make install` first)
 	uv run pytest tests/e2e -v -m e2e
 
 lint: ## Lint and format check (Python + shell)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ reportUnknownMemberType = false
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "-ra -q -m 'not slow and not integration and not subprocess and not sdk'"
+addopts = "-ra -q -m 'not slow and not integration and not subprocess and not sdk and not e2e'"
 testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
@@ -213,6 +213,7 @@ markers = [
     "slow: marks tests with heavy real-subprocess or real-filesystem overhead (run with -m slow)",
     "subprocess: marks tests that spawn real shell/git subprocesses (hook scripts, install.sh, plugin-surface gate; run with -m subprocess)",
     "sdk: marks tests that drive a real Claude Agent SDK session and cost real money (run with -m sdk)",
+    "e2e: marks tier-5 tests that drive the INSTALLED wheel -- `vox` binary as a subprocess and `vox mcp` over stdio; catches packaging faults no in-process test can see (run with -m e2e; requires `make install` first)",
 ]
 filterwarnings = [
     # Upstream elevenlabs SDK bug: pydantic v1 compat on Python 3.14. Remove when elevenlabs ships a fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ markers = [
     "slow: marks tests with heavy real-subprocess or real-filesystem overhead (run with -m slow)",
     "subprocess: marks tests that spawn real shell/git subprocesses (hook scripts, install.sh, plugin-surface gate; run with -m subprocess)",
     "sdk: marks tests that drive a real Claude Agent SDK session and cost real money (run with -m sdk)",
-    "e2e: marks tier-5 tests that drive the INSTALLED wheel -- `vox` binary as a subprocess and `vox mcp` over stdio; catches packaging faults no in-process test can see (run with -m e2e; requires `make install` first)",
+    "e2e: marks packaging-e2e tests that drive the INSTALLED wheel -- `vox` binary as a subprocess and `vox mcp` over stdio; catches entry-point resolution / missing-wheel-data / stdio-startup faults no in-process test can see (run with -m e2e; requires `make install` first; distinct from the live-audio tier in tests/conversation_mode/coverage-matrix.md)",
 ]
 filterwarnings = [
     # Upstream elevenlabs SDK bug: pydantic v1 compat on Python 3.14. Remove when elevenlabs ships a fix.

--- a/tests/e2e/test_installed_cli.py
+++ b/tests/e2e/test_installed_cli.py
@@ -1,15 +1,21 @@
 """Drive the installed ``vox`` binary as a subprocess.
 
 The rest of the suite imports ``punt_vox`` from the working tree, so none of it
-can see a packaging fault: an entry point that does not resolve, a data file
-left out of the wheel, a subcommand that exists in source but never reaches the
-installed CLI. These tests run the binary that ``make install`` put on
-``PATH`` -- the artifact a user actually gets.
+sees a packaging fault: an entry point that does not resolve, a data file left
+out of the wheel, a subcommand that exists in source but never reaches the
+installed CLI. These tests run the ``vox`` binary that ``make install`` placed
+in ``$HOME/.local/bin`` -- the artifact a user actually gets.
+
+Binary resolution is EXPLICIT, not via ``shutil.which("vox")``: ``uv run
+pytest`` prepends ``.venv/bin`` to ``PATH``, and after ``uv sync`` the
+``.venv/bin/vox`` script points back at working-tree source. ``shutil.which``
+would resolve to THAT and every packaging-fault check would silently pass on
+the source tree. See ``test_e2e_binary_is_installed_wheel_not_editable``.
 """
 
 from __future__ import annotations
 
-import shutil
+import os
 import subprocess
 from pathlib import Path
 
@@ -19,29 +25,52 @@ pytestmark = pytest.mark.e2e
 
 _TIMEOUT = 60.0
 
-# The core subcommands the packaged CLI MUST expose. A missing entry here means
-# either the entry point in pyproject.toml stopped resolving or a module was
-# dropped from the wheel; the source-tree tests cannot see either.
 _REQUIRED_COMMANDS = ("version", "status", "doctor", "say", "mcp")
 
 
-def _vox() -> str:
-    """Return the installed ``vox`` executable, skipping if absent."""
-    binary = shutil.which("vox")
-    if binary is None:
-        pytest.skip("vox is not installed -- run `make install` first")
-    return binary
+def _vox() -> Path:
+    """Return the ``uv tool``-installed ``vox`` binary path.
+
+    Override with ``VOX_E2E_BINARY`` when the tool bin dir is non-default.
+    Skips (does not fail) when the binary is absent so the suite is usable
+    on a workstation that has not run ``make install`` yet.
+    """
+    override = os.environ.get("VOX_E2E_BINARY")
+    candidate = Path(override) if override else Path.home() / ".local" / "bin" / "vox"
+    if not candidate.is_file():
+        pytest.skip(
+            f"installed vox not found at {candidate}; run `make install` "
+            "(or set VOX_E2E_BINARY to the uv tool bin path)"
+        )
+    return candidate
 
 
 def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
     """Run the installed CLI with ``args`` and capture its output."""
     return subprocess.run(
-        [_vox(), *args],
+        [str(_vox()), *args],
         capture_output=True,
         text=True,
         timeout=_TIMEOUT,
         check=False,
         cwd=cwd,
+    )
+
+
+def test_e2e_binary_is_installed_wheel_not_editable() -> None:
+    """The resolved binary must be from the installed wheel, not the venv.
+
+    ``uv run`` prepends ``.venv/bin`` to ``PATH``; a ``shutil.which("vox")``
+    call from inside ``uv run pytest`` would return the editable working-tree
+    shim and defeat the entire purpose of the packaging tier. The other tests
+    use explicit path resolution; this test makes the invariant fail LOUDLY
+    if a future change relaxes it.
+    """
+    binary = _vox()
+    parts = binary.resolve().parts
+    assert ".venv" not in parts, (
+        f"e2e binary {binary} resolves inside .venv -- the wheel install is "
+        "being bypassed and packaging faults would silently pass"
     )
 
 
@@ -53,14 +82,23 @@ def test_version_reports_the_installed_package() -> None:
     assert "vox" in combined.lower()
 
 
-def test_help_lists_core_subcommands() -> None:
-    """A subcommand present in source but absent from the installed CLI is a
-    packaging fault -- typically a module missing from the wheel."""
-    result = _run("--help")
+@pytest.mark.parametrize("subcommand", _REQUIRED_COMMANDS)
+def test_subcommand_help_resolves(subcommand: str) -> None:
+    """Every required subcommand must render its own ``--help`` cleanly.
 
-    assert result.returncode == 0, result.stderr
-    missing = [c for c in _REQUIRED_COMMANDS if c not in result.stdout]
-    assert not missing, f"subcommands absent from the installed CLI: {missing}"
+    Rich soft-wraps the top-level ``--help`` output at the runner's tty
+    width, so scraping the wrapped table for command names is width-fragile
+    (the same trap ``tests/_cli_introspect.py`` documents for the option-name
+    column). Invoking ``vox <subcommand> --help`` and asserting exit 0 proves
+    the subcommand is registered and reachable in the installed wheel with
+    no substring match on rendered output.
+    """
+    result = _run(subcommand, "--help")
+
+    assert result.returncode == 0, (
+        f"`vox {subcommand} --help` failed: rc={result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
 
 
 def test_doctor_runs_from_an_unrelated_directory(tmp_path: Path) -> None:

--- a/tests/e2e/test_installed_cli.py
+++ b/tests/e2e/test_installed_cli.py
@@ -1,0 +1,80 @@
+"""Drive the installed ``vox`` binary as a subprocess.
+
+The rest of the suite imports ``punt_vox`` from the working tree, so none of it
+can see a packaging fault: an entry point that does not resolve, a data file
+left out of the wheel, a subcommand that exists in source but never reaches the
+installed CLI. These tests run the binary that ``make install`` put on
+``PATH`` -- the artifact a user actually gets.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_TIMEOUT = 60.0
+
+# The core subcommands the packaged CLI MUST expose. A missing entry here means
+# either the entry point in pyproject.toml stopped resolving or a module was
+# dropped from the wheel; the source-tree tests cannot see either.
+_REQUIRED_COMMANDS = ("version", "status", "doctor", "say", "mcp")
+
+
+def _vox() -> str:
+    """Return the installed ``vox`` executable, skipping if absent."""
+    binary = shutil.which("vox")
+    if binary is None:
+        pytest.skip("vox is not installed -- run `make install` first")
+    return binary
+
+
+def _run(*args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    """Run the installed CLI with ``args`` and capture its output."""
+    return subprocess.run(
+        [_vox(), *args],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+        check=False,
+        cwd=cwd,
+    )
+
+
+def test_version_reports_the_installed_package() -> None:
+    result = _run("version")
+
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "vox" in combined.lower()
+
+
+def test_help_lists_core_subcommands() -> None:
+    """A subcommand present in source but absent from the installed CLI is a
+    packaging fault -- typically a module missing from the wheel."""
+    result = _run("--help")
+
+    assert result.returncode == 0, result.stderr
+    missing = [c for c in _REQUIRED_COMMANDS if c not in result.stdout]
+    assert not missing, f"subcommands absent from the installed CLI: {missing}"
+
+
+def test_doctor_runs_from_an_unrelated_directory(tmp_path: Path) -> None:
+    """``doctor`` must not depend on being launched from the source tree -- a
+    consumer runs it from wherever they happen to be."""
+    result = _run("doctor", cwd=tmp_path)
+
+    combined = result.stdout + result.stderr
+    assert "Traceback" not in combined, combined
+
+
+def test_status_runs_from_an_unrelated_directory(tmp_path: Path) -> None:
+    """``status`` reads config; must not crash without a repo-rooted cwd."""
+    result = _run("status", cwd=tmp_path)
+
+    combined = result.stdout + result.stderr
+    assert "Traceback" not in combined, combined

--- a/tests/e2e/test_installed_mcp.py
+++ b/tests/e2e/test_installed_mcp.py
@@ -1,0 +1,205 @@
+"""Drive the installed MCP server over stdio.
+
+The MCP surface is where packaging faults surface as a hung "Loading..." rather
+than an error: the server starts, tools/list answers, and the data file it
+needed was never in the wheel. Nothing in-process can see that. This spawns
+``vox mcp``, completes the JSON-RPC handshake, and asserts the tool list
+contains the core ``mic:*`` tools clients depend on.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import shutil
+import subprocess
+import threading
+import time
+from typing import IO, Any, NoReturn, Self, final
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+_PROTOCOL_VERSION = "2024-11-05"
+_TIMEOUT = 60.0
+# A server that starts but never answers -- import hang, lifespan deadlock --
+# must fail this test in seconds with a diagnostic, not stall the CI job until
+# Actions kills it.
+_REQUEST_TIMEOUT = 30.0
+
+# The core mic tool set clients depend on. Music/rec/enablement/model/provider/
+# vibe are also registered but this floor is what the bead demands.
+_REQUIRED_TOOLS = frozenset({"unmute", "notify", "speak", "voice", "status"})
+
+
+@final
+class _PipeReader:
+    """Drain one of the child's pipes on a daemon thread.
+
+    stdout is the JSON-RPC stream; reading through a queue is what gives
+    :meth:`next_line` a deadline that a blocking ``readline`` cannot. stderr is
+    the server's log: unread, a chatty server fills the pipe buffer and blocks
+    on its own logging. Every line drained is kept so a failure can quote what
+    the server said before it stopped answering.
+    """
+
+    _pipe: IO[str]
+    _lines: queue.Queue[str | None]
+    _seen: list[str]
+    __slots__ = ("_lines", "_pipe", "_seen")
+
+    def __new__(cls, pipe: IO[str]) -> Self:
+        self = super().__new__(cls)
+        self._pipe = pipe
+        self._lines = queue.Queue()
+        self._seen = []
+        threading.Thread(target=self._drain, daemon=True).start()
+        return self
+
+    def next_line(self, timeout: float) -> str | None:
+        """Return the next line, or ``None`` once the pipe closes.
+
+        ``None`` is end-of-stream -- distinct from ``TimeoutError``, which
+        means the pipe is still open and silent.
+        """
+        try:
+            return self._lines.get(timeout=timeout)
+        except queue.Empty:
+            msg = f"no output for {timeout:.1f}s"
+            raise TimeoutError(msg) from None
+
+    def text(self) -> str:
+        """Return every line drained so far -- the child's own diagnostics."""
+        return "".join(self._seen)
+
+    def _drain(self) -> None:
+        for line in self._pipe:
+            self._seen.append(line)
+            self._lines.put(line)
+        self._lines.put(None)
+
+
+@final
+class StdioClient:
+    """A minimal newline-delimited JSON-RPC client for an MCP stdio server."""
+
+    _next_id: int
+    _proc: subprocess.Popen[str]
+    _out: _PipeReader
+    _err: _PipeReader
+
+    __slots__ = ("_err", "_next_id", "_out", "_proc")
+
+    def __new__(cls, proc: subprocess.Popen[str]) -> Self:
+        stdout, stderr = proc.stdout, proc.stderr
+        assert stdout is not None
+        assert stderr is not None
+        self = super().__new__(cls)
+        self._proc = proc
+        self._next_id = 0
+        self._out = _PipeReader(stdout)
+        self._err = _PipeReader(stderr)
+        return self
+
+    @property
+    def _stdin(self) -> IO[str]:
+        stdin = self._proc.stdin
+        assert stdin is not None
+        return stdin
+
+    def notify(self, method: str) -> None:
+        """Send a notification -- a request with no id and no reply."""
+        self._send({"jsonrpc": "2.0", "method": method})
+
+    def request(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        """Send ``method`` and return the matching response's ``result``."""
+        self._next_id += 1
+        request_id = self._next_id
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params if params is not None else {},
+        }
+        self._send(payload)
+        return self._await(request_id)
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        self._stdin.write(json.dumps(payload) + "\n")
+        self._stdin.flush()
+
+    def _await(self, request_id: int) -> Any:
+        """Read lines until the response carrying ``request_id`` arrives.
+
+        Bounded by ``_REQUEST_TIMEOUT`` in total, not per line, so a server
+        dribbling notifications forever fails as surely as a silent one.
+        """
+        deadline = time.monotonic() + _REQUEST_TIMEOUT
+        while (remaining := deadline - time.monotonic()) > 0:
+            try:
+                line = self._out.next_line(remaining)
+            except TimeoutError:
+                break
+            if line is None:
+                self._fail(f"server closed stdout before answering id={request_id}")
+            text = line.strip()
+            if not text:
+                continue
+            message = json.loads(text)
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                self._fail(f"server returned an error: {message['error']}")
+            return message["result"]
+        raise AssertionError(
+            f"no reply to id={request_id} within {_REQUEST_TIMEOUT:.0f}s\n"
+            f"--- server stderr ---\n{self._err.text()}"
+        )
+
+    def _fail(self, reason: str) -> NoReturn:
+        """Raise with the server's stderr attached -- the only diagnostic there is."""
+        raise AssertionError(f"{reason}\n--- server stderr ---\n{self._err.text()}")
+
+
+def _spawn() -> subprocess.Popen[str]:
+    binary = shutil.which("vox")
+    if binary is None:
+        pytest.skip("vox is not installed -- run `make install` first")
+    return subprocess.Popen(
+        [binary, "mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+
+
+def test_installed_server_exposes_core_mic_tools() -> None:
+    proc = _spawn()
+    try:
+        client = StdioClient(proc)
+        client.request(
+            "initialize",
+            {
+                "protocolVersion": _PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "vox-e2e", "version": "0"},
+            },
+        )
+        client.notify("notifications/initialized")
+        result = client.request("tools/list")
+
+        names = {tool["name"] for tool in result["tools"]}
+        missing = sorted(_REQUIRED_TOOLS - names)
+        assert not missing, (
+            f"tools absent from the installed server: {missing}; "
+            f"present: {sorted(names)}"
+        )
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/e2e/test_installed_mcp.py
+++ b/tests/e2e/test_installed_mcp.py
@@ -10,11 +10,12 @@ contains the core ``mic:*`` tools clients depend on.
 from __future__ import annotations
 
 import json
+import os
 import queue
-import shutil
 import subprocess
 import threading
 import time
+from pathlib import Path
 from typing import IO, Any, NoReturn, Self, final
 
 import pytest
@@ -146,7 +147,13 @@ class StdioClient:
             text = line.strip()
             if not text:
                 continue
-            message = json.loads(text)
+            try:
+                message = json.loads(text)
+            except json.JSONDecodeError as exc:
+                self._fail(
+                    f"non-JSON on server stdout while awaiting id={request_id}: "
+                    f"{exc.msg} at col {exc.colno}; offending line: {text!r}"
+                )
             if message.get("id") != request_id:
                 continue
             if "error" in message:
@@ -163,11 +170,22 @@ class StdioClient:
 
 
 def _spawn() -> subprocess.Popen[str]:
-    binary = shutil.which("vox")
-    if binary is None:
-        pytest.skip("vox is not installed -- run `make install` first")
+    """Spawn ``vox mcp`` from the INSTALLED wheel, never the editable venv.
+
+    Path resolution matches ``test_installed_cli._vox``: ``uv run`` prepends
+    ``.venv/bin`` to ``PATH`` and ``shutil.which("vox")`` would return the
+    working-tree shim. Explicit ``$HOME/.local/bin/vox`` (overridable via
+    ``VOX_E2E_BINARY``) forces the packaged artifact.
+    """
+    override = os.environ.get("VOX_E2E_BINARY")
+    binary = Path(override) if override else Path.home() / ".local" / "bin" / "vox"
+    if not binary.is_file():
+        pytest.skip(
+            f"installed vox not found at {binary}; run `make install` "
+            "(or set VOX_E2E_BINARY to the uv tool bin path)"
+        )
     return subprocess.Popen(
-        [binary, "mcp"],
+        [str(binary), "mcp"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary

Closes bead **vox-uvgv (P2)** — adds a tier-3 e2e CI job that catches PACKAGING faults (broken entry point, missing wheel data file, MCP server that fails to start over stdio) which in-process pytest can't see. Adapts the pattern the z-spec agent offered during their ratchet-port exchange.

## What changed

**New `e2e` job in `.github/workflows/test.yml`, parallel to the existing `test` job:**

1. Checkout + setup-uv + setup-python 3.13
2. `apt-get install ffmpeg espeak-ng` (matches unit job's environment)
3. `uv sync --frozen --all-extras`
4. `make install` — builds wheel, `uv tool install --force dist/*.whl`
5. `echo "$HOME/.local/bin" >> "$GITHUB_PATH"` — non-interactive Actions shells don't carry uv's tool bin dir; without this `shutil.which("vox")` skips
6. `vox version` — smoke that the entry point resolved
7. `make test-e2e` → `uv run pytest tests/e2e -v -m e2e`

## Entry points exercised

- **CLI subprocess** (`tests/e2e/test_installed_cli.py`): `vox version`, `vox --help` (asserts required subcommands: `version`, `status`, `doctor`, `say`, `mcp`), `vox doctor` from an unrelated cwd, `vox status` from an unrelated cwd — each asserting exit conditions and no `Traceback`.
- **MCP over stdio** (`tests/e2e/test_installed_mcp.py`) — **real, not a stub.** Spawns `vox mcp`, hand-rolled newline-delimited JSON-RPC client (bounded 30s/request, stderr drained on a daemon thread and quoted in failures), does `initialize` → `notifications/initialized` → `tools/list`, asserts `{unmute, notify, speak, voice, status}` are present in the returned tool set.

## Adaptation note

Vox has no `CAPABILITIES` registry equivalent to z-spec's, so the required-tool set is a hard-coded floor from the bead (the five core `mic:*` tools) rather than parity against a registry. Everything else (marker declaration, `e2e` exclusion from default `pytest`, Makefile `test-e2e`, `_PipeReader`/`StdioClient` scaffolding) mirrors z-spec's pattern directly.

## Test plan

- [x] Local: workflow YAML is shellcheck-clean and valid.
- [x] `pyproject.toml` marker declared, e2e tests default-excluded from `pytest`.
- [ ] CI: e2e job runs on this PR and turns green.

## Closes

Closes vox-uvgv on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI-only; no product or auth changes. Main risk is extra CI time or flakes from subprocess/MCP timeouts, not user-facing behavior.
> 
> **Overview**
> Adds a parallel **packaging e2e** CI job that installs the built wheel and drives the real `vox` binary, catching entry-point, missing-wheel-data, and MCP stdio startup faults that in-process pytest cannot see.
> 
> The new `e2e` marker is excluded from the default pytest run. `make test-e2e` runs `tests/e2e` after `make install`. Tests resolve `$HOME/.local/bin/vox` (or `VOX_E2E_BINARY`) explicitly so `uv run` cannot pick the editable `.venv` shim.
> 
> CLI smoke covers `version`, `--help` for `version`/`status`/`doctor`/`say`/`mcp`, and `doctor`/`status` from an unrelated cwd. MCP smoke spawns `vox mcp`, completes initialize + `tools/list`, and asserts `{unmute, notify, speak, voice, status}` are registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f555b7f752f5d25884fb9cb4ca9e027e023314c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->