### PR TITLE
chore: post-release v5.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ vox is usable in three ways, all driving the same `voxd` audio daemon --- so it 
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/3389dc0/install.sh | sh
 ```
 
 Restart Claude Code, then:
@@ -50,10 +50,10 @@ Install the `vox` CLI without the Claude Code plugin — for a non-Claude harnes
 
 ```bash
 # Flag form
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh | sh -s -- --no-plugin
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/3389dc0/install.sh | sh -s -- --no-plugin
 
 # Environment form (for argument-hostile contexts — CI templates, proxies)
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh | VOX_NO_PLUGIN=1 sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/3389dc0/install.sh | VOX_NO_PLUGIN=1 sh
 ```
 
 `VOX_NO_PLUGIN` skips the plugin only when set to exactly `1`; any other value is ignored. The plugin also auto-skips when `claude` or `git` is absent.
@@ -73,7 +73,7 @@ vox doctor
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/21b1b4f/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/3389dc0/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
-  "version": "5.0.2",
+  "version": "5.0.1",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only URL pin plus dev plugin manifest rename; no runtime, daemon, or auth changes.
> 
> **Overview**
> Post-release cleanup after **v5.0.2**: restores the Claude Code plugin manifest to the **dev** identity and refreshes install links in the README.
> 
> All **curl** install examples now point at commit **`3389dc0`** instead of **`21b1b4f`** (Quick Start, `--no-plugin`, `VOX_NO_PLUGIN=1`, and the verify-before-run flow). **`plugin/.claude-plugin/plugin.json`** renames the marketplace plugin from **`vox`** back to **`vox-dev`**, matching the usual pattern where release tags ship as **`vox`** and the working tree stays on the dev plugin id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40323dcf50f800ef775a4197f2104f9df31e5fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->