### PR TITLE
chore: gitignore .beads dolt-server runtime files

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -47,3 +47,9 @@ daemon.log
 daemon.pid
 bd.sock
 sync-state.json
+
+# Dolt server runtime (bd 1.0.x server-mode local dolt-server process)
+dolt-server.lock
+dolt-server.pid
+dolt-server.port
+dolt/


### PR DESCRIPTION
## Summary
- Add `.beads/.gitignore` patterns for bd 1.0.x server-mode dolt-server runtime artifacts: `dolt-server.lock`, `dolt-server.pid`, `dolt-server.port`, `dolt/`
- These are local-only process artifacts (lock/pid/port files + the server's dolt data directory), analogous to the existing `daemon.lock`/`daemon.pid`/`bd.sock` entries in the "Daemon runtime" section, but for the dolt-server process specifically rather than the bd daemon
- No negation patterns added, per this file's explicit header rule against `!`-negations (they would re-enable tracking of merge/export views and create conflicts)

Mechanical, docs/config-only change — no runnable code touched.

## Test plan
- [x] `git status --porcelain .beads` shows nothing for `dolt-server.lock`, `dolt-server.pid`, `dolt-server.port`, `dolt/` after the change (previously untracked/shown)
- [x] `make check` passes (lint, type, shellcheck, markdownlint, tests, OO/coupling/suppression ratchets all green — .gitignore is not a scored file)
- docs-only/config-only change — Phase 3 verification N/A per Definition of Done