### PR TITLE
fix(vox-nkn8): watch the real Claude Code process, not the sh wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Vox Control Panel applet now survives long enough to register in the
+  Lux menu (vox-nkn8).** Every `vox-panel-*.log` under `~/.punt-labs/vox/logs`
+  contained exactly one line, ever — "session `<pid>` has gone; the applet is
+  leaving" — because `plugin/hooks/session-start.sh` passed `$PPID` to
+  `vox-panel --session-pid`, believing it named the Claude Code process that
+  ran the hook. It doesn't: Claude Code invokes SessionStart hooks through a
+  short-lived `sh` wrapper that exits within seconds of the hook script
+  finishing, so the panel's own liveness check saw its watched process vanish
+  almost immediately and left before it ever reached the Hub. The hook now
+  resolves the wrapper's parent (the genuinely persistent `claude` process),
+  verified by an exact — not substring/glob — match on its command name, and
+  falls back to the old `$PPID` behavior for any process tree that doesn't
+  match, so an unexpected shape fails safe (an applet that exits too early,
+  same as before) rather than watching an unrelated long-lived ancestor
+  forever. Both `ps` lookups are guarded so a vanished target can't abort the
+  whole hook under `set -e`.
 - **`vox desktop install` now knows where Claude Desktop keeps its config on
   Linux (vox-1gub).** Claude Desktop ships for Linux, where its Electron shell
   keeps `userData` under `$XDG_CONFIG_HOME` (default `~/.config`) — verified

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -401,7 +401,7 @@ if [ -f "$_repo_root/.punt-labs/vox/enabled" ]; then
   _grandparent_pid="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d '[:space:]')" || true
   _grandparent_comm=""
   if [[ -n "$_grandparent_pid" ]]; then
-    _grandparent_comm="$(ps -o comm= -p "$_grandparent_pid" 2>/dev/null)" || true
+    _grandparent_comm="$(ps -o comm= -p "$_grandparent_pid" 2>/dev/null | tr -d '[:space:]')" || true
   fi
   case "$_grandparent_comm" in
     claude) SESSION_WATCH_PID="$_grandparent_pid" ;;

--- a/plugin/hooks/session-start.sh
+++ b/plugin/hooks/session-start.sh
@@ -364,12 +364,16 @@ fi
 # lock), gated additionally on vox's own per-repo enablement marker so an
 # unrelated repo never gets a floating "Vox" menu entry.
 #
-# $PPID is the Claude Code process that ran this hook. The applet watches it
-# and exits when it goes, so it never outlives its session. SessionStart
-# fires more than once for one session -- /resume and /clear both fire it
-# again against the same process -- and the applet refuses a second start
-# itself under its own session-pid lock, so the guard below only saves the
-# pointless respawn.
+# $PPID is NOT the Claude Code process that ran this hook -- it is a
+# short-lived `sh` wrapper that Claude Code interposes to invoke SessionStart
+# hooks, and that wrapper exits within seconds of this script finishing.
+# Watching $PPID means the panel's own liveness check sees the wrapper vanish
+# almost immediately and leaves before it ever reaches the Hub -- the panel
+# never registers in the menu, which is exactly the bug this block fixes (see
+# the SESSION_WATCH_PID resolution below). SessionStart fires more than once
+# for one session -- /resume and /clear both fire it again against the same
+# process -- and the applet refuses a second start itself under its own
+# session-pid lock, so the guard below only saves the pointless respawn.
 _repo_root=$(git -C "$_cwd" rev-parse --show-toplevel 2>/dev/null) || _repo_root=""
 if [ -z "$_repo_root" ]; then
   _dir="$_cwd"
@@ -379,6 +383,31 @@ if [ -z "$_repo_root" ]; then
   _repo_root="$_dir"
 fi
 if [ -f "$_repo_root/.punt-labs/vox/enabled" ]; then
+  # The genuinely persistent `claude` process is the wrapper's *parent*, i.e.
+  # $PPID's grandparent from here. Resolve it, but verify its command name is
+  # EXACTLY "claude" (not a substring/glob match -- a process named
+  # "not-claude" must be REJECTED) before trusting it: a differently-shaped
+  # process tree (a future Claude Code version with no wrapper, a different
+  # OS's process model) must fail safe -- an applet that exits too early,
+  # same as today -- rather than silently watching an unrelated long-lived
+  # ancestor (a login shell, systemd) forever, which would leak the panel
+  # process past the actual session's end.
+  #
+  # Both `ps` calls are allowed to fail -- a vanished parent between
+  # resolving the pid and querying its comm is a real race, however rare, and
+  # under `set -e` an unguarded failure here would abort the whole hook (no
+  # panel, nothing past this point) rather than falling back to $PPID as
+  # intended.
+  _grandparent_pid="$(ps -o ppid= -p "$PPID" 2>/dev/null | tr -d '[:space:]')" || true
+  _grandparent_comm=""
+  if [[ -n "$_grandparent_pid" ]]; then
+    _grandparent_comm="$(ps -o comm= -p "$_grandparent_pid" 2>/dev/null)" || true
+  fi
+  case "$_grandparent_comm" in
+    claude) SESSION_WATCH_PID="$_grandparent_pid" ;;
+    *) SESSION_WATCH_PID="$PPID" ;;
+  esac
+
   # ~/.punt-labs/vox/logs is where every other vox process already logs, and
   # unlike a shared tmp dir it is not writable by other local users -- so a
   # predictable per-session filename cannot be pre-empted by a symlink planted
@@ -390,7 +419,7 @@ if [ -f "$_repo_root/.punt-labs/vox/enabled" ]; then
   # traversable by a permissive umask stays that way. This mirrors
   # private_state.ensure_private_tree() on the Python side.
   chmod 700 "$HOME/.punt-labs" "$HOME/.punt-labs/vox" "$PANEL_LOG_DIR" 2>/dev/null || true
-  PANEL_LOG="$PANEL_LOG_DIR/vox-panel-$PPID.log"
+  PANEL_LOG="$PANEL_LOG_DIR/vox-panel-$SESSION_WATCH_PID.log"
   # An unwritable log path must cost this session its log, not its panel. The
   # `>>` redirects below are unguarded, and a failed redirect on a synchronous
   # command aborts under `set -e` -- so without this fallback an unwritable
@@ -401,10 +430,10 @@ if [ -f "$_repo_root/.punt-labs/vox/enabled" ]; then
     # connected to voxd or luxd yet at this point in the hook, so there is no
     # daemon to carry this reason into `vox status`/`vox doctor`.
     echo "$(date '+%Y-%m-%d %H:%M:%S') session-start: vox-panel not found on PATH; the Vox control panel will not be available this session" >>"$PANEL_LOG"
-  elif pgrep -f "vox-panel --session-pid ${PPID}\$" >/dev/null 2>&1; then
+  elif pgrep -f "vox-panel --session-pid ${SESSION_WATCH_PID}\$" >/dev/null 2>&1; then
     echo "$(date '+%Y-%m-%d %H:%M:%S') session-start: this session is already served; not spawning another panel" >>"$PANEL_LOG"
   else
-    nohup vox-panel --session-pid "$PPID" >>"$PANEL_LOG" 2>&1 &
+    nohup vox-panel --session-pid "$SESSION_WATCH_PID" >>"$PANEL_LOG" 2>&1 &
     disown
   fi
 fi

--- a/tests/test_session_start_pid.py
+++ b/tests/test_session_start_pid.py
@@ -26,6 +26,8 @@ import os
 import shutil
 import stat
 import subprocess
+import time
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -50,6 +52,31 @@ fi
 "$@" &
 wait
 """
+
+
+def _poll_until(predicate: Callable[[], bool], *, timeout: float = 10.0) -> None:
+    """Poll *predicate* until it's true -- the panel stub is spawned via
+    ``nohup ... & disown`` (fire-and-forget), so it can still be writing its
+    output file after the hook script -- and this test's ``subprocess.Popen``
+    call -- has already returned. An immediate check races that write; a
+    blind ``sleep`` only narrows the window without closing it.
+
+    10s matches the equivalent poll in ``test_hook_gate.py``: a 15-run
+    isolated rerun of that poll (no concurrent load) still missed a 2s
+    deadline once, so 2s is not a safe bound for OS scheduling of an
+    already-disowned background process even at rest. The predicate
+    resolves in milliseconds on the happy path -- this loop returns as soon
+    as it's true -- so the generous ceiling costs nothing when the spawn is
+    prompt and only matters on the rare slow tail.
+    """
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() > deadline:
+            msg = (
+                "timed out waiting for the backgrounded vox-panel stub to write output"
+            )
+            raise AssertionError(msg)
+        time.sleep(0.02)
 
 
 def _make_executable(path: Path) -> None:
@@ -121,7 +148,7 @@ def _run_tree(tmp_path: Path, *, claude_comm: str) -> tuple[int, int, int]:
     assert len(trace_lines) == 2, trace_lines
     wrapper_pid = int(trace_lines[1])
 
-    assert stub_out.exists(), "vox-panel stub was never invoked"
+    _poll_until(stub_out.exists)
     stub_args = stub_out.read_text(encoding="utf-8").split()
     assert stub_args[:1] == ["--session-pid"], stub_args
     resolved_session_pid = int(stub_args[1])

--- a/tests/test_session_start_pid.py
+++ b/tests/test_session_start_pid.py
@@ -1,0 +1,163 @@
+"""Behavioral tests for the PID resolution in plugin/hooks/session-start.sh.
+
+Claude Code invokes SessionStart hooks through a short-lived ``sh`` wrapper:
+the hook's own ``$PPID`` names that wrapper, not the long-running ``claude``
+process that actually owns the session. Every ``vox-panel-*.log`` under
+``~/.punt-labs/vox/logs`` contained exactly one line -- "session <pid> has
+gone; the applet is leaving" -- because the panel was spawned watching
+``$PPID`` directly, so its own liveness check saw the wrapper vanish within
+seconds and left before ever reaching the Hub to register in the Lux menu
+(vox-nkn8).
+
+These tests drive the real hook script as a subprocess at the bottom of a
+real three-level process tree -- a stand-in ``claude`` process, a wrapper
+that forks it away, and the hook script itself -- and assert it resolves the
+*grandparent* pid, verified by an exact command-name match, rather than the
+wrapper it was directly forked from. A fixture ``vox-panel`` stub on ``PATH``
+captures the ``--session-pid`` argument the script actually passed, so this
+is an outside-in check: nothing here reads the script's internals, only what
+it does.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parent.parent / "plugin" / "hooks" / "session-start.sh"
+)
+
+pytestmark = [
+    pytest.mark.subprocess,
+    pytest.mark.skipif(shutil.which("jq") is None, reason="requires jq"),
+    pytest.mark.skipif(shutil.which("ps") is None, reason="requires ps"),
+    pytest.mark.skipif(shutil.which("pgrep") is None, reason="requires pgrep"),
+]
+
+_RELAY_SH = """#!/usr/bin/env bash
+# Forks "$@" as a genuine child (backgrounding always forks) and waits for it,
+# so each level in the tree is a distinct process with the expected parent.
+if [[ -n "${RELAY_TRACE_FILE:-}" ]]; then
+  echo "$$" >> "$RELAY_TRACE_FILE"
+fi
+"$@" &
+wait
+"""
+
+
+def _make_executable(path: Path) -> None:
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_named_binary(tmp_path: Path, name: str) -> Path:
+    """Copy the real `bash` binary to *name* so its `ps` comm matches *name*.
+
+    `/proc/[pid]/comm` reflects the basename of the execve'd file, not a
+    script's shebang target -- invoking `bash script.sh` always reports comm
+    `bash`. Renaming the binary itself is the only way to control comm.
+    """
+    bash_path = shutil.which("bash")
+    assert bash_path is not None, "bash must be on PATH to build the fixture"
+    dest = tmp_path / name
+    shutil.copy(bash_path, dest)
+    _make_executable(dest)
+    return dest
+
+
+def _system_path() -> str:
+    return os.environ.get("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+
+
+def _run_tree(tmp_path: Path, *, claude_comm: str) -> tuple[int, int, int]:
+    """Spawn claude(comm=claude_comm) -> wrapper -> session-start.sh.
+
+    Returns (claude_pid, wrapper_pid, resolved_session_pid).
+    """
+    relay_sh = tmp_path / "relay.sh"
+    relay_sh.write_text(_RELAY_SH, encoding="utf-8")
+    _make_executable(relay_sh)
+
+    claude_bin = _make_named_binary(tmp_path, claude_comm)
+
+    stub_bin = tmp_path / "stubbin"
+    stub_bin.mkdir()
+    stub_out = tmp_path / "stub_out.txt"
+    (stub_bin / "vox-panel").write_text(
+        f'#!/usr/bin/env bash\nprintf \'%s\\n\' "$@" > "{stub_out}"\n',
+        encoding="utf-8",
+    )
+    _make_executable(stub_bin / "vox-panel")
+
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    repo_dir = tmp_path / "repo"
+    (repo_dir / ".punt-labs" / "vox").mkdir(parents=True)
+    (repo_dir / ".punt-labs" / "vox" / "enabled").touch()
+    trace_file = tmp_path / "relay_trace.txt"
+
+    env = dict(os.environ)
+    env["HOME"] = str(fake_home)
+    env["PATH"] = f"{stub_bin}:{_system_path()}"
+    env["RELAY_TRACE_FILE"] = str(trace_file)
+
+    proc = subprocess.Popen(
+        [str(claude_bin), str(relay_sh), "bash", str(relay_sh), "bash", str(_SCRIPT)],
+        env=env,
+        stdin=subprocess.PIPE,
+        text=True,
+    )
+    claude_pid = proc.pid
+    proc.communicate(input=json.dumps({"cwd": str(repo_dir)}), timeout=15)
+    assert proc.returncode == 0
+
+    trace_lines = trace_file.read_text(encoding="utf-8").split()
+    assert len(trace_lines) == 2, trace_lines
+    wrapper_pid = int(trace_lines[1])
+
+    assert stub_out.exists(), "vox-panel stub was never invoked"
+    stub_args = stub_out.read_text(encoding="utf-8").split()
+    assert stub_args[:1] == ["--session-pid"], stub_args
+    resolved_session_pid = int(stub_args[1])
+
+    return claude_pid, wrapper_pid, resolved_session_pid
+
+
+class TestResolvesTheRealSessionAcrossTheWrapper:
+    def test_watches_the_grandparent_when_it_looks_like_claude(
+        self, tmp_path: Path
+    ) -> None:
+        claude_pid, wrapper_pid, resolved = _run_tree(tmp_path, claude_comm="claude")
+        assert resolved == claude_pid
+        assert resolved != wrapper_pid
+
+    def test_falls_back_to_the_wrapper_when_the_grandparent_is_unrecognized(
+        self, tmp_path: Path
+    ) -> None:
+        claude_pid, wrapper_pid, resolved = _run_tree(
+            tmp_path, claude_comm="not-recognized"
+        )
+        assert resolved == wrapper_pid
+        assert resolved != claude_pid
+
+    def test_rejects_a_near_miss_name_that_merely_contains_claude(
+        self, tmp_path: Path
+    ) -> None:
+        """A substring match (`*claude*`) would wrongly trust this ancestor.
+
+        `not-claude` contains the literal string "claude" but is not the real
+        Claude Code process, so the exact-match check must reject it and fall
+        back to the wrapper -- the same fail-safe outcome as any other
+        unrecognized ancestor.
+        """
+        claude_pid, wrapper_pid, resolved = _run_tree(
+            tmp_path, claude_comm="not-claude"
+        )
+        assert resolved == wrapper_pid
+        assert resolved != claude_pid


### PR DESCRIPTION
## Summary

- The Vox Control Panel applet (vox-panel) never registered in the Lux menu -- every vox-panel-*.log under ~/.punt-labs/vox/logs (21 files sampled) contained exactly one line, ever: "session <pid> has gone; the applet is leaving", before ever reaching the Hub.
- Root cause: `plugin/hooks/session-start.sh` passed `$PPID` to `vox-panel --session-pid`, believing (per its own now-corrected comment) that $PPID was "the Claude Code process that ran this hook." It is not -- Claude Code invokes SessionStart hooks through a short-lived `sh` wrapper, and that wrapper exits within seconds of the hook script finishing, every time. The applet's liveness watch saw the wrapper vanish almost immediately and left before ever registering.
- Fix: resolve the wrapper's own parent (the genuinely persistent `claude` process) and watch that instead, with an **exact** match against `ps -o comm=` output (verified live: returns exactly `claude`, 8/8 samples) -- not a substring glob. An unrecognized process-tree shape falls back to the old (safe, if broken) `$PPID` behavior.
- Both `ps` calls are guarded against a vanished target aborting the whole hook under `set -e`.

## Why

Same root cause as lux-zrnd (`punt-labs/lux`'s lux-beads applet), fixed independently since the two hooks are separate files in separate repos. Root-caused via direct process-tree instrumentation against a real, live Claude Code session (8 independent SessionStart fires, identical pattern every time).

**Learned from review on the sibling fix:** the lux-zrnd fix's first pass used a `*claude*` glob match, which Copilot correctly flagged as overly permissive (also matches "not-claude"). This fix uses an exact match from the start, with a test proving a "not-claude" near-miss is correctly rejected and falls back to `$PPID`.

## Test plan

- [x] New test (`tests/test_session_start_pid.py`, subprocess-marked) spawns a real 3-level process tree and covers all three cases: `comm="claude"` resolves correctly, `comm="not-recognized"` falls back, `comm="not-claude"` (the adversarial near-miss) also falls back
- [x] All 19 existing tests in `test_session_start_hook.py` still pass unmodified
- [x] `make check`: 4460 passed, mypy/pyright/ruff/markdownlint clean; OO/coupling/suppression ratchets are no-ops (no src/ Python touched)
- [x] `shellcheck` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to SessionStart panel spawn PID selection in shell with fail-safe fallback; new tests cover the behavior without touching auth or core daemons.
> 
> **Overview**
> Fixes the Vox Control Panel never appearing in the Lux menu because `vox-panel` was tied to the hook’s `$PPID` — a short-lived `sh` wrapper that exits right after SessionStart — so the applet’s liveness check ended the session almost immediately.
> 
> **`plugin/hooks/session-start.sh`** now resolves `SESSION_WATCH_PID` as the wrapper’s parent when `ps` reports its command name is exactly `claude`; otherwise it keeps the previous `$PPID` behavior. `ps` failures are tolerated under `set -e`. Panel spawn, dedupe (`pgrep`), and log filenames all use that resolved PID.
> 
> **`tests/test_session_start_pid.py`** adds subprocess tests over a three-level process tree (stand-in `claude` → wrapper → hook) and asserts the `--session-pid` passed to `vox-panel`, including fallback when the ancestor isn’t `claude` and rejection of a `not-claude` near-miss (exact match, not substring).
> 
> **`CHANGELOG.md`** documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b14d0d45dc8cd5a4b35d6d9db7cc7df29fa12e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->