### PR TITLE
chore: release v5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.4] - 2026-08-31
+
 ### Changed
 
 - **Every `astral-sh/setup-uv` pin now names the version it actually runs, and all six agree (vox-qw9r).** The workflows carried one pin at `c771a70e` commented `# v9.0.0` and five at `e58605a9` commented `# v5`. The automated bump raised only the first to `20cfd1bf # v10.0.1` and rewrote the other five to `c771a70e` while leaving their `# v5` comment intact — which would have shipped five pins claiming v5 while running v9.0.0, and two different versions of one action across the CI matrix. A SHA-pinned action whose version comment lies is worse than an unpinned one, because the comment is the only thing a reader can check. All six are now `20cfd1bf # v10.0.1`.
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The release scripts no longer bypass git hooks (pkit-hsyi).** `scripts/release-plugin.sh` and `scripts/restore-dev-plugin.sh` both passed `--no-verify`, which the org standards ban: the release path was the one path that skipped every local hook, including the audit seal. Hooks now run on the release-prep commit. `restore-dev-plugin.sh` additionally no longer commits at all — it stages the restored dev state and the caller commits it with hooks running, because committing inside the script meant either keeping `--no-verify` or resolving a hook failure mid-release with no re-stamp step to fold the resolution into. A test now pins that neither script can reintroduce the flag.
 - **`vox daemon install` now captures `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` into the voxd LaunchAgent, and the plist is its own object.** Behind a TLS-inspecting corporate proxy — which presents its own CA — a launchd-started voxd could not reach HTTPS endpoints the installing shell reached, because the plist carried only `PATH` and `VOXD_BIND`. The only remaining way to supply the CA was a `launchctl bootout`/`bootstrap` cycle from an activation script, and `bootout` is asynchronous: on nix-darwin this raced `claude plugin install`'s git clone through a window where the CA was untrusted, failing 3/3 times with `SSL certificate verify result 20`. Both vars are now captured at install time, so no bootout dance is needed. An unset *or empty* var is omitted rather than written through, because an empty `SSL_CERT_FILE` is worse than an absent one — OpenSSL reads it as a bundle containing no certificates instead of falling back to the system trust store. The env capture, the plist XML, and the plist file move to a new `VoxdPlist`, leaving `LaunchdBackend` with only the launchd lifecycle it composes a `LaunchctlAgent` for: the class had held two disjoint responsibilities, which its cohesion score stated numerically — `max_lcom` and `avg_lcom` fall from 0.694 to 0.067, and `module_size` from 144 to 73.
 - **The test suite no longer spawns real vox-panels against the live Lux hub
   (vox-h7k8).** `tests/test_hook_gate.py`'s stdin-edge tests (malformed and

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ MARKETPLACE_REPO="punt-labs/claude-plugins"
 MARKETPLACE_NAME="punt-labs"
 PLUGIN_NAME="vox"
 PACKAGE="punt-vox"
-VERSION="5.0.3"
+VERSION="5.0.4"
 BINARY="vox"
 
 # --- Argument parsing: --no-plugin / VOX_NO_PLUGIN (install-cli-only.md) ---

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "author": {
     "name": "Punt Labs",
     "email": "hello@punt-labs.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "punt-vox"
-version = "5.0.3"
+version = "5.0.4"
 description = "Text-to-speech CLI, MCP server, and Claude Code plugin (ElevenLabs, AWS Polly, OpenAI)"
 readme = "README.md"
 authors = [{ name = "Punt Labs", email = "hello@punt-labs.com" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1276,7 +1276,7 @@ wheels = [
 
 [[package]]
 name = "punt-vox"
-version = "5.0.3"
+version = "5.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "audioop-lts" },


### PR DESCRIPTION
## Summary

Cuts **5.0.4**. Moves `[Unreleased]` → `[5.0.4] - 2026-08-31` and bumps all four version references: `pyproject.toml`, `plugin/.claude-plugin/plugin.json`, `install.sh`'s `VERSION` pin, and `uv.lock`'s own `punt-vox` entry. (No `manifest.json` in this repo, so no `.mcpb` mirror.)

Also adds the changelog entry **#483 never got** — the release scripts dropping `--no-verify` (pkit-hsyi). Notable in its own right, and it changes the procedure *this tag* follows: `restore-dev-plugin.sh` now stages the restored dev state without committing, so the caller commits it with hooks running.

## Why patch, not minor

Three Changed, four Fixed, **no new features and nothing breaking**:

| | |
|---|---|
| **Changed** | `setup-uv` pins — all six on v10.0.1 with comments matching their SHAs |
| | `openai` 3.6.0, `httpx2` 2.12.0 |
| | `punt-lux` lock at 0.31.1, so tests exercise the lux that ships |
| **Fixed** | release scripts no longer bypass git hooks |
| | `vox daemon install` captures `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` |
| | the test suite no longer spawns real vox-panels at the live Lux hub |
| | ten held-vs-displayed divergences in the Lux `vox.music` panel |

The launchd change captures env vars it didn't before, which reads feature-ish — but it exists to fix an install path that was broken behind a TLS proxy, so it belongs under Fixed and the release stays a patch.

## Verification

```
make check ....... 4686 passed, mypy, pyright, lint, 3 ratchets — all green
uv build ......... punt_vox-5.0.4-py3-none-any.whl + .tar.gz
twine check ...... PASSED (both artifacts)
```

**Phase 3, the part that isn't mine:** the launchd change is macOS-only and this machine is Linux, so `claude:tty13` verified it on a Mac across all four environment cases — neither var set, both set, exactly one set, and the empty-value boundary — plus `plutil -lint`, a real PATH in the plist (not the fallback), daemon up, and audible speech. Their environment was restored and the temp certs removed afterwards.

They also found a real defect in passing, filed as **`vox-eo00`** (P1) and deliberately *not* held for this release: a bad `SSL_CERT_FILE` path kills voxd at boot, because `daemon.py:236` constructs `ElevenLabsMusicProvider()` eagerly and the SDK builds its SSL context in the constructor — so a music dependency takes down speech, chimes and hooks. Not new here: the workaround this PR's predecessor replaces injected the same var into the same LaunchAgent, so the crash was already reachable for exactly the users who need it. Had this change newly exposed it, the tag would wait.

Everything else in the release was exercised on Linux through its real entry points during the PRs that landed it (#484, #486, #487, #489, #490).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The tag bundles dependency upgrades, macOS daemon TLS env wiring, and release-script hook enforcement—install and CI paths that are easy to get subtly wrong even when tests are green.
> 
> **Overview**
> **Cuts patch release 5.0.4** by syncing `5.0.3` → `5.0.4` in `pyproject.toml`, `install.sh`, `plugin/.claude-plugin/plugin.json`, and `uv.lock`, and moving the accumulated **Unreleased** notes into **`[5.0.4] - 2026-08-31`**.
> 
> The new changelog section records what ships with this tag (mostly fixes and hygiene from earlier PRs): aligned **`astral-sh/setup-uv`** pins/comments, **`openai` / `httpx`** lock upgrades, **`punt-lux` 0.31.1** so CI matches installed lux, release scripts that **stop using `--no-verify`** (with `restore-dev-plugin.sh` staging only), **`vox daemon install`** persisting **`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`** via a **`VoxdPlist`** split from launchd, isolated hook tests so the suite **does not spawn live vox-panels**, and Lux music-panel held/display fixes (per the truncated entry).
> 
> This PR’s diff is **version + changelog only**; behavior changes ride in those already-merged commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1a9416f1982badf0aafa43d0f3636f4694ba992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->