### PR TITLE
chore: remove legacy root .biff config

### DIFF
--- a/.biff
+++ b/.biff
@@ -1,8 +1,0 @@
-[team]
-members = ["jmf-pobox", "github-actions"]
-
-[relay]
-url = "tls://connect.ngs.global"
-
-[peers]
-orgs = ["punt-labs"]


### PR DESCRIPTION
## Summary

Remove the legacy root `.biff` config file — 8 lines of `[team]` / `[relay]` / `[peers]` that predate biff's move to its own config location. The file was staged for deletion in an earlier session; this PR closes the loop.

## Verification

Nothing live references the root path — `git grep '\.biff'` returns only `.gitignore` entries for `.biff.local` (user-local override) and `.punt-labs/ethos/.biff` (submodule config), both distinct paths from the root `.biff` being removed.

## Test plan

- [x] `git grep '\.biff'` confirmed no live consumers of the root path.
- [x] `.gitignore` entries preserved for `.biff.local` and `.punt-labs/ethos/.biff` — those are unaffected.
- N/A: no code, no tests, no docs — pure config removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure removal of a leftover 8-line config file with no remaining in-repo consumers. No code, auth, or data-path changes.
> 
> **Overview**
> Deletes the unused root `.biff` file (team, relay, and peers settings) after biff moved to its own config location.
> 
> `.gitignore` still covers `.biff.local` and `.punt-labs/ethos/.biff`; those paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1403c6ec85bb204299941d72b3b9e8cbb214ad9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->