### PR TITLE
docs: bump README install.sh SHA pin to v5.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ vox is usable in three ways, all driving the same `voxd` audio daemon --- so it 
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh | sh
 ```
 
 Restart Claude Code, then:
@@ -50,10 +50,10 @@ Install the `vox` CLI without the Claude Code plugin — for a non-Claude harnes
 
 ```bash
 # Flag form
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh | sh -s -- --no-plugin
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh | sh -s -- --no-plugin
 
 # Environment form (for argument-hostile contexts — CI templates, proxies)
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh | VOX_NO_PLUGIN=1 sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh | VOX_NO_PLUGIN=1 sh
 ```
 
 `VOX_NO_PLUGIN` skips the plugin only when set to exactly `1`; any other value is ignored. The plugin also auto-skips when `claude` or `git` is absent.
@@ -73,7 +73,7 @@ vox doctor
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/67b5ac4/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh


### PR DESCRIPTION
## Summary

- The README's install command pins `raw.githubusercontent.com/punt-labs/vox/<SHA>/install.sh` to a specific commit for reproducibility. That SHA (`67b5ac4`) was still the **v5.0.0 release commit** — the release fixed in #457. Anyone copy-pasting the README's install command was handed the broken v5.0.0 build (`voxd` `ImportError` on startup) even after v5.0.1 published to PyPI.
- Reproduced live: an operator ran the exact README command minutes after v5.0.1 published and got `punt-vox==5.0.0` installed, with `voxd` failing to start (`ServiceHealthError: voxd registered but never became reachable`).
- Bumped all 4 occurrences to `21b1b4f`, the v5.0.1 merge commit. Confirmed via `gh api repos/punt-labs/vox/contents/install.sh?ref=21b1b4f` that this SHA's `install.sh` has `VERSION="5.0.1"`.

This is the known gap referenced in the release memory ("punt release CLI doesn't update README URLs; do it in the post-release PR") — missed in the #457 release PR since that PR predated its own merge commit.

## Verification

- `make lint` green (ruff, shellcheck, skill-permissions, plugin-surface checks).
- Confirmed `21b1b4f`'s `install.sh` pins `VERSION="5.0.1"` via the GitHub contents API before pushing this change.
- Docs-only change — Phase 3 audio-demo verification N/A; verification here is confirming the referenced commit's file content is correct, done above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only SHA pin change in README; no runtime or security logic is modified.
> 
> **Overview**
> Updates the four README `install.sh` curl pins from commit `67b5ac4` (v5.0.0) to `21b1b4f` (v5.0.1). Copy-paste install commands now fetch the patched installer instead of the broken v5.0.0 build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8b25aedadcfcb471a9b4c7d908675cee76bb6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->