### PR TITLE
chore: restore the dev plugin name after v5.0.5

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
   "version": "5.0.5",
   "author": {


### PR DESCRIPTION
One line: `plugin.json` name `vox` → `vox-dev`, so a local `--plugin-dir plugin` load registers alongside a prod install instead of shadowing it. The **v5.0.5 tag keeps the prod name**, which is what the marketplace clones — verified.

## Why this replaces #498

`punt release` wrote its post-release commit as:

```
chore: restore dev plugin state [skip ci]
```

That `[skip ci]` suppressed `docs`, `lint` and `test` — exactly the three **required** status checks in main's ruleset (id 13252005). They can never report, so #498 is permanently `BLOCKED`.

Pushing a clean commit on top did not revive them: GitHub had already suppressed the `pull_request` runs for that branch, and no docs/lint/test run exists on it for either commit — only the `dynamic` Copilot/Cursor runs.

The tool's own output named the cause, and neither of us caught it at the time:

> ⚠ No branch protection configured on punt-labs/vox's main branch

`punt release` reads the **classic branch-protection API**, gets a 404, and concludes skipping CI is free. main is protected by a **ruleset** — a different API it never consults. Any repo migrated to rulesets hits this on every release, and the failure is quiet: the release itself succeeds, so the only symptom is that main silently keeps the prod plugin name. Filed as **punt-rzb** (P1).

This branch carries no skip directive, so the required checks run normally.

## After this merges

Close #498 as superseded and delete its branch.