### PR TITLE
chore: restore the dev plugin name after v5.0.5

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "vox",
+  "name": "vox-dev",
   "description": "Text-to-speech for Claude Code: /unmute, /mute, /vibe, /vox:recap",
   "version": "5.0.5",
   "author": {


### PR DESCRIPTION
One line: `plugin.json` name `vox` → `vox-dev`, so a local `--plugin-dir plugin` load registers alongside a prod install instead of shadowing it. The v5.0.5 tag keeps the prod name — that's what the marketplace clones.

Replaces #498 and #499, on both of which `docs`/`lint`/`test` never dispatched (Actions flakiness — workflows active, triggers match, no path filters, no concurrency groups, no skip directive).