### PR TITLE
chore(release): carry the prod plugin name on the v5.0.4 tag

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox-dev",
+  "name": "vox",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
   "version": "5.0.4",
   "author": {


### PR DESCRIPTION
## What went wrong

I tagged `v5.0.4` straight off `main` and skipped `scripts/release-plugin.sh`. That script exists for one reason: **the marketplace installs the plugin through a `git-subdir` source that clones from the tag**, so the tagged commit must carry prod artifacts. `main` holds `"name": "vox-dev"` by design.

Every prior release got this right — `v5.0.3`'s tag carries `"name": "vox"`:

```
git show v5.0.3:plugin/.claude-plugin/plugin.json  ->  "name": "vox"
git show v5.0.4:plugin/.claude-plugin/plugin.json  ->  "name": "vox-dev"   <- wrong
```

**Effect:** a marketplace install from `v5.0.4` would have registered the plugin as `vox-dev`, colliding with a developer's dev install rather than upgrading anyone's prod one.

**PyPI is unaffected** — `punt-vox` 5.0.4 built, passed TestPyPI, passed a real test-install, and published correctly. This is the plugin channel only.

The script's other job — stripping `*-dev.md` from the shipped surface — was already a no-op; there are none in `plugin/commands/`.

## The fix, in three steps

1. **This PR** sets the name to `vox`.
2. The `v5.0.4` tag then moves to this commit (force-move, operator-approved).
3. A post-release PR restores `"vox-dev"` for development and repoints the README installer SHA — the same shape as `8423cd6` did for 5.0.3.

## A second miss this surfaced

The README still pins the installer to `d968a18`, which is **v5.0.3's** release commit:

```
curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/d968a18/install.sh | sh
```

So `curl | sh` currently installs the previous release. Four occurrences, fixed in step 3 once this commit's SHA is known.

## Verification

`make lint` green, including both plugin gates (`check-skill-permissions`, `check-plugin-surface`). Manifest-only change — no source, no tests, no runtime behavior.

**Phase 3: N/A** — a one-key manifest edit with no runnable path of its own. The gate that matters is the tag content, verified directly with `git show v5.0.4:...` after the tag moves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-key change in `plugin.json` with no source or runtime logic; impact is limited to how the plugin is identified on marketplace install from the tag.
> 
> **Overview**
> Corrects the Claude plugin manifest so the **v5.0.4** release tag exposes **`"name": "vox"`** instead of **`vox-dev`**, matching what `scripts/release-plugin.sh` normally does before tagging.
> 
> Marketplace installs clone the tagged `plugin/` subtree; a **`vox-dev`** name would register as a dev plugin and collide with local dev installs rather than upgrading production **`vox`**. This PR is **manifest-only** (version **5.0.4** unchanged); PyPI **`punt-vox`** is out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5d3addc456785fdc5f98a2fe5cbc6323853fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->