### PR TITLE
chore: post-release v5.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ vox is usable in three ways, all driving the same `voxd` audio daemon --- so it 
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/d968a18/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/8380ad5/install.sh | sh
 ```
 
 Restart Claude Code, then:
@@ -50,10 +50,10 @@ Install the `vox` CLI without the Claude Code plugin — for a non-Claude harnes
 
 ```bash
 # Flag form
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/d968a18/install.sh | sh -s -- --no-plugin
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/8380ad5/install.sh | sh -s -- --no-plugin
 
 # Environment form (for argument-hostile contexts — CI templates, proxies)
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/d968a18/install.sh | VOX_NO_PLUGIN=1 sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/8380ad5/install.sh | VOX_NO_PLUGIN=1 sh
 ```
 
 `VOX_NO_PLUGIN` skips the plugin only when set to exactly `1`; any other value is ignored. The plugin also auto-skips when `claude` or `git` is absent.
@@ -73,7 +73,7 @@ vox doctor
 <summary>Verify before running</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/d968a18/install.sh -o install.sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/8380ad5/install.sh -o install.sh
 shasum -a 256 install.sh
 cat install.sh
 sh install.sh

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
   "version": "5.0.4",
   "author": {


### PR DESCRIPTION
## Summary

The third and last step of correcting the 5.0.4 release. Same shape as `8423cd6` did for 5.0.3.

**Restores the dev plugin name.** The working tree carries `"vox-dev"` so a `--plugin-dir` load registers alongside a prod install instead of shadowing it. The `v5.0.4` tag keeps `"vox"` — that's what the marketplace clones, and it's now correct:

```
git show v5.0.4:plugin/.claude-plugin/plugin.json  ->  "name": "vox", "version": "5.0.4"
```

**Repoints the README installer** from `d968a18` to `8380ad5`, in four `curl | sh` lines.

## The README SHA was a second, older bug

That pin was still at **v5.0.3's** release commit, so the documented one-liner installed the *previous* release:

```
-curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/d968a18/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/punt-labs/vox/8380ad5/install.sh | sh
```

This one is not from today's slip — 5.0.3's own post-release commit set it and nothing moved it since. It would have shipped stale again if I hadn't been checking the SHA while fixing the plugin name.

## Where the release now stands

| | |
|---|---|
| PyPI `punt-vox` 5.0.4 | published, all four pipeline stages green |
| `v5.0.4` tag | `8380ad5`, carries `"name": "vox"` |
| GitHub release | published, marked Latest |
| README installer | repointed here |
| Dev plugin name | restored here |

## Verification

`make lint` green (both plugin gates included) and `make docs` clean at the CI-matched markdownlint 0.23.2.

**Phase 3: N/A** — docs plus a one-key manifest edit, no runnable path. The load-bearing check was the tag content, verified directly with `git show v5.0.4:...` after the tag moved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only install URL updates plus a dev-tree plugin manifest rename; no runtime or security-sensitive code paths change on the release tag.
> 
> **Overview**
> **Post-release housekeeping for v5.0.4** so the default branch matches how releases are supposed to look while the tagged release stays marketplace-ready.
> 
> The Claude Code plugin manifest **`name` goes back to `vox-dev`** (from `vox`). That lets a local `--plugin-dir` load register next to a production `vox` install instead of replacing it; the **`v5.0.4` tag keeps `"vox"`** for marketplace clones.
> 
> All **four README `curl | sh` install examples** now pin **`install.sh` at commit `8380ad5`** (the v5.0.4 release) instead of **`d968a18`**, which was still pointing at the previous release’s installer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3ddd8a8b0784c9f2cb9233f28659eb936ca191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->