### PR TITLE
chore: release v5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.3] - 2026-08-29
+
 ### Fixed
 
 - **The Vox Control Panel applet now survives long enough to register in the

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="5.0.2"
+VERSION="5.0.3"
 BINARY="vox"
 
 # --- Argument parsing: --no-plugin / VOX_NO_PLUGIN (install-cli-only.md) ---

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
   "version": "5.0.3",
   "author": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "5.0.2"
+version = "5.0.3"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1277,7 +1277,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "5.0.2"
+version = "5.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },
@@ -1806,8 +1806,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly version, changelog, and plugin metadata; any behavioral risk lives in fixes already described for 5.0.3 (desktop config and session hooks), not in new logic in this diff.
> 
> **Overview**
> **Release v5.0.3** — bumps the package and installer version (`pyproject.toml`, `install.sh`, `uv.lock`) and adds the **[5.0.3] - 2026-08-29** changelog section documenting what ships in this tag.
> 
> The shipped **plugin manifest** is updated for production: `"name"` goes from `vox-dev` to **`vox`** and **`version`** to **5.0.3** in `plugin/.claude-plugin/plugin.json`.
> 
> **`uv.lock`** also refreshes transitive **`secretstorage`** dependency markers so `cryptography` / `jeepney` are only required on non-Windows (or Python ≥3.15), matching upstream packaging.
> 
> The new changelog entries (not all visible in this diff) headline **Vox Control Panel** surviving SessionStart by watching the real `claude` PID instead of the hook wrapper’s `$PPID`, plus **Linux Claude Desktop** config path support, **`vox doctor`** / **`vox desktop install|uninstall`** hardening (atomic config writes, permissions, refusal before writing, relative `XDG_CONFIG_HOME` handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def66cfbc4d9c3af74ec6d3650108b8f7e31d24c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->