### PR TITLE
fix(release): drop --no-verify from release scripts (pkit-hsyi)

### DIFF
--- a/scripts/release-plugin.sh
+++ b/scripts/release-plugin.sh
@@ -63,4 +63,6 @@ else
 fi
 
 git -C "$REPO_ROOT" add "$PLUGIN_JSON"
-git -C "$REPO_ROOT" commit --no-verify -m "chore: prepare plugin for release"
+# The org bans --no-verify; hooks run against the release-prep commit like
+# any other.
+git -C "$REPO_ROOT" commit -m "chore: prepare plugin for release"

--- a/scripts/restore-dev-plugin.sh
+++ b/scripts/restore-dev-plugin.sh
@@ -8,6 +8,13 @@ set -euo pipefail
 #
 # If no argument is given, auto-detects the last "prepare plugin for release"
 # commit and restores from its parent.
+#
+# CONTRACT: This script restores dev-state files and stages them. It does
+# NOT commit. The org bans the --no-verify escape hatch this script used to
+# pass on its own commit; committing here now means the caller either skips
+# hooks or resolves a hook failure mid-release with no re-stamp step to fold
+# it into. The caller commits the staged restore with hooks running. See
+# pkit-hsyi and punt-kit 462c65d for the sibling fix this mirrors.
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_JSON="${REPO_ROOT}/plugin/.claude-plugin/plugin.json"
@@ -57,4 +64,3 @@ git -C "$REPO_ROOT" add "$PLUGIN_JSON"
 if [[ "$restored" == true ]]; then
   git -C "$REPO_ROOT" add "$COMMANDS_DIR"
 fi
-git -C "$REPO_ROOT" commit --no-verify -m "chore: restore dev plugin state [skip ci]"

--- a/tests/test_release_scripts_never_bypass_git_hooks.py
+++ b/tests/test_release_scripts_never_bypass_git_hooks.py
@@ -1,0 +1,37 @@
+"""Regression test: release scripts must not bypass git hooks (pkit-hsyi)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_release_scripts_never_bypass_git_hooks() -> None:
+    """No release-path script may pass ``--no-verify`` to git.
+
+    The org CLAUDE.md bans ``--no-verify`` outright. ``release-plugin.sh``
+    previously carried it on the "prepare plugin for release" commit; this
+    test greps both release-path scripts so a reintroduction fails
+    immediately, not on the next release. Comments in the target scripts
+    are stripped before scanning, so prose describing the ban (e.g. in
+    ``restore-dev-plugin.sh``'s CONTRACT comment) does not trigger a
+    false positive.
+    """
+    root = Path(__file__).parent.parent
+    targets = [
+        root / "scripts" / "release-plugin.sh",
+        root / "scripts" / "restore-dev-plugin.sh",
+    ]
+    for path in targets:
+        text = path.read_text(encoding="utf-8")
+        code_only_lines: list[str] = []
+        for raw in text.splitlines():
+            stripped = raw.lstrip()
+            if stripped.startswith("#"):
+                continue
+            code, sep, _ = raw.partition("#")
+            code_only_lines.append(code if sep else raw)
+        code_only = "\n".join(code_only_lines)
+        assert "--no-verify" not in code_only, (
+            f"{path.name} reintroduced --no-verify — org CLAUDE.md bans "
+            "the flag; let the hooks run or surface a real hook failure."
+        )


### PR DESCRIPTION
## Summary

- Drop `--no-verify` from `scripts/release-plugin.sh`'s "prepare plugin for release" commit.
- `scripts/restore-dev-plugin.sh` no longer commits at all — it now restores and stages only, with a CONTRACT comment explaining why (committing here would need `--no-verify` or a follow-up `--amend` to fold in a hook failure, both banned). The caller owns the commit.
- Add `tests/test_release_scripts_never_bypass_git_hooks.py` (copied verbatim from biff #406) as a regression guard against reintroduction.

Mirrors punt-kit's fix (462c65d) and biff's fix (#406) — third of four sibling repos in the hsyi fleet sweep.

Refs: pkit-hsyi, punt-kit 462c65d, [biff #406](https://github.com/punt-labs/biff/pull/406)

## Test plan

- [x] `make check` passes (4461 tests, including the new regression test)
- [x] Committed with hooks active (no `--no-verify`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release workflow behavior changes (hooks on prep commit; restore is stage-only), but no runtime product or security-sensitive logic; callers must commit after restore.
> 
> **Overview**
> Aligns plugin release automation with the org rule that forbids **`git commit --no-verify`**.
> 
> **`release-plugin.sh`** now creates the “prepare plugin for release” commit with hooks enabled (the `--no-verify` flag and inline rationale are removed).
> 
> **`restore-dev-plugin.sh`** only checks out dev files and stages them—it no longer commits. A **CONTRACT** comment documents that the release caller must commit the staged restore with hooks running, avoiding mid-release hook failures with no clean way to fold fixes in.
> 
> Adds **`tests/test_release_scripts_never_bypass_git_hooks.py`**, which scans both scripts’ executable lines (comments stripped) so reintroducing `--no-verify` fails CI immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af12621d72c076de02d8721acf2a75f0765d261d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->